### PR TITLE
[feat] 공통 응답/예외 세팅 및 yml 파일 작성 (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,10 +42,7 @@ out/
 **/.DS_Store
 **/._.DS_Store
 
-src/main/resources/application.yml
-src/main/resources/application-*.yml
-!src/main/resources/application.yml
-!src/test/resources/application.yml
+src/main/resources/application-local.yml
 .env
 .db.local.env
 *.local.sql

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     //implementation 'org.springframework.boot:spring-boot-starter-security'
-    //implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,6 @@ dependencies {
     //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.flywaydb:flyway-core'
-    implementation 'org.flywaydb:flyway-database-postgresql'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    //implementation 'org.springframework.boot:spring-boot-starter-security'
+    //implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
@@ -31,7 +31,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+    //testImplementation 'org.springframework.security:spring-security-test'
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/insideout/backend/BackendApplication.java
+++ b/src/main/java/com/insideout/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.insideout.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/insideout/backend/domain/example/exception/ExampleErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/example/exception/ExampleErrorCode.java
@@ -1,0 +1,20 @@
+package com.insideout.backend.domain.example.exception;
+
+import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExampleErrorCode implements BaseErrorCode {
+
+    EXAMPLE_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "EXAMPLE404_1",
+            "해당 예시를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/insideout/backend/domain/example/exception/MemberException.java
+++ b/src/main/java/com/insideout/backend/domain/example/exception/MemberException.java
@@ -1,0 +1,8 @@
+package com.insideout.backend.domain.example.exception;
+
+import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
+import com.insideout.backend.global.apiPayload.exception.ProjectException;
+
+public class MemberException extends ProjectException {
+    public MemberException(BaseErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/com/insideout/backend/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/ApiResponse.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
 import com.insideout.backend.global.apiPayload.code.BaseSuccessCode;
 import com.insideout.backend.global.apiPayload.code.GeneralSuccessCode;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 @JsonPropertyOrder({"isSuccess","timestamp","code","message","result"})
 public class ApiResponse<T> {
 
@@ -38,33 +38,45 @@ public class ApiResponse<T> {
         this.result = result;
     }
 
-    // 200 성공 응답 - 결과 데이터 있는 경우
-    public static <T> ApiResponse<T> OK(T result) {
-        return new ApiResponse<>(true, GeneralSuccessCode.OK.getCode(), GeneralSuccessCode.OK.getMessage(), result);
+    // [성공] 가장 많이 쓰는 200 OK (결과 데이터 있음)
+    public static <T> ResponseEntity<ApiResponse<T>> OK(T result) {
+        return of(GeneralSuccessCode.OK, result);
     }
 
-    // 200 성공 응답 - 결과 데이터 없는 경우
-    public static <T> ApiResponse<T> OK() {
-        return new ApiResponse<>(true, GeneralSuccessCode.OK.getCode(), GeneralSuccessCode.OK.getMessage(), null);
+    // [성공] 가장 많이 쓰는 200 OK (결과 데이터 없음)
+    public static <T> ResponseEntity<ApiResponse<T>> OK() {
+        return of(GeneralSuccessCode.OK, null);
     }
 
-    // 결과 데이터(result)가 포함된 성공 응답 커스텀
-    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code, T result) {
+    // [성공] 201, 202 등 커스텀 성공 상태가 필요할 때
+    public static <T> ResponseEntity<ApiResponse<T>> of(BaseSuccessCode code, T result) {
+        if (code.getStatus() == HttpStatus.NO_CONTENT) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(onSuccessBody(code, result));
+    }
+
+    // [실패] 에러 핸들러에서 사용 (데이터 없는 일반 에러)
+    public static <T> ResponseEntity<ApiResponse<T>> onFailureEntity(BaseErrorCode code) {
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(onFailureBody(code, null));
+    }
+
+    // [실패] 에러 핸들러에서 사용 (데이터 포함 - 예: Validation 에러 메시지)
+    public static <T> ResponseEntity<ApiResponse<T>> onFailureEntity(BaseErrorCode code, T result) {
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(onFailureBody(code, result));
+    }
+
+    private static <T> ApiResponse<T> onSuccessBody(BaseSuccessCode code, T result) {
         return new ApiResponse<>(true, code.getCode(), code.getMessage(), result);
     }
 
-    // 결과 데이터(result)가 없는 성공 응답 커스텀
-    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code) {
-        return new ApiResponse<>(true, code.getCode(), code.getMessage(), null);
-    }
-
-    // 결과 데이터(result)가 포함된 실패 응답
-    public static <T> ApiResponse<T> onFailure(BaseErrorCode code, T result){
+    private static <T> ApiResponse<T> onFailureBody(BaseErrorCode code, T result) {
         return new ApiResponse<>(false, code.getCode(), code.getMessage(), result);
-    }
-
-    // 결과 데이터(result)가 없는 실패 응답
-    public static <T> ApiResponse<T> onFailure(BaseErrorCode code) {
-        return new ApiResponse<>(false, code.getCode(), code.getMessage(), null);
     }
 }

--- a/src/main/java/com/insideout/backend/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/ApiResponse.java
@@ -1,0 +1,70 @@
+package com.insideout.backend.global.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
+import com.insideout.backend.global.apiPayload.code.BaseSuccessCode;
+import com.insideout.backend.global.apiPayload.code.GeneralSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess","timestamp","code","message","result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+
+    @JsonProperty("code")
+    private final String code;
+
+    @JsonProperty("message")
+    private final String message;
+
+    @JsonProperty("timestamp")
+    private final LocalDateTime timestamp;
+
+    @JsonProperty("result")
+    private T result;
+
+    private ApiResponse(Boolean isSuccess, String code, String message, T result) {
+        this.isSuccess = isSuccess;
+        this.timestamp = LocalDateTime.now();
+        this.code = code;
+        this.message = message;
+        this.result = result;
+    }
+
+    // 200 성공 응답 - 결과 데이터 있는 경우
+    public static <T> ApiResponse<T> OK(T result) {
+        return new ApiResponse<>(true, GeneralSuccessCode.OK.getCode(), GeneralSuccessCode.OK.getMessage(), result);
+    }
+
+    // 200 성공 응답 - 결과 데이터 없는 경우
+    public static <T> ApiResponse<T> OK() {
+        return new ApiResponse<>(true, GeneralSuccessCode.OK.getCode(), GeneralSuccessCode.OK.getMessage(), null);
+    }
+
+    // 결과 데이터(result)가 포함된 성공 응답 커스텀
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code, T result) {
+        return new ApiResponse<>(true, code.getCode(), code.getMessage(), result);
+    }
+
+    // 결과 데이터(result)가 없는 성공 응답 커스텀
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code) {
+        return new ApiResponse<>(true, code.getCode(), code.getMessage(), null);
+    }
+
+    // 결과 데이터(result)가 포함된 실패 응답
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode code, T result){
+        return new ApiResponse<>(false, code.getCode(), code.getMessage(), result);
+    }
+
+    // 결과 데이터(result)가 없는 실패 응답
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode code) {
+        return new ApiResponse<>(false, code.getCode(), code.getMessage(), null);
+    }
+}

--- a/src/main/java/com/insideout/backend/global/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,10 @@
+package com.insideout.backend.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/insideout/backend/global/apiPayload/code/BaseSuccessCode.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/code/BaseSuccessCode.java
@@ -1,0 +1,10 @@
+package com.insideout.backend.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseSuccessCode {
+
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/insideout/backend/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/code/GeneralErrorCode.java
@@ -1,0 +1,29 @@
+package com.insideout.backend.global.apiPayload.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GeneralErrorCode implements BaseErrorCode{
+
+    // 400번대 에러
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400_1", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401_1", "인증되지 않았습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403_1", "접근이 금지되었습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404_1", "해당 리소스를 찾을 수 없습니다."),
+
+    // 500번대 에러 (Server Error)
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500_1", "서버 내부 에러가 발생했습니다."),
+    NOT_IMPLEMENTED(HttpStatus.NOT_IMPLEMENTED, "COMMON501_1", "구현되지 않은 기능입니다."),
+    BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "COMMON502_1", "잘못된 게이트웨이 요청입니다."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "COMMON503_1", "서비스를 이용할 수 없습니다."),
+    GATEWAY_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "COMMON504_1", "게이트웨이 시간 초과입니다."),
+
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/insideout/backend/global/apiPayload/code/GeneralSuccessCode.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/code/GeneralSuccessCode.java
@@ -1,0 +1,28 @@
+package com.insideout.backend.global.apiPayload.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GeneralSuccessCode implements BaseSuccessCode{
+
+    OK(HttpStatus.OK,
+            "COMMON200_1",
+            "성공적으로 요청을 처리했습니다."),
+    CREATED(HttpStatus.CREATED,
+            "COMMON201_1",
+            "새로운 리소스가 생성되었습니다."),
+    ACCEPTED(HttpStatus.ACCEPTED,
+            "COMMON202_1",
+            "요청이 접수되었습니다."),
+    NO_CONTENT(HttpStatus.NO_CONTENT,
+            "COMMON204_1",
+            "처리가 완료되었으며 반환할 데이터가 없습니다.")
+
+    ;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/insideout/backend/global/apiPayload/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/exception/GlobalExceptionHandler.java
@@ -1,0 +1,67 @@
+package com.insideout.backend.global.apiPayload.exception;
+
+import com.insideout.backend.global.apiPayload.ApiResponse;
+import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
+import com.insideout.backend.global.apiPayload.code.GeneralErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    // 커스텀 예외 처리 (ProjectException)
+    @ExceptionHandler(ProjectException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(ProjectException e) {
+        BaseErrorCode errorCode = e.getErrorCode();
+        log.error("Custom Exception: {}", errorCode.getMessage());
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode));
+    }
+
+    // Validation 예외 처리 (MethodArgumentNotValidException)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(MethodArgumentNotValidException e) {
+        log.error("Validation Exception 발생");
+
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        // GeneralErrorCode.BAD_REQUEST 등을 사용하여 응답
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.onFailure(GeneralErrorCode.BAD_REQUEST, errors));
+    }
+
+    // JSON 파싱 에러 (HttpMessageNotReadableException)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("HTTP Message Not Readable: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.onFailure(GeneralErrorCode.BAD_REQUEST));
+    }
+
+    // 그 외 정의되지 않은 모든 예외 (500)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<String>> handleAllException(Exception e) {
+        log.error("Internal Server Error: ", e); // 전체 스택트레이스 로그 기록
+
+        BaseErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, e.getMessage())); // 에러 메시지를 result에 담아줌
+    }
+}

--- a/src/main/java/com/insideout/backend/global/apiPayload/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/exception/GlobalExceptionHandler.java
@@ -24,9 +24,7 @@ public class GlobalExceptionHandler {
         BaseErrorCode errorCode = e.getErrorCode();
         log.error("Custom Exception: {}", errorCode.getMessage());
 
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ApiResponse.onFailure(errorCode));
+        return ApiResponse.onFailureEntity(errorCode);
     }
 
     // Validation 예외 처리 (MethodArgumentNotValidException)
@@ -40,18 +38,14 @@ public class GlobalExceptionHandler {
         );
 
         // GeneralErrorCode.BAD_REQUEST 등을 사용하여 응답
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.onFailure(GeneralErrorCode.BAD_REQUEST, errors));
+        return ApiResponse.onFailureEntity(GeneralErrorCode.BAD_REQUEST, errors);
     }
 
     // JSON 파싱 에러 (HttpMessageNotReadableException)
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         log.error("HTTP Message Not Readable: {}", e.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.onFailure(GeneralErrorCode.BAD_REQUEST));
+        return ApiResponse.onFailureEntity(GeneralErrorCode.BAD_REQUEST);
     }
 
     // 그 외 정의되지 않은 모든 예외 (500)
@@ -60,8 +54,7 @@ public class GlobalExceptionHandler {
         log.error("Internal Server Error: ", e); // 전체 스택트레이스 로그 기록
 
         BaseErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ApiResponse.onFailure(errorCode, e.getMessage())); // 에러 메시지를 result에 담아줌
+        // 에러 메시지를 포함해서 반환
+        return ApiResponse.onFailureEntity(GeneralErrorCode.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/insideout/backend/global/apiPayload/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/exception/GlobalExceptionHandler.java
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
 
         Map<String, String> errors = new HashMap<>();
         e.getBindingResult().getFieldErrors().forEach(error ->
-                errors.put(error.getField(), error.getDefaultMessage())
+                errors.putIfAbsent(error.getField(), error.getDefaultMessage())
         );
 
         // GeneralErrorCode.BAD_REQUEST 등을 사용하여 응답

--- a/src/main/java/com/insideout/backend/global/apiPayload/exception/ProjectException.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/exception/ProjectException.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.global.apiPayload.exception;
+
+import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ProjectException extends RuntimeException {
+    private final BaseErrorCode errorCode;
+}

--- a/src/main/java/com/insideout/backend/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/insideout/backend/global/entity/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package com.insideout.backend.global.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,14 @@
+spring:
+  config:
+    import:
+      - optional:classpath:db.properties
+
+  datasource:
+    url: jdbc:postgresql://localhost:${DB_PORT}/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update # 공용 DB는 테이블 구조 확정되면  validate

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,15 @@
 spring:
-  config:
-    import:
-      - optional:classpath:db.properties
-      - optional:classpath:security.yml
+  profiles:
+    active: local
 
   application:
     name: backend
 
-  datasource:
-    driver-class-name: org.postgresql.Driver
+  config:
+    import:
+      - optional:classpath:security.yml
 
   jpa:
-    hibernate:
-      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -22,8 +19,3 @@ spring:
 
 server:
   port: 8080
-
-logging:
-  level:
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #4 

## 📝작업 내용

공통 응답/예외 세팅과 BaseTimeEntity를 정의했습니다. 
yml 파일은 local, dev를 나누어 관리합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 시큐리티 의존을 제외해두었습니다. 개발 시 확인해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 표준화된 API 응답 래퍼와 공통 성공/오류 코드 도입으로 일관된 응답 형식 제공
  * 글로벌 예외 처리 추가로 검증·파싱·일반 오류에 대해 통일된 오류 응답 반환
  * 엔티티 생성/수정 시간 자동 추적(JPA 감사) 활성화

* **Chores**
  * 로컬/개발 환경 프로필 및 구성 파일 정리·업데이트
  * 빌드 의존성 정리 (보안/마이그레이션 관련 일부 의존성 제외)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->