### PR TITLE
[feat] 보호 API authenticated 전환 및 CustomUserDetails 기반 인가 적용 (#14)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/user/controller/UserQueryController.java
+++ b/src/main/java/com/insideout/backend/domain/user/controller/UserQueryController.java
@@ -1,0 +1,22 @@
+package com.insideout.backend.domain.user.controller;
+
+import com.insideout.backend.domain.user.dto.response.CurrentUserResponse;
+import com.insideout.backend.global.security.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserQueryController {
+
+	@GetMapping("/me")
+	public CurrentUserResponse me(@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return new CurrentUserResponse(
+			userDetails.getUserId(),
+			userDetails.getEmail(),
+			userDetails.getGlobalRole()
+		);
+	}
+}

--- a/src/main/java/com/insideout/backend/domain/user/dto/response/CurrentUserResponse.java
+++ b/src/main/java/com/insideout/backend/domain/user/dto/response/CurrentUserResponse.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.user.dto.response;
+
+import com.insideout.backend.domain.user.enums.GlobalRole;
+import java.util.UUID;
+
+public record CurrentUserResponse(
+	UUID userId,
+	String email,
+	GlobalRole globalRole
+) {
+}

--- a/src/main/java/com/insideout/backend/global/config/OpenApiConfig.java
+++ b/src/main/java/com/insideout/backend/global/config/OpenApiConfig.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +30,7 @@ public class OpenApiConfig {
                                         .bearerFormat("JWT"));
 
         return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList(jwtSchemeName))
                 .info(
                         new Info()
                                 .title("INSIDEOUT API")
@@ -40,4 +42,3 @@ public class OpenApiConfig {
                 .components(components);
     }
 }
-

--- a/src/main/java/com/insideout/backend/global/security/CustomUserDetails.java
+++ b/src/main/java/com/insideout/backend/global/security/CustomUserDetails.java
@@ -1,0 +1,36 @@
+package com.insideout.backend.global.security;
+
+import com.insideout.backend.domain.user.enums.GlobalRole;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+	private final UUID userId;
+	private final String email;
+	private final String passwordHash;
+	private final GlobalRole globalRole;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority("ROLE_" + globalRole.name()));
+	}
+
+	@Override
+	public String getPassword() {
+		return passwordHash;
+	}
+
+	@Override
+	public String getUsername() {
+		return email;
+	}
+}

--- a/src/main/java/com/insideout/backend/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/insideout/backend/global/security/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.insideout.backend.global.security;
+
+import com.insideout.backend.domain.user.entity.User;
+import com.insideout.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User user =
+			userRepository
+				.findByEmail(username)
+				.orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+		return new CustomUserDetails(
+			user.getId(),
+			user.getEmail(),
+			user.getPasswordHash(),
+			user.getGlobalRole()
+		);
+	}
+}

--- a/src/main/java/com/insideout/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/insideout/backend/global/security/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.insideout.backend.global.security;
 
 import com.insideout.backend.global.security.jwt.JwtAuthenticationFilter;
+import com.insideout.backend.global.security.jwt.JwtAuthenticationEntryPoint;
+import com.insideout.backend.global.security.jwt.JwtAccessDeniedHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +21,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -27,6 +31,10 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/api/v1/**", "/error").permitAll()

--- a/src/main/java/com/insideout/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/insideout/backend/global/security/SecurityConfig.java
@@ -37,8 +37,8 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/api/v1/**", "/error").permitAll()
-                        .anyRequest().permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/error").permitAll()
+                        .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/insideout/backend/global/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/insideout/backend/global/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package com.insideout.backend.global.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.insideout.backend.global.apiPayload.ApiResponse;
+import com.insideout.backend.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void handle(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AccessDeniedException accessDeniedException
+	) throws IOException, ServletException {
+		response.setStatus(GeneralErrorCode.FORBIDDEN.getStatus().value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		ApiResponse<Object> body = ApiResponse.onFailureEntity(GeneralErrorCode.FORBIDDEN).getBody();
+		response.getWriter().write(objectMapper.writeValueAsString(body));
+	}
+}

--- a/src/main/java/com/insideout/backend/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/insideout/backend/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.insideout.backend.global.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.insideout.backend.global.apiPayload.ApiResponse;
+import com.insideout.backend.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
+	) throws IOException, ServletException {
+		response.setStatus(GeneralErrorCode.UNAUTHORIZED.getStatus().value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		ApiResponse<Object> body = ApiResponse.onFailureEntity(GeneralErrorCode.UNAUTHORIZED).getBody();
+		response.getWriter().write(objectMapper.writeValueAsString(body));
+	}
+}

--- a/src/main/java/com/insideout/backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/insideout/backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -61,8 +62,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 					);
 					SecurityContextHolder.getContext().setAuthentication(authentication);
 				}
-			} catch (JwtException | IllegalArgumentException ignored) {
-				// 유효하지 않은 토큰은 인증을 세팅하지 않고 다음 필터로 진행한다.
+			} catch (JwtException | IllegalArgumentException | UsernameNotFoundException ignored) {
+				// 유효하지 않거나 계정이 없는 토큰은 인증을 세팅하지 않고 다음 필터로 진행한다.
 			}
 		}
 

--- a/src/main/java/com/insideout/backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/insideout/backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.insideout.backend.global.security.jwt;
 
+import com.insideout.backend.global.security.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -7,7 +8,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.NonNull;
@@ -26,6 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private static final String ACCESS_TOKEN_TYPE = "access";
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private final CustomUserDetailsService customUserDetailsService;
 
 	@Override
 	protected void doFilterInternal(
@@ -48,11 +49,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 					&& StringUtils.hasText(subject)
 					&& SecurityContextHolder.getContext().getAuthentication() == null) {
 
+					var userDetails = customUserDetailsService.loadUserByUsername(subject);
 					UsernamePasswordAuthenticationToken authentication =
 						new UsernamePasswordAuthenticationToken(
-							subject,
+							userDetails,
 							null,
-							Collections.emptyList()
+							userDetails.getAuthorities()
 						);
 					authentication.setDetails(
 						new WebAuthenticationDetailsSource().buildDetails(request)


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #14 

## 📝작업 내용
JWT 기반 보호 API 인증/인가 흐름을 적용했어요!
- `CustomUserDetails`, `CustomUserDetailsService` 추가
  - JWT subject(email) 기준으로 사용자 조회 후 SecurityContext principal 주입
- `JwtAuthenticationFilter` 개선
  - 토큰 단일 파싱(중복 파싱 제거)
  - `tokenType=access`만 인증 처리
  - subject 비어있을 경우 인증 세팅 방지
- Security 예외 핸들러 추가 및 연동
  - `JwtAuthenticationEntryPoint`(401)
  - `JwtAccessDeniedHandler`(403)
- Security 인가 정책 전환
  - `/api/v1/auth/**`, Swagger, `/error`만 `permitAll`
  - 그 외 요청 `authenticated()`
- 현재 사용자 확인용 보호 API 추가
  - `GET /api/v1/users/me`
  - `@AuthenticationPrincipal` 기반 현재 사용자 정보 반환
- Swagger 인증 테스트 편의 개선
  - OpenAPI `SecurityRequirement` 설정 추가


### 스크린샷 (선택)
- `/api/v1/users/me` 테스트 결과
  - 토큰 없음: `401 (COMMON401_1)`
<img width="807" height="403" alt="스크린샷 2026-04-30 오후 3 14 31" src="https://github.com/user-attachments/assets/68a0c48a-eff6-4bf8-b7b4-0162ac2030ba" />

  - refresh 토큰: `401 (COMMON401_1)`
<img width="583" height="329" alt="스크린샷 2026-04-30 오후 3 50 42" src="https://github.com/user-attachments/assets/a8e0582d-3aa5-4279-87d9-694c2198e145" />

  - access 토큰: `200` + `userId/email/globalRole`
<img width="720" height="277" alt="스크린샷 2026-04-30 오후 3 48 48" src="https://github.com/user-attachments/assets/b0772220-8863-4114-a6d7-f61ea849f07a" />



## 💬리뷰 요구사항(선택)
- 인가 정책 전환 범위(`/api/v1/auth/`만 공개, 나머지 authenticated)로 일단 해놨어요!! 확인 부탁해용
- `GET /api/v1/users/me`를 임시 검증용으로 만든 거라서 추후 삭제 가능해요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * GET /api/v1/users/me 추가: 현재 사용자의 ID, 이메일, 전역 역할 조회 가능
  * Spring Security용 사용자 상세 정보 제공 기능 추가

* **보안**
  * JWT 기반 인증 체계 적용 및 대부분의 API에 인증 요구 강화
  * 인증 실패 및 접근 권한 부족 시 일관된 JSON 오류 응답 제공
* **API 문서**
  * OpenAPI에 전역 JWT 보안 요구사항 선언 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->