### PR TITLE
[feat] 웹 엔티티 작성 및 레포지토리 클래스 생성 (#17)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
+    implementation 'org.hibernate.orm:hibernate-spatial'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/insideout/backend/domain/ai/entity/AiDetection.java
+++ b/src/main/java/com/insideout/backend/domain/ai/entity/AiDetection.java
@@ -1,0 +1,128 @@
+package com.insideout.backend.domain.ai.entity;
+
+import com.insideout.backend.domain.building.entity.Floorplan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.Geometry;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * AI가 도면에서 탐지해낸 개별 객체(문, 복도, 화장실, 글자 등)의 결과물.
+ *
+ * <p>AI가 분석을 마치면 이 테이블에 결과들이 쌓이고,
+ * 건물 관리자는 맵 에디터에서 이 결과들을 보고 승인(accepted)하거나 거절(rejected)합니다.
+ * 승인된 탐지물은 실제 Node, Edge, Poi 엔티티로 변환됩니다.
+ */
+@Entity
+@Table(name = "ai_detection")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiDetection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id", nullable = false)
+    private AiJob job;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floorplan_id", nullable = false)
+    private Floorplan floorplan;
+
+    /**
+     * AI가 식별한 객체의 종류.
+     * <p>'wall', 'door', 'room', 'elevator', 'text', 'poi_candidate' 등.
+     */
+    @Column(name = "detect_type", nullable = false)
+    private String detectType;
+
+    /**
+     * AI가 인식한 라벨명.
+     */
+    private String label;
+
+    /**
+     * AI의 예측 확신도 (0.0 ~ 1.0).
+     * <p>수치가 낮으면 맵 에디터에서 "주의해서 검토하세요"라고 표시할 수 있습니다.
+     */
+    @Column(precision = 5, scale = 4)
+    private BigDecimal confidence;
+
+    /**
+     * 객체의 도면 상 기하학적 모양 (Point, Polygon 등 자유로운 형태).
+     */
+    @Column(name = "geom_px", columnDefinition = "geometry(Geometry, 0)", nullable = false)
+    private Geometry geomPx;
+
+    /**
+     * 객체를 감싸는 직사각형 바운딩 박스.
+     */
+    @Column(name = "bbox_px", columnDefinition = "box2d")
+    private String bboxPx; // box2d는 JPA에서 String 매핑이 간편합니다.
+
+    /**
+     * 텍스트 인식(OCR) 결과일 경우 읽어낸 글자.
+     */
+    @Column(name = "ocr_text")
+    private String ocrText;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> attrs;
+
+    /**
+     * 관리자 검토 상태.
+     * <p>'pending'(대기중), 'accepted'(승인됨), 'rejected'(기각됨).
+     */
+    @Column(nullable = false)
+    private String status;
+
+    /**
+     * 관리자 승인으로 인해 실제로 생성된 시스템 엔티티의 종류 ('node', 'edge', 'poi' 등).
+     */
+    @Column(name = "committed_entity_type")
+    private String committedEntityType;
+
+    /**
+     * 생성된 시스템 엔티티의 실제 ID.
+     */
+    @Column(name = "committed_entity_id")
+    private UUID committedEntityId;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.status == null) {
+            this.status = "pending";
+        }
+    }
+
+    @Builder
+    public AiDetection(UUID tenantId, AiJob job, Floorplan floorplan, String detectType, String label, BigDecimal confidence, Geometry geomPx, String bboxPx, String ocrText, Map<String, Object> attrs, String status, String committedEntityType, UUID committedEntityId) {
+        this.tenantId = tenantId;
+        this.job = job;
+        this.floorplan = floorplan;
+        this.detectType = detectType;
+        this.label = label;
+        this.confidence = confidence;
+        this.geomPx = geomPx;
+        this.bboxPx = bboxPx;
+        this.ocrText = ocrText;
+        this.attrs = attrs;
+        this.status = status != null ? status : "pending";
+        this.committedEntityType = committedEntityType;
+        this.committedEntityId = committedEntityId;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/ai/entity/AiJob.java
+++ b/src/main/java/com/insideout/backend/domain/ai/entity/AiJob.java
@@ -1,0 +1,105 @@
+package com.insideout.backend.domain.ai.entity;
+
+import com.insideout.backend.domain.building.entity.Floorplan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * AI 파이프라인(객체 추출, 텍스트 인식, POI 추출 등)의 작업 내역을 관리하는 엔티티.
+ *
+ * <p>도면 이미지를 업로드한 후 비동기로 실행되는 머신러닝 작업의 상태를 추적합니다.
+ * 요구사항 35번~42번(단지/건물 도면 오브젝트, 텍스트, POI 추출)의 진행 상태를 담습니다.
+ */
+@Entity
+@Table(name = "ai_job")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiJob {
+
+    /**
+     * AI 작업의 고유 식별자 (PK).
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /**
+     * 작업을 요청한 테넌트.
+     */
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    /**
+     * 분석 대상이 되는 도면 이미지 엔티티.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floorplan_id", nullable = false)
+    private Floorplan floorplan;
+
+    /**
+     * 현재 작업의 처리 상태.
+     * <p>'queued'(대기중), 'running'(분석중), 'succeeded'(완료됨), 'failed'(실패함).
+     * 프론트엔드에서 폴링(Polling)이나 웹소켓으로 상태를 체크할 때 사용합니다.
+     */
+    @Column(nullable = false)
+    private String status;
+
+    /**
+     * 분석에 사용된 AI 모델의 버전.
+     * <p>나중에 모델이 업데이트되어 재분석이 필요할 때 필터링 기준으로 쓸 수 있습니다.
+     */
+    @Column(name = "model_version")
+    private String modelVersion;
+
+    /**
+     * AI 분석 시 넘겨준 파라미터. (예: 어떤 객체만 추출할 것인지 등)
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> params;
+
+    /**
+     * 분석이 실제로 시작된 시각. (큐에서 꺼내진 시점)
+     */
+    @Column(name = "started_at")
+    private OffsetDateTime startedAt;
+
+    /**
+     * 분석이 끝난 시각 (성공/실패 무관).
+     */
+    @Column(name = "finished_at")
+    private OffsetDateTime finishedAt;
+
+    /**
+     * 실패했을 경우 기록되는 에러 메시지 또는 스택트레이스.
+     */
+    private String error;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.status == null) {
+            this.status = "queued";
+        }
+    }
+
+    @Builder
+    public AiJob(UUID tenantId, Floorplan floorplan, String status, String modelVersion, Map<String, Object> params, OffsetDateTime startedAt, OffsetDateTime finishedAt, String error) {
+        this.tenantId = tenantId;
+        this.floorplan = floorplan;
+        this.status = status != null ? status : "queued";
+        this.modelVersion = modelVersion;
+        this.params = params;
+        this.startedAt = startedAt;
+        this.finishedAt = finishedAt;
+        this.error = error;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/ai/repository/AiDetectionRepository.java
+++ b/src/main/java/com/insideout/backend/domain/ai/repository/AiDetectionRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.ai.repository;
+
+import com.insideout.backend.domain.ai.entity.AiDetection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface AiDetectionRepository extends JpaRepository<AiDetection, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/ai/repository/AiJobRepository.java
+++ b/src/main/java/com/insideout/backend/domain/ai/repository/AiJobRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.ai.repository;
+
+import com.insideout.backend.domain.ai.entity.AiJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface AiJobRepository extends JpaRepository<AiJob, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/building/entity/Building.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/Building.java
@@ -9,6 +9,9 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import org.locationtech.jts.geom.Polygon;
+import jakarta.validation.constraints.Min;
+import com.insideout.backend.domain.building.exception.BuildingErrorCode;
+import com.insideout.backend.domain.building.exception.BuildingException;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -63,6 +66,7 @@ public class Building {
     /**
      * 건물 내부에 접근할 수 있는 주출입구/부출입구의 개수.
      */
+    @Min(0)
     @Column(name = "entrance_count", nullable = false)
     private int entranceCount;
 
@@ -99,6 +103,9 @@ public class Building {
 
     @Builder
     public Building(Tenant tenant, String name, String address, Polygon footprint, int entranceCount, Map<String, Object> meta, String externalApiId) {
+        if (entranceCount < 0) {
+            throw new BuildingException(BuildingErrorCode.NEGATIVE_ENTRANCE_COUNT);
+        }
         this.tenant = tenant;
         this.name = name;
         this.address = address;

--- a/src/main/java/com/insideout/backend/domain/building/entity/Building.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/Building.java
@@ -1,0 +1,110 @@
+package com.insideout.backend.domain.building.entity;
+
+import com.insideout.backend.domain.tenant.entity.Tenant;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.Polygon;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 길찾기의 대상이 되는 개별 건물(Building) 엔티티.
+ *
+ * <p>하나의 테넌트(단지)는 여러 개의 건물을 가질 수 있습니다.
+ * 건물이 1개인 경우에도 플랫폼 등록 시 단지-건물 계층 구조를 따릅니다.
+ */
+@Entity
+@Table(name = "building")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Building {
+
+    /**
+     * 건물의 고유 식별자 (PK).
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /**
+     * 이 건물이 속한 테넌트 (단지/기관).
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    /**
+     * 건물명.
+     * <p>예시: "제1공학관", "본관".
+     */
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * 건물의 도로명 또는 지번 주소.
+     */
+    private String address;
+
+    /**
+     * 건물의 2D 지표면 경계(외곽선) 정보.
+     * <p>실외 지도(카카오 등) 위에 오버레이를 띄울 때 건물이 차지하는 영역을 나타냅니다.
+     * PostGIS의 geography(Polygon, 4326)에 매핑됩니다.
+     */
+    @Column(columnDefinition = "geography(Polygon, 4326)")
+    private Polygon footprint;
+
+    /**
+     * 건물 내부에 접근할 수 있는 주출입구/부출입구의 개수.
+     */
+    @Column(name = "entrance_count", nullable = false)
+    private int entranceCount;
+
+    /**
+     * 건물의 추가적인 메타데이터.
+     * <p>운영 시간, 전화번호 등 정형화하기 어려운 정보들을 JSON 형태로 유연하게 저장합니다.
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> meta;
+
+    /**
+     * 외부 지도 API(카카오맵, 네이버맵 등)에서의 식별자.
+     * <p>실외 길찾기와 연동 시 매핑을 위해 사용됩니다.
+     */
+    @Column(name = "external_api_id")
+    private String externalApiId;
+
+    /**
+     * 건물이 시스템에 등록된 시각.
+     */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now();
+        }
+        if (this.meta == null) {
+            this.meta = Map.of();
+        }
+    }
+
+    @Builder
+    public Building(Tenant tenant, String name, String address, Polygon footprint, int entranceCount, Map<String, Object> meta, String externalApiId) {
+        this.tenant = tenant;
+        this.name = name;
+        this.address = address;
+        this.footprint = footprint;
+        this.entranceCount = entranceCount;
+        this.meta = meta != null ? meta : Map.of();
+        this.externalApiId = externalApiId;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/building/entity/BuildingDirectory.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/BuildingDirectory.java
@@ -1,0 +1,94 @@
+package com.insideout.backend.domain.building.entity;
+
+import com.insideout.backend.domain.map.entity.MapVersion;
+import com.insideout.backend.domain.tenant.entity.Tenant;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 앱 전역 검색 및 메인 화면 리스트업을 위한 건물 통합 인덱스 테이블.
+ *
+ * <p>모든 Building 정보 중 대중에게 공개(public)되고 배포된(published) 데이터만
+ * 모아두어, 검색 성능을 극대화하기 위해 사용됩니다. (요구사항 5, 6, 7번)
+ */
+@Entity
+@Table(name = "building_directory")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BuildingDirectory {
+
+    /**
+     * Building 엔티티의 ID와 동일한 값을 사용합니다. (1:1 관계의 읽기 전용 뷰 느낌)
+     */
+    @Id
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String address;
+
+    /**
+     * 건물 분류 카테고리 (대학, 병원, 쇼핑몰 등).
+     */
+    private String category;
+
+    /**
+     * 건물의 중심점 좌표(GPS). 검색 시 거리순 정렬 등에 사용됩니다.
+     */
+    @Column(columnDefinition = "geography(Point, 4326)")
+    private Point centroid;
+
+    /**
+     * 건물이 차지하는 영역(GPS).
+     */
+    @Column(columnDefinition = "geography(Polygon, 4326)")
+    private Polygon bbox;
+
+    /**
+     * 일반 사용자에게 공개할지 여부.
+     */
+    @Column(name = "is_public", nullable = false)
+    private boolean isPublic;
+
+    /**
+     * 이 건물이 현재 제공하고 있는 실제 도면/길찾기 데이터의 버전.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "published_version_id")
+    private MapVersion publishedVersion;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    @Builder
+    public BuildingDirectory(UUID id, Tenant tenant, String name, String address, String category, Point centroid, Polygon bbox, boolean isPublic, MapVersion publishedVersion) {
+        this.id = id;
+        this.tenant = tenant;
+        this.name = name;
+        this.address = address;
+        this.category = category;
+        this.centroid = centroid;
+        this.bbox = bbox;
+        this.isPublic = isPublic;
+        this.publishedVersion = publishedVersion;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/building/entity/Floor.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/Floor.java
@@ -1,0 +1,73 @@
+package com.insideout.backend.domain.building.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * 건물의 개별 층(Floor) 엔티티.
+ *
+ * <p>도면 데이터 호출(요구사항 9번), 층 전환 UI 표시 등에 기준이 되는 데이터입니다.
+ */
+@Entity
+@Table(name = "floor")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Floor {
+
+    /**
+     * 층의 고유 식별자 (PK).
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /**
+     * 이 층이 속한 테넌트 식별자.
+     * <p>성능 및 파티셔닝 목적으로 다중 테넌트 환경에서 FK 없이 직접 저장합니다.
+     */
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    /**
+     * 이 층이 속한 건물.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id", nullable = false)
+    private Building building;
+
+    /**
+     * 숫자 형태의 층 레벨.
+     * <p>지하 1층: -1, 1층: 1, 2층: 2 등으로 표현되어 층간 이동 계산에 사용됩니다.
+     */
+    @Column(nullable = false)
+    private int level;
+
+    /**
+     * UI에 노출되는 층의 명칭.
+     * <p>예시: "B1", "1F", "로비층".
+     */
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * 해당 층의 실제 지표면 대비 고도(미터 단위).
+     * <p>Z축이 포함된 3D 경로 계산이나 정밀한 계단/엘리베이터 이동 거리 계산 시 사용될 수 있습니다.
+     */
+    @Column(name = "elevation_m", precision = 10, scale = 2)
+    private BigDecimal elevationM;
+
+    @Builder
+    public Floor(UUID tenantId, Building building, int level, String name, BigDecimal elevationM) {
+        this.tenantId = tenantId;
+        this.building = building;
+        this.level = level;
+        this.name = name;
+        this.elevationM = elevationM;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/building/entity/Floorplan.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/Floorplan.java
@@ -1,6 +1,8 @@
 package com.insideout.backend.domain.building.entity;
 
 import com.insideout.backend.domain.user.entity.User;
+import com.insideout.backend.domain.building.exception.BuildingErrorCode;
+import com.insideout.backend.domain.building.exception.BuildingException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -97,6 +99,13 @@ public class Floorplan {
 
     @Builder
     public Floorplan(UUID tenantId, Floor floor, String imageUrl, String imageSha256, int widthPx, int heightPx, User uploadedBy, boolean isCurrent) {
+        if (widthPx <= 0 || heightPx <= 0) {
+            throw new BuildingException(BuildingErrorCode.INVALID_FLOORPLAN_DIMENSIONS);
+        }
+        if (tenantId != null && floor != null && floor.getTenantId() != null 
+                && !tenantId.equals(floor.getTenantId())) {
+            throw new BuildingException(BuildingErrorCode.TENANT_MISMATCH);
+        }
         this.tenantId = tenantId;
         this.floor = floor;
         this.imageUrl = imageUrl;

--- a/src/main/java/com/insideout/backend/domain/building/entity/Floorplan.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/Floorplan.java
@@ -1,0 +1,109 @@
+package com.insideout.backend.domain.building.entity;
+
+import com.insideout.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 층별 실내 도면(Floorplan) 원본 이미지 정보를 담는 엔티티.
+ *
+ * <p>관리자가 업로드한 원본 도면 이미지를 관리하며,
+ * AI 객체 추출 및 맵 에디터 바탕 이미지로 사용됩니다.
+ */
+@Entity
+@Table(name = "floorplan")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Floorplan {
+
+    /**
+     * 도면 고유 식별자 (PK).
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /**
+     * 도면이 속한 테넌트 식별자.
+     */
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    /**
+     * 도면이 속한 층.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_id", nullable = false)
+    private Floor floor;
+
+    /**
+     * S3 또는 스토리지에 저장된 이미지의 URL.
+     */
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    /**
+     * 이미지의 해시값(SHA-256).
+     * <p>중복 업로드 방지 및 캐싱 최적화에 사용됩니다.
+     */
+    @Column(name = "image_sha256")
+    private String imageSha256;
+
+    /**
+     * 원본 이미지의 픽셀 너비.
+     * <p>AI 모델이 좌표를 인식하거나 맵 에디터에서 캔버스 크기를 설정할 때 중요합니다.
+     */
+    @Column(name = "width_px", nullable = false)
+    private int widthPx;
+
+    /**
+     * 원본 이미지의 픽셀 높이.
+     */
+    @Column(name = "height_px", nullable = false)
+    private int heightPx;
+
+    /**
+     * 도면을 업로드한 사용자(관리자).
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uploaded_by")
+    private User uploadedBy;
+
+    /**
+     * 현재 해당 층의 최신(활성화된) 도면인지 여부.
+     * <p>같은 층에 여러 도면이 올라갈 수 있으므로(리모델링 등), 이 값이 true인 도면만 서비스됩니다.
+     */
+    @Column(name = "is_current", nullable = false)
+    private boolean isCurrent;
+
+    /**
+     * 도면이 시스템에 업로드된 시각.
+     */
+    @Column(name = "uploaded_at", nullable = false, updatable = false)
+    private OffsetDateTime uploadedAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.uploadedAt == null) {
+            this.uploadedAt = OffsetDateTime.now();
+        }
+    }
+
+    @Builder
+    public Floorplan(UUID tenantId, Floor floor, String imageUrl, String imageSha256, int widthPx, int heightPx, User uploadedBy, boolean isCurrent) {
+        this.tenantId = tenantId;
+        this.floor = floor;
+        this.imageUrl = imageUrl;
+        this.imageSha256 = imageSha256;
+        this.widthPx = widthPx;
+        this.heightPx = heightPx;
+        this.uploadedBy = uploadedBy;
+        this.isCurrent = isCurrent;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/building/entity/FloorplanCalibration.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/FloorplanCalibration.java
@@ -1,0 +1,88 @@
+package com.insideout.backend.domain.building.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 도면 이미지의 픽셀(Pixel) 좌표를 실제 지구의 위경도(GPS)와 
+ * 미터(Meter) 단위로 변환해주는 '마법의 수학 행렬' 정보를 담는 엔티티.
+ *
+ * <p>관리자가 맵 에디터에서 도면의 실제 위치(기준점)를 찍으면(요구사항 45번),
+ * 이 데이터가 생성되어 거리를 계산(length_m)할 수 있게 해줍니다.
+ */
+@Entity
+@Table(name = "floorplan_calibration")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FloorplanCalibration {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floorplan_id", nullable = false)
+    private Floorplan floorplan;
+
+    /**
+     * Ground Control Points (기준점들).
+     * <p>사용자가 맵 에디터에서 찍은 "픽셀 좌표 (x,y)"와 "실제 GPS 좌표 (Lat,Lng)"의 쌍을 담습니다.
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> gcp;
+
+    /**
+     * 변환 행렬 (Affine Transform Matrix).
+     * <p>이 숫자 배열을 픽셀 좌표에 곱하면 실제 GPS 좌표가 튀어나옵니다.
+     */
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(columnDefinition = "double precision[]")
+    private List<Double> affine;
+
+    /**
+     * 도면이 북쪽을 기준으로 얼마나 돌아가 있는지 (회전 각도).
+     */
+    @Column(name = "rotation_deg", precision = 10, scale = 2)
+    private BigDecimal rotationDeg;
+
+    /**
+     * 캘리브레이션 오차율 (미터).
+     */
+    @Column(name = "rmse_m", precision = 10, scale = 2)
+    private BigDecimal rmseM;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now();
+        }
+    }
+
+    @Builder
+    public FloorplanCalibration(UUID tenantId, Floorplan floorplan, Map<String, Object> gcp, List<Double> affine, BigDecimal rotationDeg, BigDecimal rmseM) {
+        this.tenantId = tenantId;
+        this.floorplan = floorplan;
+        this.gcp = gcp;
+        this.affine = affine;
+        this.rotationDeg = rotationDeg;
+        this.rmseM = rmseM;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
@@ -1,0 +1,31 @@
+package com.insideout.backend.domain.building.exception;
+
+import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BuildingErrorCode implements BaseErrorCode {
+
+    NEGATIVE_ENTRANCE_COUNT(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_1",
+        "출입구 개수(entranceCount)는 0 이상이어야 합니다."
+    ),
+    INVALID_FLOORPLAN_DIMENSIONS(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_2",
+        "도면의 가로/세로 길이는 0보다 커야 합니다."
+    ),
+    TENANT_MISMATCH(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_3",
+        "도면의 테넌트 ID와 층의 테넌트 ID가 일치하지 않습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/insideout/backend/domain/building/exception/BuildingException.java
+++ b/src/main/java/com/insideout/backend/domain/building/exception/BuildingException.java
@@ -1,0 +1,9 @@
+package com.insideout.backend.domain.building.exception;
+
+import com.insideout.backend.global.apiPayload.exception.ProjectException;
+
+public class BuildingException extends ProjectException {
+    public BuildingException(BuildingErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/building/repository/BuildingDirectoryRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/BuildingDirectoryRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.building.repository;
+
+import com.insideout.backend.domain.building.entity.BuildingDirectory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface BuildingDirectoryRepository extends JpaRepository<BuildingDirectory, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/BuildingRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.building.repository;
+
+import com.insideout.backend.domain.building.entity.Building;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface BuildingRepository extends JpaRepository<Building, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/building/repository/FloorRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/FloorRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.building.repository;
+
+import com.insideout.backend.domain.building.entity.Floor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface FloorRepository extends JpaRepository<Floor, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/building/repository/FloorplanCalibrationRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/FloorplanCalibrationRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.building.repository;
+
+import com.insideout.backend.domain.building.entity.FloorplanCalibration;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface FloorplanCalibrationRepository extends JpaRepository<FloorplanCalibration, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/building/repository/FloorplanRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/FloorplanRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.building.repository;
+
+import com.insideout.backend.domain.building.entity.Floorplan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface FloorplanRepository extends JpaRepository<Floorplan, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/Edge.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Edge.java
@@ -1,0 +1,140 @@
+package com.insideout.backend.domain.map.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.LineString;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 두 노드(Node)를 연결하는 경로인 엣지(Edge) 엔티티.
+ *
+ * <p>길찾기 알고리즘의 간선(Edge) 역할을 수행하며,
+ * 거리, 가중치(오르막길, 계단 등) 정보를 가집니다.
+ */
+@Entity
+@Table(name = "edge")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Edge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "map_version_id", nullable = false)
+    private MapVersion mapVersion;
+
+    /**
+     * 출발 노드.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_node_id", nullable = false)
+    private Node fromNode;
+
+    /**
+     * 도착 노드.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_node_id", nullable = false)
+    private Node toNode;
+
+    /**
+     * 엣지의 종류 (보행로, 계단, 엘리베이터, 문 등).
+     * <p>EdgeKind 테이블의 코드를 저장합니다. 가중치 계산의 핵심이 됩니다.
+     */
+    @Column(name = "kind", nullable = false)
+    private String kindCode;
+
+    /**
+     * 엣지의 도면 픽셀상 형태 (선 렌더링 시 필요).
+     * <p>노드간 직선이 아닌 꺾인 선형일 수 있으므로 LineString으로 저장합니다.
+     */
+    @Column(name = "geom_px", columnDefinition = "geometry(LineString, 0)")
+    private LineString geomPx;
+
+    /**
+     * 엣지의 실제 지구 상의 선형 (위경도 및 고도).
+     */
+    @Column(name = "geom_wgs84", columnDefinition = "geography(LineStringZ, 4326)")
+    private LineString geomWgs84;
+
+    /**
+     * 노드 간의 실제 물리적 거리 (미터).
+     * <p>길찾기 최단거리 계산 시 사용됩니다.
+     */
+    @Column(name = "length_m", precision = 10, scale = 2)
+    private BigDecimal lengthM;
+
+    /**
+     * 방향성 여부.
+     * <p>true이면 fromNode -> toNode 로만 이동 가능합니다. (예: 에스컬레이터 상행)
+     */
+    @Column(name = "is_directed", nullable = false)
+    private boolean isDirected;
+
+    /**
+     * 엣지 고유의 가중치 배수.
+     * <p>기본값은 1.0이며, 이 엣지가 특별히 건너기 힘들거나 편하면 값을 조절합니다.
+     */
+    @Column(name = "base_weight", nullable = false, precision = 10, scale = 2)
+    private BigDecimal baseWeight;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> properties;
+
+    @Column(nullable = false)
+    private String source;
+
+    @Column(name = "ai_detection_id")
+    private UUID aiDetectionId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now();
+        }
+        if (this.properties == null) {
+            this.properties = Map.of();
+        }
+        if (this.baseWeight == null) {
+            this.baseWeight = BigDecimal.ONE;
+        }
+        if (this.source == null) {
+            this.source = "manual";
+        }
+    }
+
+    @Builder
+    public Edge(UUID tenantId, MapVersion mapVersion, Node fromNode, Node toNode, String kindCode, LineString geomPx, LineString geomWgs84, BigDecimal lengthM, boolean isDirected, BigDecimal baseWeight, Map<String, Object> properties, String source, UUID aiDetectionId) {
+        this.tenantId = tenantId;
+        this.mapVersion = mapVersion;
+        this.fromNode = fromNode;
+        this.toNode = toNode;
+        this.kindCode = kindCode;
+        this.geomPx = geomPx;
+        this.geomWgs84 = geomWgs84;
+        this.lengthM = lengthM;
+        this.isDirected = isDirected;
+        this.baseWeight = baseWeight != null ? baseWeight : BigDecimal.ONE;
+        this.properties = properties != null ? properties : Map.of();
+        this.source = source != null ? source : "manual";
+        this.aiDetectionId = aiDetectionId;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/Edge.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Edge.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import org.locationtech.jts.geom.LineString;
+import com.insideout.backend.domain.map.exception.MapErrorCode;
+import com.insideout.backend.domain.map.exception.MapException;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -123,6 +125,15 @@ public class Edge {
 
     @Builder
     public Edge(UUID tenantId, MapVersion mapVersion, Node fromNode, Node toNode, String kindCode, LineString geomPx, LineString geomWgs84, BigDecimal lengthM, boolean isDirected, BigDecimal baseWeight, Map<String, Object> properties, String source, UUID aiDetectionId) {
+        BigDecimal finalBaseWeight = baseWeight != null ? baseWeight : BigDecimal.ONE;
+        
+        if (finalBaseWeight.signum() <= 0) {
+            throw new MapException(MapErrorCode.INVALID_BASE_WEIGHT);
+        }
+        if (lengthM != null && lengthM.signum() < 0) {
+            throw new MapException(MapErrorCode.NEGATIVE_LENGTH);
+        }
+
         this.tenantId = tenantId;
         this.mapVersion = mapVersion;
         this.fromNode = fromNode;
@@ -132,7 +143,7 @@ public class Edge {
         this.geomWgs84 = geomWgs84;
         this.lengthM = lengthM;
         this.isDirected = isDirected;
-        this.baseWeight = baseWeight != null ? baseWeight : BigDecimal.ONE;
+        this.baseWeight = finalBaseWeight;
         this.properties = properties != null ? properties : Map.of();
         this.source = source != null ? source : "manual";
         this.aiDetectionId = aiDetectionId;

--- a/src/main/java/com/insideout/backend/domain/map/entity/EdgeKind.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/EdgeKind.java
@@ -1,0 +1,74 @@
+package com.insideout.backend.domain.map.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+/**
+ * 엣지(Edge)의 종류 사전 테이블.
+ *
+ * 마스터 데이터로 V5 시드 데이터에 INSERT 됨:
+ * walkway(일반 보행), stair(계단), elevator(엘리베이터),
+ * escalator(에스컬레이터, 단방향), door(문 통과), outdoor(실외 보행).
+ *
+ * <p>Edge 엔티티가 이 테이블의 code를 참조해서
+ * "이 엣지는 보행로인지, 계단인지, 엘리베이터인지" 결정.
+ */
+@Entity
+@Table(name = "edge_kind")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EdgeKind {
+
+    /**
+     * 엣지 종류 코드 (Primary Key).
+     *
+     * <p>예시: "walkway"(보행), "stair"(계단 이동), "elevator"(엘리베이터 이동).
+     */
+    @Id
+    @Column(length = 50)
+    private String code;
+
+    /**
+     * 한글 표시 이름.
+     * <p>예시: "일반 보행", "계단 이동", "엘리베이터 이동".
+     */
+    @Column(name = "name_ko", nullable = false)
+    private String nameKo;
+
+    /**
+     * 방향성이 있는 엣지인지.
+     *
+     * <p>true: 단방향 (예: 에스컬레이터는 한 방향으로만 이동 가능)
+     * <br>false: 양방향 (대부분의 보행로, 계단)
+     *
+     * <p>라우팅 엔진이 그래프 만들 때 단방향 엣지는 한쪽으로만 연결.
+     */
+    @Column(name = "is_directed", nullable = false)
+    private boolean isDirected;
+
+    /**
+     * 기본 가중치 배수.
+     *
+     * <p>A* 길찾기에서 이 종류의 엣지는 거리 × 이 배수만큼 비용으로 계산됨.
+     *
+     * <p>예시:
+     * <ul>
+     *   <li>walkway: 1.0 (기본)</li>
+     *   <li>stair: 3.0 (계단은 힘들어서 회피 권장)</li>
+     *   <li>elevator: 5.0 (대기시간 고려)</li>
+     *   <li>door: 1.2 (문 통과 약간 페널티)</li>
+     * </ul>
+     */
+    @Column(name = "default_cost_multiplier", nullable = false, precision = 10, scale = 2)
+    private BigDecimal defaultCostMultiplier;
+
+    @Builder
+    public EdgeKind(String code, String nameKo, boolean isDirected, BigDecimal defaultCostMultiplier) {
+        this.code = code;
+        this.nameKo = nameKo;
+        this.isDirected = isDirected;
+        this.defaultCostMultiplier = defaultCostMultiplier != null ? defaultCostMultiplier : BigDecimal.ONE;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/MapVersion.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/MapVersion.java
@@ -1,0 +1,106 @@
+package com.insideout.backend.domain.map.entity;
+
+import com.insideout.backend.domain.building.entity.Building;
+import com.insideout.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 길찾기 그래프(노드, 엣지, POI 등)의 버전을 관리하는 엔티티.
+ *
+ * <p>관리자가 맵 에디터에서 작업을 하더라도 사용자에게 바로 노출되지 않고,
+ * 'published' 상태의 버전만 서비스에 반영됩니다.
+ * 작업 히스토리 추적 및 롤백이 가능하도록 설계되었습니다.
+ */
+@Entity
+@Table(name = "map_version")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MapVersion {
+
+    /**
+     * 맵 버전의 고유 식별자 (PK).
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /**
+     * 이 맵 버전이 속한 테넌트 식별자.
+     */
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    /**
+     * 이 맵 버전이 속한 건물.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id", nullable = false)
+    private Building building;
+
+    /**
+     * 버전을 구별하기 위한 라벨.
+     * <p>예시: "2024-1학기 개편 반영", "v1.0.0".
+     */
+    @Column(nullable = false)
+    private String label;
+
+    /**
+     * 버전의 상태.
+     * <p>'draft'(임시저장), 'published'(배포됨), 'archived'(과거 버전).
+     */
+    @Column(nullable = false)
+    private String status;
+
+    /**
+     * 이 버전이 파생된 부모 버전의 식별자. (히스토리 추적용)
+     */
+    @Column(name = "parent_version_id")
+    private UUID parentVersionId;
+
+    /**
+     * 이 버전을 생성한 관리자.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    /**
+     * 버전이 생성된(초안이 만들어진) 시각.
+     */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    /**
+     * 이 버전이 사용자들에게 배포된 시각 ('published' 상태 전환 시각).
+     */
+    @Column(name = "published_at")
+    private OffsetDateTime publishedAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now();
+        }
+        if (this.status == null) {
+            this.status = "draft";
+        }
+    }
+
+    @Builder
+    public MapVersion(UUID tenantId, Building building, String label, String status, UUID parentVersionId, User createdBy, OffsetDateTime publishedAt) {
+        this.tenantId = tenantId;
+        this.building = building;
+        this.label = label;
+        this.status = status != null ? status : "draft";
+        this.parentVersionId = parentVersionId;
+        this.createdBy = createdBy;
+        this.publishedAt = publishedAt;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/MapVersion.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/MapVersion.java
@@ -95,12 +95,21 @@ public class MapVersion {
 
     @Builder
     public MapVersion(UUID tenantId, Building building, String label, String status, UUID parentVersionId, User createdBy, OffsetDateTime publishedAt) {
+        String finalStatus = status != null ? status : "draft";
+        OffsetDateTime finalPublishedAt = publishedAt;
+
+        if ("published".equals(finalStatus) && finalPublishedAt == null) {
+            finalPublishedAt = OffsetDateTime.now();
+        } else if (finalPublishedAt != null && !"published".equals(finalStatus)) {
+            finalStatus = "published";
+        }
+
         this.tenantId = tenantId;
         this.building = building;
         this.label = label;
-        this.status = status != null ? status : "draft";
+        this.status = finalStatus;
         this.parentVersionId = parentVersionId;
         this.createdBy = createdBy;
-        this.publishedAt = publishedAt;
+        this.publishedAt = finalPublishedAt;
     }
 }

--- a/src/main/java/com/insideout/backend/domain/map/entity/Node.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Node.java
@@ -1,0 +1,129 @@
+package com.insideout.backend.domain.map.entity;
+
+import com.insideout.backend.domain.building.entity.Floor;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.Point;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 실내 길찾기 경로의 교차점, 출입구, 이동 지점을 나타내는 노드(Node) 엔티티.
+ *
+ * <p>맵 에디터에서 사용자가 지정하거나 AI가 추출한 교차점이며,
+ * A* 알고리즘 등에서 정점(Vertex) 역할을 합니다.
+ */
+@Entity
+@Table(name = "node")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Node {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    /**
+     * 노드가 속한 맵 버전.
+     * <p>버전이 다르면 노드 그래프도 완전히 다를 수 있습니다.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "map_version_id", nullable = false)
+    private MapVersion mapVersion;
+
+    /**
+     * 이 노드가 위치한 층.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_id", nullable = false)
+    private Floor floor;
+
+    /**
+     * 노드의 종류. (복도 교차점, 엘리베이터, 계단 등)
+     * <p>NodeKind 테이블의 코드를 참조합니다. (수동 관리를 위해 다대일 연관관계 대신 코드 문자열 직접 저장)
+     */
+    @Column(name = "kind", nullable = false)
+    private String kindCode;
+
+    /**
+     * 도면 이미지 상의 2D 좌표(Pixel).
+     * <p>맵 에디터에 노드를 렌더링하거나, 픽셀 기준 길찾기 선을 그릴 때 사용합니다.
+     */
+    @Column(name = "geom_px", columnDefinition = "geometry(Point, 0)", nullable = false)
+    private Point geomPx;
+
+    /**
+     * 실제 지구 상의 3D 좌표 (위도, 경도, 고도).
+     * <p>실외 지도(카카오/네이버 맵)와 매핑될 때 사용됩니다.
+     */
+    @Column(name = "geom_wgs84", columnDefinition = "geography(PointZ, 4326)")
+    private Point geomWgs84;
+
+    /**
+     * 노드의 명칭. (옵션)
+     * <p>예: "서문 출입구", "A동 연결통로"
+     */
+    @Column(name = "name_ko")
+    private String nameKo;
+
+    /**
+     * 노드의 추가 속성들을 담는 JSON 데이터.
+     * <p>휠체어 접근 가능 여부 등 확장 데이터를 유연하게 담습니다.
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> properties;
+
+    /**
+     * 노드가 어떻게 생성되었는지 출처.
+     * <p>'ai'(자동추출), 'ai_confirmed'(관리자 확정), 'manual'(관리자 직접 생성).
+     */
+    @Column(nullable = false)
+    private String source;
+
+    /**
+     * AI가 추출한 노드인 경우, 원본 AI 탐지 결과(AiDetection)의 ID.
+     */
+    @Column(name = "ai_detection_id")
+    private UUID aiDetectionId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now();
+        }
+        if (this.properties == null) {
+            this.properties = Map.of();
+        }
+        if (this.source == null) {
+            this.source = "manual";
+        }
+    }
+
+    @Builder
+    public Node(UUID tenantId, MapVersion mapVersion, Floor floor, String kindCode, Point geomPx, Point geomWgs84, String nameKo, Map<String, Object> properties, String source, UUID aiDetectionId) {
+        this.tenantId = tenantId;
+        this.mapVersion = mapVersion;
+        this.floor = floor;
+        this.kindCode = kindCode;
+        this.geomPx = geomPx;
+        this.geomWgs84 = geomWgs84;
+        this.nameKo = nameKo;
+        this.properties = properties != null ? properties : Map.of();
+        this.source = source != null ? source : "manual";
+        this.aiDetectionId = aiDetectionId;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/Node.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Node.java
@@ -113,6 +113,13 @@ public class Node {
         }
     }
 
+    // TODO: Node 생성 시 mapVersion과 floor가 동일한 Building을 참조하는지 반드시 검증해야 합니다.
+    //       LAZY 로딩 특성상 이 생성자 안에서 검증하면 LazyInitializationException이 발생할 수 있으므로,
+    //       NodeService에서 두 엔티티를 완전히 로딩한 후 아래와 같이 검증하고 생성하세요:
+    //
+    //       if (!floor.getBuilding().getId().equals(mapVersion.getBuilding().getId())) {
+    //           throw new MapException(MapErrorCode.BUILDING_MISMATCH);
+    //       }
     @Builder
     public Node(UUID tenantId, MapVersion mapVersion, Floor floor, String kindCode, Point geomPx, Point geomWgs84, String nameKo, Map<String, Object> properties, String source, UUID aiDetectionId) {
         this.tenantId = tenantId;

--- a/src/main/java/com/insideout/backend/domain/map/entity/Node.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Node.java
@@ -120,6 +120,25 @@ public class Node {
     //       if (!floor.getBuilding().getId().equals(mapVersion.getBuilding().getId())) {
     //           throw new MapException(MapErrorCode.BUILDING_MISMATCH);
     //       }
+
+//    // NodeService 또는 NodeFactory 내부 (트랜잭션 컨텍스트 안)
+//    public Node createNode(CreateNodeRequest request) {
+//        MapVersion mapVersion = mapVersionRepository.findById(request.mapVersionId())
+//                .orElseThrow(...);
+//        Floor floor = floorRepository.findById(request.floorId())
+//                .orElseThrow(...);
+//
+//        // Building 일관성 검증 — 두 엔티티가 이미 로드된 상태이므로 안전
+//        if (!floor.getBuilding().getId().equals(mapVersion.getBuilding().getId())) {
+//            throw new MapException(MapErrorCode.BUILDING_MISMATCH);
+//        }
+//
+//        return nodeRepository.save(Node.builder()
+//                .mapVersion(mapVersion)
+//                .floor(floor)
+//        ...
+//        .build());
+//    }
     @Builder
     public Node(UUID tenantId, MapVersion mapVersion, Floor floor, String kindCode, Point geomPx, Point geomWgs84, String nameKo, Map<String, Object> properties, String source, UUID aiDetectionId) {
         this.tenantId = tenantId;

--- a/src/main/java/com/insideout/backend/domain/map/entity/NodeKind.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/NodeKind.java
@@ -1,0 +1,73 @@
+package com.insideout.backend.domain.map.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 노드(Node)의 종류 사전 테이블.
+ *
+ * 마스터 데이터(시드 데이터로 미리 채워둠)이며, V5 마이그레이션에서
+ * INSERT 됨: corridor, door, entrance, stair, elevator, escalator, poi_anchor, portal
+ *
+ * <p>이 테이블은 "어떤 종류의 노드들이 시스템에 존재하는가"를 정의함.
+ * Node 엔티티가 이 테이블의 code 컬럼을 외래키로 참조.
+ *
+ * <p>비유: enum과 비슷하지만 DB에서 관리해서 운영 중에도 추가 가능.
+ */
+@Entity
+@Table(name = "node_kind")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NodeKind {
+
+    /**
+     * 노드 종류 코드 (Primary Key).
+     *
+     * <p>예시: "corridor"(복도 교차점), "elevator"(엘리베이터),
+     * "stair"(계단), "door"(문), "entrance"(건물 출입구).
+     *
+     * <p>UUID 대신 의미 있는 문자열을 PK로 사용 — 마스터 데이터라 변경 거의 없음.
+     */
+    @Id
+    @Column(length = 50)
+    private String code;
+
+    /**
+     * 한글 표시 이름.
+     *
+     * <p>예시: "복도 교차점", "엘리베이터", "계단".
+     * 사용자에게 보여주는 텍스트.
+     */
+    @Column(name = "name_ko", nullable = false)
+    private String nameKo;
+
+    /**
+     * 층간 이동 관련 노드인지 여부.
+     *
+     * <p>true: 엘리베이터, 계단, 에스컬레이터 (다른 층으로 연결됨)
+     * <br>false: 일반 복도, 문 등 (같은 층 안에서만 의미 있음)
+     *
+     * <p>라우팅 엔진이 "이 노드는 층간 이동 가능"을 판단할 때 사용.
+     */
+    @Column(name = "is_vertical", nullable = false)
+    private boolean isVertical;
+
+    /**
+     * vertical_connector로 묶여야 하는 노드인지 여부.
+     *
+     * <p>true: 엘리베이터, 계단 — 여러 층의 노드들이 하나의 "이동 수단"으로 묶여야 함
+     * <br>false: 일반 노드
+     *
+     * <p>true인 노드는 반드시 VerticalConnector에 등록되어야 라우팅에서 제대로 동작.
+     */
+    @Column(name = "needs_connector", nullable = false)
+    private boolean needsConnector;
+
+    @Builder
+    public NodeKind(String code, String nameKo, boolean isVertical, boolean needsConnector) {
+        this.code = code;
+        this.nameKo = nameKo;
+        this.isVertical = isVertical;
+        this.needsConnector = needsConnector;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
@@ -1,0 +1,132 @@
+package com.insideout.backend.domain.map.entity;
+
+import com.insideout.backend.domain.building.entity.Building;
+import com.insideout.backend.domain.building.entity.Floor;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.Geometry;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 길찾기 중 일시적이거나 동적인 통행 제한 구역/장애물을 나타내는 엔티티.
+ *
+ * <p>공사 중, 청소 중, 행사 등의 이유로 기존의 엣지(Edge)를 막거나
+ * 비용(가중치)을 증가시켜야 할 때 사용됩니다.
+ * 영구적인 맵 버전을 업데이트하지 않고도 실시간으로 경로를 우회시킬 수 있습니다.
+ */
+@Entity
+@Table(name = "obstacle")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Obstacle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id", nullable = false)
+    private Building building;
+
+    /**
+     * 장애물이 위치한 층.
+     * <p>null일 경우 건물 전체에 영향을 미치는 것으로 해석할 수 있습니다.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_id")
+    private Floor floor;
+
+    /**
+     * 장애물의 종류. (construction, closed, slippery, event 등)
+     */
+    @Column(nullable = false)
+    private String kind;
+
+    /**
+     * 장애물이 차지하는 물리적 공간 (도면 픽셀 단위).
+     * <p>프론트엔드에 장애물 경고 아이콘이나 위험 구역(Polygon)을 렌더링하기 위해 사용됩니다.
+     */
+    @Column(name = "geom_px", columnDefinition = "geometry")
+    private Geometry geomPx;
+
+    /**
+     * 이 장애물로 인해 직접적으로 영향을 받는 길찾기 엣지(Edge)들의 ID 리스트.
+     * <p>이 배열에 속한 엣지는 라우팅 시 페널티를 받거나 차단됩니다.
+     */
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(name = "affected_edge_ids", columnDefinition = "uuid[]")
+    private List<UUID> affectedEdgeIds;
+
+    /**
+     * 이 구역을 지나갈 때 부여되는 추가적인 거리 가중치(페널티).
+     * <p>미끄러움 등으로 인해 "되도록 피하되 불가피하면 지나가는 길"로 만들고 싶을 때 사용.
+     */
+    @Column(name = "extra_cost", nullable = false, precision = 10, scale = 2)
+    private BigDecimal extraCost;
+
+    /**
+     * 이 구역이 완전히 차단되어 통행이 불가능한지 여부.
+     * <p>true이면 라우팅 엔진은 해당 affected_edge_ids를 경로에서 완전 제외합니다.
+     */
+    @Column(name = "is_blocking", nullable = false)
+    private boolean isBlocking;
+
+    /**
+     * 장애물의 유효 시작 시간. (예: 공사 시작일)
+     */
+    @Column(name = "active_from")
+    private OffsetDateTime activeFrom;
+
+    /**
+     * 장애물의 유효 종료 시간. (예: 공사 종료일)
+     * <p>이 시간이 지나면 라우팅 엔진이 장애물을 무시합니다.
+     */
+    @Column(name = "active_to")
+    private OffsetDateTime activeTo;
+
+    /**
+     * 사용자에게 노출될 장애물 관련 안내 문구.
+     * <p>예: "바닥 왁스 작업 중이므로 우회 바랍니다."
+     */
+    private String note;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now();
+        }
+        if (this.extraCost == null) {
+            this.extraCost = BigDecimal.ZERO;
+        }
+    }
+
+    @Builder
+    public Obstacle(UUID tenantId, Building building, Floor floor, String kind, Geometry geomPx, List<UUID> affectedEdgeIds, BigDecimal extraCost, boolean isBlocking, OffsetDateTime activeFrom, OffsetDateTime activeTo, String note) {
+        this.tenantId = tenantId;
+        this.building = building;
+        this.floor = floor;
+        this.kind = kind;
+        this.geomPx = geomPx;
+        this.affectedEdgeIds = affectedEdgeIds;
+        this.extraCost = extraCost != null ? extraCost : BigDecimal.ZERO;
+        this.isBlocking = isBlocking;
+        this.activeFrom = activeFrom;
+        this.activeTo = activeTo;
+        this.note = note;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
@@ -16,6 +16,7 @@ import org.locationtech.jts.geom.Geometry;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -133,6 +134,11 @@ public class Obstacle {
     public Obstacle(UUID tenantId, Building building, Floor floor, String kind, Geometry geomPx, List<UUID> affectedEdgeIds, BigDecimal extraCost, boolean isBlocking, OffsetDateTime activeFrom, OffsetDateTime activeTo, String note) {
         BigDecimal finalExtraCost = extraCost != null ? extraCost : BigDecimal.ZERO;
 
+        // 필수 필드 null 선검증 (DB nullable=false 콜럼과 동기화)
+        Objects.requireNonNull(tenantId, "tenantId must not be null");
+        Objects.requireNonNull(building, "building must not be null");
+        Objects.requireNonNull(kind, "kind must not be null");
+
         if (finalExtraCost.signum() < 0) {
             throw new MapException(MapErrorCode.NEGATIVE_EXTRA_COST);
         }
@@ -140,7 +146,7 @@ public class Obstacle {
             throw new MapException(MapErrorCode.INVALID_ACTIVE_PERIOD);
         }
         // floor.getTenantId()는 UUID 직접 필드이므로 생성자에서 안전하게 검증 가능
-        if (tenantId != null && floor != null && floor.getTenantId() != null
+        if (floor != null && floor.getTenantId() != null
                 && !tenantId.equals(floor.getTenantId())) {
             throw new MapException(MapErrorCode.OBSTACLE_TENANT_MISMATCH);
         }

--- a/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
@@ -117,6 +117,18 @@ public class Obstacle {
         }
     }
 
+    // TODO: Obstacle 생성 시 아래 불변식을 Service에서 반드시 검증해야 합니다.
+    //       building.getTenant() 및 floor.getBuilding()은 LAZY 로딩 연관 엔티티 호출이므로
+    //       생성자 안에서 호출 시 LazyInitializationException이 발생합니다.
+    //       ObstacleService에서 building, floor를 완전히 로딩한 후 검증하세요:
+    //
+    //       1. tenantId가 building의 tenant와 일치하는지:
+    //          if (!tenantId.equals(building.getTenant().getId()))
+    //              throw new MapException(MapErrorCode.OBSTACLE_TENANT_MISMATCH);
+    //
+    //       2. floor가 building 소속인지:
+    //          if (!floor.getBuilding().getId().equals(building.getId()))
+    //              throw new MapException(MapErrorCode.OBSTACLE_BUILDING_MISMATCH);
     @Builder
     public Obstacle(UUID tenantId, Building building, Floor floor, String kind, Geometry geomPx, List<UUID> affectedEdgeIds, BigDecimal extraCost, boolean isBlocking, OffsetDateTime activeFrom, OffsetDateTime activeTo, String note) {
         BigDecimal finalExtraCost = extraCost != null ? extraCost : BigDecimal.ZERO;
@@ -126,6 +138,11 @@ public class Obstacle {
         }
         if (activeFrom != null && activeTo != null && activeFrom.isAfter(activeTo)) {
             throw new MapException(MapErrorCode.INVALID_ACTIVE_PERIOD);
+        }
+        // floor.getTenantId()는 UUID 직접 필드이므로 생성자에서 안전하게 검증 가능
+        if (tenantId != null && floor != null && floor.getTenantId() != null
+                && !tenantId.equals(floor.getTenantId())) {
+            throw new MapException(MapErrorCode.OBSTACLE_TENANT_MISMATCH);
         }
 
         this.tenantId = tenantId;

--- a/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
@@ -2,6 +2,8 @@ package com.insideout.backend.domain.map.entity;
 
 import com.insideout.backend.domain.building.entity.Building;
 import com.insideout.backend.domain.building.entity.Floor;
+import com.insideout.backend.domain.map.exception.MapErrorCode;
+import com.insideout.backend.domain.map.exception.MapException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -117,13 +119,22 @@ public class Obstacle {
 
     @Builder
     public Obstacle(UUID tenantId, Building building, Floor floor, String kind, Geometry geomPx, List<UUID> affectedEdgeIds, BigDecimal extraCost, boolean isBlocking, OffsetDateTime activeFrom, OffsetDateTime activeTo, String note) {
+        BigDecimal finalExtraCost = extraCost != null ? extraCost : BigDecimal.ZERO;
+
+        if (finalExtraCost.signum() < 0) {
+            throw new MapException(MapErrorCode.NEGATIVE_EXTRA_COST);
+        }
+        if (activeFrom != null && activeTo != null && activeFrom.isAfter(activeTo)) {
+            throw new MapException(MapErrorCode.INVALID_ACTIVE_PERIOD);
+        }
+
         this.tenantId = tenantId;
         this.building = building;
         this.floor = floor;
         this.kind = kind;
         this.geomPx = geomPx;
         this.affectedEdgeIds = affectedEdgeIds;
-        this.extraCost = extraCost != null ? extraCost : BigDecimal.ZERO;
+        this.extraCost = finalExtraCost;
         this.isBlocking = isBlocking;
         this.activeFrom = activeFrom;
         this.activeTo = activeTo;

--- a/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
@@ -132,6 +132,13 @@ public class Poi {
         }
     }
 
+    // TODO: Poi 생성 시 mapVersion과 floor가 동일한 Building을 참조하는지 반드시 검증해야 합니다.
+    //       Node와 동일한 이유(LAZY 로딩)로 생성자 안에서 검증하면 LazyInitializationException이 발생합니다.
+    //       PoiService에서 두 엔티티를 완전히 로딩한 후 아래와 같이 검증하고 생성하세요:
+    //
+    //       if (!floor.getBuilding().getId().equals(mapVersion.getBuilding().getId())) {
+    //           throw new MapException(MapErrorCode.BUILDING_MISMATCH);
+    //       }
     @Builder
     public Poi(UUID tenantId, MapVersion mapVersion, Floor floor, Long categoryId, String name, String code, Point geomPx, Polygon footprintPx, Point geomWgs84, UUID anchorNodeId, List<String> tags, Map<String, Object> attrs, String externalApiId, String source, UUID aiDetectionId) {
         this.tenantId = tenantId;

--- a/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
@@ -1,0 +1,153 @@
+package com.insideout.backend.domain.map.entity;
+
+import com.insideout.backend.domain.building.entity.Floor;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 길찾기 및 통합 검색의 대상이 되는 주요 관심 지점(Point of Interest) 엔티티.
+ *
+ * <p>식당, 화장실, 엘리베이터, 매장 등 사용자가 최종 목적지로 선택하거나
+ * 도면 상에 마커로 표시되는 지점들을 의미합니다. (요구사항 10번, 12번)
+ */
+@Entity
+@Table(name = "poi")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Poi {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "map_version_id", nullable = false)
+    private MapVersion mapVersion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_id", nullable = false)
+    private Floor floor;
+
+    /**
+     * POI의 분류 카테고리 (화장실, 식당 등).
+     * <p>검색 필터링이나 지도 상의 아이콘(마커) 이미지를 결정하는 데 사용됩니다.
+     */
+    @Column(name = "category_id")
+    private Long categoryId;
+
+    /**
+     * POI의 명칭 (자동완성 및 검색어 매칭 대상).
+     * <p>예시: "스타벅스", "남자화장실".
+     */
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * POI 식별용 코드 (보통 학사/사내 시스템 연동 시 호실 번호 등).
+     */
+    private String code;
+
+    /**
+     * 도면 이미지 상의 중심점 좌표(Pixel).
+     * <p>사용자가 도면을 볼 때 POI 마커가 렌더링될 위치입니다.
+     */
+    @Column(name = "geom_px", columnDefinition = "geometry(Point, 0)", nullable = false)
+    private Point geomPx;
+
+    /**
+     * 도면 이미지 상에서 이 POI가 차지하는 실제 면적/경계 다각형(Pixel).
+     * <p>지도에서 해당 영역 터치 시 이 POI를 선택하게 만들 때 사용됩니다.
+     */
+    @Column(name = "footprint_px", columnDefinition = "geometry(Polygon, 0)")
+    private Polygon footprintPx;
+
+    /**
+     * 실제 위경도 좌표. (실외 지도와 통합 렌더링 시 필요)
+     */
+    @Column(name = "geom_wgs84", columnDefinition = "geography(Point, 4326)")
+    private Point geomWgs84;
+
+    /**
+     * 목적지로 설정되었을 때 길찾기 안내가 끝나는 실제 도착지 노드(Node) ID.
+     * <p>매장 중심(POI)까지 들어가는게 아니라 "매장 입구 노드"까지 안내하기 위해 사용됩니다.
+     */
+    @Column(name = "anchor_node_id")
+    private UUID anchorNodeId;
+
+    /**
+     * 검색 키워드 확장을 위한 태그 목록.
+     * <p>예: ["커피", "디저트", "조용한"] -> "커피" 검색 시 이 POI 노출.
+     */
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(columnDefinition = "text[]")
+    private List<String> tags;
+
+    /**
+     * POI의 운영시간, 전화번호, 사진URL 등 부가 정보 (요구사항 8번 연동).
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> attrs;
+
+    /**
+     * 네이버/카카오/구글 플레이스 API 등 외부 연동 ID.
+     */
+    @Column(name = "external_api_id")
+    private String externalApiId;
+
+    @Column(nullable = false)
+    private String source;
+
+    @Column(name = "ai_detection_id")
+    private UUID aiDetectionId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now();
+        }
+        if (this.attrs == null) {
+            this.attrs = Map.of();
+        }
+        if (this.source == null) {
+            this.source = "manual";
+        }
+    }
+
+    @Builder
+    public Poi(UUID tenantId, MapVersion mapVersion, Floor floor, Long categoryId, String name, String code, Point geomPx, Polygon footprintPx, Point geomWgs84, UUID anchorNodeId, List<String> tags, Map<String, Object> attrs, String externalApiId, String source, UUID aiDetectionId) {
+        this.tenantId = tenantId;
+        this.mapVersion = mapVersion;
+        this.floor = floor;
+        this.categoryId = categoryId;
+        this.name = name;
+        this.code = code;
+        this.geomPx = geomPx;
+        this.footprintPx = footprintPx;
+        this.geomWgs84 = geomWgs84;
+        this.anchorNodeId = anchorNodeId;
+        this.tags = tags;
+        this.attrs = attrs != null ? attrs : Map.of();
+        this.externalApiId = externalApiId;
+        this.source = source != null ? source : "manual";
+        this.aiDetectionId = aiDetectionId;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/PoiCategory.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/PoiCategory.java
@@ -1,0 +1,112 @@
+package com.insideout.backend.domain.map.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * POI 카테고리 트리 테이블.
+ *
+ * 계층형 분류 체계를 ltree 타입으로 저장:
+ * <pre>
+ *   facility
+ *   ├── facility.restroom
+ *   ├── facility.elevator
+ *   ├── facility.stair
+ *   └── facility.parking
+ *
+ *   store
+ *   ├── store.cafe
+ *   ├── store.food
+ *   └── store.retail
+ *
+ *   academic
+ *   ├── academic.classroom
+ *   ├── academic.lab
+ *   └── academic.office
+ * </pre>
+ *
+ * <p>POI 엔티티가 이 테이블의 id를 외래키로 참조해서 자기 카테고리를 가짐.
+ *
+ * <p>참고: 현재는 ltree 타입을 String으로만 저장. 트리 검색 쿼리는
+ * 필요 시 native query로 작성.
+ */
+@Entity
+@Table(name = "poi_category")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PoiCategory {
+
+    /**
+     * 카테고리 ID (Primary Key, 자동 증가).
+     *
+     * <p>bigserial 타입 — node_kind/edge_kind와 달리 카테고리는 동적으로 추가될 가능성이 있어서
+     * 의미 있는 PK 대신 숫자 PK 사용.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 카테고리 코드 (UNIQUE).
+     *
+     * <p>예시: "facility.restroom", "store.cafe".
+     * path와 거의 같은 값이지만 별도 컬럼으로 둬서 코드 검색 시 인덱스 활용.
+     */
+    @Column(unique = true, nullable = false, length = 100)
+    private String code;
+
+    /**
+     * 트리 경로 (PostgreSQL ltree 타입).
+     *
+     * <p>점(.)으로 구분된 계층 경로: "store.cafe", "academic.classroom".
+     *
+     * <p>ltree는 Hibernate가 직접 지원 안 해서 String으로 매핑.
+     * 트리 검색이 필요하면 native query로 ltree 연산자(`<@`, `@>`) 사용.
+     */
+    @Column(nullable = false, columnDefinition = "ltree")
+    private String path;
+
+    /**
+     * 카테고리 한글 이름.
+     * <p>예시: "화장실", "카페", "강의실".
+     */
+    @Column(name = "name_ko", nullable = false)
+    private String nameKo;
+
+    /**
+     * 카테고리 영문 이름 (선택).
+     * <p>예시: "Restroom", "Cafe", "Classroom".
+     */
+    @Column(name = "name_en")
+    private String nameEn;
+
+    /**
+     * 아이콘 식별자 (선택).
+     * <p>프론트엔드가 이 값을 보고 적절한 아이콘 표시.
+     * <p>예시: "icon_restroom", "icon_cafe".
+     */
+    @Column(name = "icon_key")
+    private String iconKey;
+
+    /**
+     * 시스템 기본 카테고리 여부.
+     *
+     * <p>true: 시스템이 기본 제공하는 카테고리 (시드 데이터)
+     * <br>false: 사용자(테넌트 관리자)가 추가한 커스텀 카테고리
+     *
+     * <p>true인 카테고리는 삭제·수정 제한.
+     */
+    @Column(name = "is_system", nullable = false)
+    private boolean isSystem;
+
+    @Builder
+    public PoiCategory(String code, String path, String nameKo, String nameEn,
+                       String iconKey, boolean isSystem) {
+        this.code = code;
+        this.path = path;
+        this.nameKo = nameKo;
+        this.nameEn = nameEn;
+        this.iconKey = iconKey;
+        this.isSystem = isSystem;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnector.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnector.java
@@ -1,0 +1,97 @@
+package com.insideout.backend.domain.map.entity;
+
+import com.insideout.backend.domain.building.entity.Building;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 건물 내에서 층간 이동을 가능하게 해주는 수직 연결통로(수직 기둥) 엔티티.
+ *
+ * <p>엘리베이터, 계단, 에스컬레이터 등을 의미합니다.
+ * 예를 들어 "1호기 엘리베이터"는 하나의 VerticalConnector이며,
+ * 이것이 1층 노드, 2층 노드, 3층 노드를 관통하며 이어줍니다. (요구사항 21번 층 전환 핵심)
+ */
+@Entity
+@Table(name = "vertical_connector")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VerticalConnector {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "map_version_id", nullable = false)
+    private MapVersion mapVersion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id", nullable = false)
+    private Building building;
+
+    /**
+     * 연결통로 종류. (elevator, stair, escalator, ramp)
+     */
+    @Column(nullable = false)
+    private String kind;
+
+    /**
+     * 명칭 (예: "중앙 엘리베이터 A호기", "비상계단 1").
+     */
+    private String name;
+
+    /**
+     * 수용 인원 (엘리베이터의 경우 라우팅 대기 시간 계산에 활용 가능).
+     */
+    private Integer capacity;
+
+    /**
+     * 평균 대기 시간(초). 길찾기 소요 시간에 합산됩니다.
+     */
+    @Column(name = "avg_wait_seconds")
+    private Integer avgWaitSeconds;
+
+    /**
+     * 운행 방향. ('up', 'down', 'both')
+     * <p>에스컬레이터의 경우 올라가는 것만 있을 수 있습니다.
+     */
+    private String direction;
+
+    /**
+     * 휠체어 접근 가능 여부 등 부가 속성.
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> accessibility;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.accessibility == null) {
+            this.accessibility = Map.of();
+        }
+    }
+
+    @Builder
+    public VerticalConnector(UUID tenantId, MapVersion mapVersion, Building building, String kind, String name, Integer capacity, Integer avgWaitSeconds, String direction, Map<String, Object> accessibility) {
+        this.tenantId = tenantId;
+        this.mapVersion = mapVersion;
+        this.building = building;
+        this.kind = kind;
+        this.name = name;
+        this.capacity = capacity;
+        this.avgWaitSeconds = avgWaitSeconds;
+        this.direction = direction;
+        this.accessibility = accessibility != null ? accessibility : Map.of();
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNode.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNode.java
@@ -44,6 +44,21 @@ public class VerticalConnectorNode {
     @JoinColumn(name = "floor_id", nullable = false)
     private Floor floor;
 
+    // TODO: VerticalConnectorNode 생성 시 아래 3가지 불변식을 Service에서 반드시 검증해야 합니다.
+    //       LAZY 로딩 특성상 이 생성자 안에서 연관 엔티티를 호출하면 LazyInitializationException이 발생합니다.
+    //       Service에서 connector, node, floor를 완전히 로딩한 후 검증하세요:
+    //
+    //       1. floor가 node의 floor와 일치하는지:
+    //          if (!node.getFloor().getId().equals(floor.getId()))
+    //              throw new MapException(MapErrorCode.VERTICAL_CONNECTOR_FLOOR_MISMATCH);
+    //
+    //       2. tenantId가 connector의 tenantId와 일치하는지:
+    //          if (!tenantId.equals(connector.getTenantId()))
+    //              throw new MapException(MapErrorCode.VERTICAL_CONNECTOR_TENANT_MISMATCH);
+    //
+    //       3. tenantId가 node의 tenantId와 일치하는지:
+    //          if (!tenantId.equals(node.getTenantId()))
+    //              throw new MapException(MapErrorCode.VERTICAL_CONNECTOR_TENANT_MISMATCH);
     @Builder
     public VerticalConnectorNode(UUID tenantId, VerticalConnector connector, Node node, Floor floor) {
         this.tenantId = tenantId;

--- a/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNode.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNode.java
@@ -1,0 +1,54 @@
+package com.insideout.backend.domain.map.entity;
+
+import com.insideout.backend.domain.building.entity.Floor;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * 엘리베이터/계단 통로(VerticalConnector)와 
+ * 각 층의 출입구 노드(Node)를 연결해주는 매핑 테이블.
+ *
+ * <p>예를 들어 1호기 엘리베이터가 1층, 2층, 3층에서 멈춘다면
+ * 이 테이블에 1층 노드, 2층 노드, 3층 노드가 각각 맵핑되어 기록됩니다.
+ * 라우팅 엔진은 이 테이블을 보고 "아, 이 노드에서 엘리베이터를 타면 다른 층 노드로 갈 수 있구나"를 알게 됩니다.
+ */
+@Entity
+@Table(name = "vertical_connector_node")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(VerticalConnectorNodeId.class)
+public class VerticalConnectorNode {
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "connector_id", nullable = false)
+    private VerticalConnector connector;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "node_id", nullable = false)
+    private Node node;
+
+    /**
+     * 해당 노드가 속한 층.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_id", nullable = false)
+    private Floor floor;
+
+    @Builder
+    public VerticalConnectorNode(UUID tenantId, VerticalConnector connector, Node node, Floor floor) {
+        this.tenantId = tenantId;
+        this.connector = connector;
+        this.node = node;
+        this.floor = floor;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNodeId.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNodeId.java
@@ -1,5 +1,6 @@
 package com.insideout.backend.domain.map.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +11,7 @@ import java.util.UUID;
  * VerticalConnectorNode 복합키 클래스.
  */
 @NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode
 public class VerticalConnectorNodeId implements Serializable {
     private UUID connector;

--- a/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNodeId.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNodeId.java
@@ -1,0 +1,17 @@
+package com.insideout.backend.domain.map.entity;
+
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * VerticalConnectorNode 복합키 클래스.
+ */
+@NoArgsConstructor
+@EqualsAndHashCode
+public class VerticalConnectorNodeId implements Serializable {
+    private UUID connector;
+    private UUID node;
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/Zone.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Zone.java
@@ -1,0 +1,94 @@
+package com.insideout.backend.domain.map.entity;
+
+import com.insideout.backend.domain.building.entity.Floor;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.locationtech.jts.geom.Polygon;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 도면 상의 특정 영역(Zone)을 나타내는 엔티티.
+ *
+ * <p>단순 점(Point)이 아닌 면(Polygon) 데이터이며,
+ * '복도', '일반 방', '접근 금지 구역' 등을 색칠하거나 
+ * 영역별 길찾기 회피 구역 등을 설정할 때 사용합니다.
+ */
+@Entity
+@Table(name = "zone")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Zone {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "map_version_id", nullable = false)
+    private MapVersion mapVersion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_id", nullable = false)
+    private Floor floor;
+
+    /**
+     * 영역의 종류 (corridor, room, restricted 등).
+     */
+    @Column(nullable = false)
+    private String kind;
+
+    /**
+     * 영역의 명칭 (옵션).
+     * <p>예: "A동 1층 로비 영역", "통제구역 1"
+     */
+    private String name;
+
+    /**
+     * 도면 상의 다각형 영역 (Pixel 단위).
+     * <p>렌더링 엔진(프론트엔드)에서 지도에 색상 오버레이를 그릴 때 사용됩니다.
+     */
+    @Column(name = "geom_px", columnDefinition = "geometry(Polygon, 0)", nullable = false)
+    private Polygon geomPx;
+
+    /**
+     * 영역에 대한 추가 속성 데이터 (디스플레이 컬러 등).
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> properties;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now();
+        }
+        if (this.properties == null) {
+            this.properties = Map.of();
+        }
+    }
+
+    @Builder
+    public Zone(UUID tenantId, MapVersion mapVersion, Floor floor, String kind, String name, Polygon geomPx, Map<String, Object> properties) {
+        this.tenantId = tenantId;
+        this.mapVersion = mapVersion;
+        this.floor = floor;
+        this.kind = kind;
+        this.name = name;
+        this.geomPx = geomPx;
+        this.properties = properties != null ? properties : Map.of();
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/entity/Zone.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Zone.java
@@ -43,10 +43,12 @@ public class Zone {
     private Floor floor;
 
     /**
-     * 영역의 종류 (corridor, room, restricted 등).
+     * 영역의 종류.
+     * <p>허용값은 {@link ZoneKind} 참고. DB의 CHECK 제약과 동기화되어 있습니다.
      */
     @Column(nullable = false)
-    private String kind;
+    @Enumerated(EnumType.STRING)
+    private ZoneKind kind;
 
     /**
      * 영역의 명칭 (옵션).
@@ -81,8 +83,20 @@ public class Zone {
         }
     }
 
+    // TODO: Zone 생성 시 아래 불변식을 Service에서 반드시 검증해야 합니다.
+    //       mapVersion.getTenantId() 및 floor.getTenantId()는 LAZY 로딩 연관 엔티티 호출이므로
+    //       @PrePersist/@PreUpdate 또는 생성자 안에서 호출 시 LazyInitializationException이 발생합니다.
+    //       Service에서 mapVersion, floor를 완전히 로딩한 후 검증하세요:
+    //
+    //       1. tenantId가 mapVersion의 tenantId와 일치하는지:
+    //          if (!tenantId.equals(mapVersion.getTenantId()))
+    //              throw new MapException(MapErrorCode.ZONE_TENANT_MISMATCH);
+    //
+    //       2. tenantId가 floor의 tenantId와 일치하는지:
+    //          if (!tenantId.equals(floor.getTenantId()))
+    //              throw new MapException(MapErrorCode.ZONE_TENANT_MISMATCH);
     @Builder
-    public Zone(UUID tenantId, MapVersion mapVersion, Floor floor, String kind, String name, Polygon geomPx, Map<String, Object> properties) {
+    public Zone(UUID tenantId, MapVersion mapVersion, Floor floor, ZoneKind kind, String name, Polygon geomPx, Map<String, Object> properties) {
         this.tenantId = tenantId;
         this.mapVersion = mapVersion;
         this.floor = floor;

--- a/src/main/java/com/insideout/backend/domain/map/entity/Zone.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Zone.java
@@ -12,6 +12,7 @@ import org.locationtech.jts.geom.Polygon;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -97,12 +98,12 @@ public class Zone {
     //              throw new MapException(MapErrorCode.ZONE_TENANT_MISMATCH);
     @Builder
     public Zone(UUID tenantId, MapVersion mapVersion, Floor floor, ZoneKind kind, String name, Polygon geomPx, Map<String, Object> properties) {
-        this.tenantId = tenantId;
-        this.mapVersion = mapVersion;
-        this.floor = floor;
-        this.kind = kind;
+        this.tenantId = Objects.requireNonNull(tenantId, "tenantId must not be null");
+        this.mapVersion = Objects.requireNonNull(mapVersion, "mapVersion must not be null");
+        this.floor = Objects.requireNonNull(floor, "floor must not be null");
+        this.kind = Objects.requireNonNull(kind, "kind must not be null");
         this.name = name;
-        this.geomPx = geomPx;
+        this.geomPx = Objects.requireNonNull(geomPx, "geomPx must not be null");
         this.properties = properties != null ? properties : Map.of();
     }
 }

--- a/src/main/java/com/insideout/backend/domain/map/entity/ZoneKind.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/ZoneKind.java
@@ -1,0 +1,23 @@
+package com.insideout.backend.domain.map.entity;
+
+/**
+ * Zone(구역)의 종류를 정의하는 열거형.
+ *
+ * <p>DB의 zone.kind CHECK 제약과 동기화되어 있습니다.
+ * 새로운 종류를 추가할 경우 반드시 DB 마이그레이션 스크립트도 함께 수정해야 합니다.
+ *
+ * <pre>
+ *   corridor         - 복도, 보행 통로
+ *   room             - 일반 방, 강의실 등
+ *   restricted       - 출입 통제 구역
+ *   public_space     - 로비, 광장 등 공공 영역
+ *   outdoor_boundary - 실외 경계 구역
+ * </pre>
+ */
+public enum ZoneKind {
+    corridor,
+    room,
+    restricted,
+    public_space,
+    outdoor_boundary;
+}

--- a/src/main/java/com/insideout/backend/domain/map/exception/MapErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/map/exception/MapErrorCode.java
@@ -48,6 +48,16 @@ public enum MapErrorCode implements BaseErrorCode {
         HttpStatus.BAD_REQUEST,
         "MAP400_8",
         "Zone의 tenantId가 mapVersion 또는 floor의 tenantId와 일치하지 않습니다."
+    ),
+    OBSTACLE_TENANT_MISMATCH(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_9",
+        "장애물의 tenantId가 floor 또는 building의 tenant와 일치하지 않습니다."
+    ),
+    OBSTACLE_BUILDING_MISMATCH(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_10",
+        "장애물의 floor가 해당 building에 속하지 않습니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/com/insideout/backend/domain/map/exception/MapErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/map/exception/MapErrorCode.java
@@ -1,0 +1,56 @@
+package com.insideout.backend.domain.map.exception;
+
+import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MapErrorCode implements BaseErrorCode {
+
+    NEGATIVE_LENGTH(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_1",
+        "엣지의 물리적 거리(lengthM)는 0 이상이어야 합니다."
+    ),
+    INVALID_BASE_WEIGHT(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_2",
+        "엣지의 가중치(baseWeight)는 0보다 커야 합니다."
+    ),
+    BUILDING_MISMATCH(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_3",
+        "노드의 MapVersion과 Floor가 서로 다른 건물(Building)을 참조하고 있습니다."
+    ),
+    NEGATIVE_EXTRA_COST(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_4",
+        "장애물의 추가 비용(extraCost)은 0 이상이어야 합니다."
+    ),
+    INVALID_ACTIVE_PERIOD(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_5",
+        "장애물의 시작 시간(activeFrom)은 종료 시간(activeTo)보다 이후일 수 없습니다."
+    ),
+    VERTICAL_CONNECTOR_FLOOR_MISMATCH(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_6",
+        "VerticalConnectorNode의 floor와 node의 floor가 일치하지 않습니다."
+    ),
+    VERTICAL_CONNECTOR_TENANT_MISMATCH(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_7",
+        "VerticalConnectorNode의 tenantId가 connector 또는 node의 tenantId와 일치하지 않습니다."
+    ),
+    ZONE_TENANT_MISMATCH(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_8",
+        "Zone의 tenantId가 mapVersion 또는 floor의 tenantId와 일치하지 않습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/insideout/backend/domain/map/exception/MapException.java
+++ b/src/main/java/com/insideout/backend/domain/map/exception/MapException.java
@@ -1,0 +1,9 @@
+package com.insideout.backend.domain.map.exception;
+
+import com.insideout.backend.global.apiPayload.exception.ProjectException;
+
+public class MapException extends ProjectException {
+    public MapException(MapErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -1,0 +1,29 @@
+package com.insideout.backend.domain.map.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 타 도메인(예: Navigation)에서 Map 도메인의 데이터를 안전하게 조회하기 위한 읽기 전용 서비스.
+ *
+ * <p>Repository를 직접 타 도메인에 노출하지 않고,
+ * 이 서비스를 통해서 필요한 노드, 엣지, POI 등의 데이터를 제공합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MapQueryFacade {
+
+    // 내부적으로 자기 도메인의 Repository는 자유롭게 주입받아 사용합니다.
+    // private final NodeRepository nodeRepository;
+    // private final EdgeRepository edgeRepository;
+    // private final ObstacleRepository obstacleRepository;
+
+    /*
+    // 예시: Navigation 팀원이 호출할 메서드 껍데기
+    public List<Node> getNodesForRouting(UUID mapVersionId) {
+        return nodeRepository.findByMapVersionId(mapVersionId);
+    }
+    */
+}

--- a/src/main/java/com/insideout/backend/domain/map/repository/EdgeRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/EdgeRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.map.repository;
+
+import com.insideout.backend.domain.map.entity.Edge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface EdgeRepository extends JpaRepository<Edge, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.map.repository;
+
+import com.insideout.backend.domain.map.entity.MapVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface MapVersionRepository extends JpaRepository<MapVersion, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.map.repository;
+
+import com.insideout.backend.domain.map.entity.Node;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface NodeRepository extends JpaRepository<Node, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/map/repository/ObstacleRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/ObstacleRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.map.repository;
+
+import com.insideout.backend.domain.map.entity.Obstacle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ObstacleRepository extends JpaRepository<Obstacle, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/map/repository/PoiRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/PoiRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.map.repository;
+
+import com.insideout.backend.domain.map.entity.Poi;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface PoiRepository extends JpaRepository<Poi, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/map/repository/VerticalConnectorNodeRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/VerticalConnectorNodeRepository.java
@@ -1,0 +1,10 @@
+package com.insideout.backend.domain.map.repository;
+
+import com.insideout.backend.domain.map.entity.VerticalConnectorNode;
+import com.insideout.backend.domain.map.entity.VerticalConnectorNodeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VerticalConnectorNodeRepository extends JpaRepository<VerticalConnectorNode, VerticalConnectorNodeId> {
+}

--- a/src/main/java/com/insideout/backend/domain/map/repository/VerticalConnectorRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/VerticalConnectorRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.map.repository;
+
+import com.insideout.backend.domain.map.entity.VerticalConnector;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface VerticalConnectorRepository extends JpaRepository<VerticalConnector, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/map/repository/ZoneRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/ZoneRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.map.repository;
+
+import com.insideout.backend.domain.map.entity.Zone;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ZoneRepository extends JpaRepository<Zone, UUID> {
+}

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -1,0 +1,24 @@
+package com.insideout.backend.domain.navigation.service;
+
+import com.insideout.backend.domain.map.facade.MapQueryFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 실내외 길찾기(Navigation) 기능을 담당하는 핵심 서비스.
+ * 
+ * <p>Repository를 직접 참조하지 않고, MapQueryService 등 
+ * 다른 도메인의 Service를 주입받아 필요한 데이터를 가져옵니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NavigationService {
+
+    // 타 도메인의 Repository를 직접 쓰지 않고 Service를 주입받아 사용합니다.
+    private final MapQueryFacade mapQueryFacade;
+
+    // TODO: A* 알고리즘 등 경로 탐색 로직 작성
+    
+}

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 실내외 길찾기(Navigation) 기능을 담당하는 핵심 서비스.
  * 
- * <p>Repository를 직접 참조하지 않고, MapQueryService 등 
+ * <p>Repository를 직접 참조하지 않고, MapQueryFacade 등
  * 다른 도메인의 Service를 주입받아 필요한 데이터를 가져옵니다.
  */
 @Service

--- a/src/main/java/com/insideout/backend/domain/tenant/entity/Tenant.java
+++ b/src/main/java/com/insideout/backend/domain/tenant/entity/Tenant.java
@@ -1,0 +1,47 @@
+package com.insideout.backend.domain.tenant.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tenant")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tenant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String slug;
+
+    @Column(name = "display_name", nullable = false)
+    private String displayName;
+
+    @Column(nullable = false)
+    private String status;        // pending / approved / suspended
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) createdAt = OffsetDateTime.now();
+        if (status == null) status = "pending";
+    }
+
+    @Builder
+    public Tenant(String slug, String displayName, String status) {
+        this.slug = slug;
+        this.displayName = displayName;
+        this.status = status != null ? status : "pending";
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/tenant/entity/TenantMembership.java
+++ b/src/main/java/com/insideout/backend/domain/tenant/entity/TenantMembership.java
@@ -1,0 +1,79 @@
+package com.insideout.backend.domain.tenant.entity;
+
+import com.insideout.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 테넌트(건물/단지 그룹)와 사용자(건물 관리자)를 연결하는 다대다(N:M) 매핑 테이블.
+ *
+ * <p>현재 기획상 "1명의 관리자가 본인의 건물을 관리"하므로 
+ * 복잡한 권한(role)보다는 "이 건물이 누구 소유인가?"를 식별하는 용도로 사용됩니다.
+ */
+@Entity
+@Table(name = "tenant_membership")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(TenantMembershipId.class)
+public class TenantMembership {
+
+    /**
+     * 매핑되는 테넌트 (건물 또는 단지).
+     * <p>복합키의 일부분으로 동작합니다.
+     */
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tenant_id", nullable = false)
+    private Tenant tenant;
+
+    /**
+     * 매핑되는 사용자 (건물 관리자).
+     * <p>복합키의 일부분으로 동작합니다.
+     */
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /**
+     * 테넌트 내에서의 사용자 역할.
+     *
+     * <p>현재 요구사항에서는 권한 분리가 불필요하므로 무조건 "owner"로 고정하여 사용합니다.
+     * (추후 공동 관리 기능 추가 시 활용될 수 있도록 필드만 유지합니다)
+     */
+    @Column(name = "role", nullable = false)
+    private String role;
+
+    /**
+     * 건물을 등록하고 관리 권한을 얻은 시각.
+     */
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private OffsetDateTime joinedAt;
+
+    /**
+     * 엔티티가 DB에 저장되기 전에 자동으로 실행되는 콜백.
+     * <p>가입 시간을 기록하고, 역할(role)을 기본값인 "owner"로 세팅합니다.
+     */
+    @PrePersist
+    void onPrePersist() {
+        if (this.joinedAt == null) {
+            this.joinedAt = OffsetDateTime.now();
+        }
+        if (this.role == null || this.role.isBlank()) {
+            this.role = "owner";
+        }
+    }
+
+    @Builder
+    public TenantMembership(Tenant tenant, User user, String role) {
+        this.tenant = tenant;
+        this.user = user;
+        // 빌더로 넘겼을 때도 비어있으면 owner로 고정
+        this.role = (role != null && !role.isBlank()) ? role : "owner";
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/tenant/entity/TenantMembershipId.java
+++ b/src/main/java/com/insideout/backend/domain/tenant/entity/TenantMembershipId.java
@@ -1,0 +1,19 @@
+package com.insideout.backend.domain.tenant.entity;
+
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * TenantMembership 엔티티의 복합키(Composite Key) 클래스.
+ *
+ * <p>tenant_id와 user_id를 묶어서 식별자로 사용합니다.
+ */
+@NoArgsConstructor
+@EqualsAndHashCode
+public class TenantMembershipId implements Serializable {
+    private UUID tenant;
+    private UUID user;
+}

--- a/src/main/java/com/insideout/backend/domain/tenant/repository/TenantMembershipRepository.java
+++ b/src/main/java/com/insideout/backend/domain/tenant/repository/TenantMembershipRepository.java
@@ -1,0 +1,10 @@
+package com.insideout.backend.domain.tenant.repository;
+
+import com.insideout.backend.domain.tenant.entity.TenantMembership;
+import com.insideout.backend.domain.tenant.entity.TenantMembershipId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TenantMembershipRepository extends JpaRepository<TenantMembership, TenantMembershipId> {
+}

--- a/src/main/java/com/insideout/backend/domain/tenant/repository/TenantRepository.java
+++ b/src/main/java/com/insideout/backend/domain/tenant/repository/TenantRepository.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.tenant.repository;
+
+import com.insideout.backend.domain.tenant.entity.Tenant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface TenantRepository extends JpaRepository<Tenant, UUID> {
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,7 +1,7 @@
 spring:
   config:
     import:
-      - optional:classpath:db.properties
+      - optional:file:.env[.properties]
 
   datasource:
     url: jdbc:postgresql://localhost:${DB_PORT}/${POSTGRES_DB}
@@ -9,6 +9,11 @@ spring:
     password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
+
   jpa:
     hibernate:
-      ddl-auto: update # 공용 DB는 테이블 구조 확정되면  validate
+      ddl-auto: validate # 공용 DB는 테이블 구조 확정되면  validate

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: dev
 
   application:
     name: backend

--- a/src/main/resources/db/migration/V5__create_indoor_nav_schema.sql
+++ b/src/main/resources/db/migration/V5__create_indoor_nav_schema.sql
@@ -1,0 +1,408 @@
+-- =====================================================================
+-- V5: Indoor Navigation Platform - Full Schema (excluding app_user)
+-- 전제: V1~V4에서 app_user 테이블이 이미 생성되어 있음
+-- =====================================================================
+
+-- ============================
+-- Extensions
+-- ============================
+CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE EXTENSION IF NOT EXISTS ltree;
+-- citext, pgcrypto는 V1에서 이미 활성화됨 (IF NOT EXISTS라 다시 호출해도 무방하지만 생략)
+
+
+-- =====================================================================
+-- A. 공용 테이블 (모든 테넌트 공유)
+-- =====================================================================
+
+-- A-1. tenant
+CREATE TABLE tenant (
+                        id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+                        slug          text        UNIQUE NOT NULL,
+                        display_name  text        NOT NULL,
+                        status        text        NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending','approved','suspended')),
+                        created_at    timestamptz NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE  tenant            IS '테넌트(건물 관리자 조직)';
+COMMENT ON COLUMN tenant.slug       IS 'URL/식별용 짧은 이름 (예: hyu-eng)';
+
+-- A-3. tenant_membership (app_user는 V1에서 이미 생성)
+CREATE TABLE tenant_membership (
+                                   tenant_id  uuid NOT NULL REFERENCES tenant(id)   ON DELETE CASCADE,
+                                   user_id    uuid NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+                                   role       text NOT NULL CHECK (role IN ('owner','editor','viewer')),
+                                   joined_at  timestamptz NOT NULL DEFAULT now(),
+                                   PRIMARY KEY (tenant_id, user_id)
+);
+
+-- A-5. poi_category (ltree 트리)
+CREATE TABLE poi_category (
+                              id        bigserial PRIMARY KEY,
+                              code      text      UNIQUE NOT NULL,
+                              path      ltree     UNIQUE NOT NULL,
+                              name_ko   text      NOT NULL,
+                              name_en   text,
+                              icon_key  text,
+                              is_system boolean   NOT NULL DEFAULT true
+);
+CREATE INDEX poi_category_path_gist ON poi_category USING GIST (path);
+
+-- A-6. node_kind
+CREATE TABLE node_kind (
+                           code             text    PRIMARY KEY,
+                           name_ko          text    NOT NULL,
+                           is_vertical      boolean NOT NULL DEFAULT false,
+                           needs_connector  boolean NOT NULL DEFAULT false
+);
+
+-- A-7. edge_kind
+CREATE TABLE edge_kind (
+                           code                     text    PRIMARY KEY,
+                           name_ko                  text    NOT NULL,
+                           is_directed              boolean NOT NULL DEFAULT false,
+                           default_cost_multiplier  numeric NOT NULL DEFAULT 1.0
+);
+
+
+-- =====================================================================
+-- B. 건물·층·도면 (테넌트 소유)
+-- =====================================================================
+
+-- B-1. building
+CREATE TABLE building (
+                          id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+                          tenant_id       uuid        NOT NULL REFERENCES tenant(id) ON DELETE CASCADE,
+                          name            text        NOT NULL,
+                          address         text,
+                          footprint       geography(Polygon, 4326),
+                          entrance_count  int         NOT NULL DEFAULT 0,
+                          meta            jsonb       NOT NULL DEFAULT '{}'::jsonb,
+                          external_api_id text,
+                          created_at      timestamptz NOT NULL DEFAULT now(),
+                          UNIQUE (tenant_id, id)
+);
+CREATE INDEX building_tenant_idx    ON building (tenant_id);
+CREATE INDEX building_footprint_gix ON building USING GIST (footprint);
+
+-- A-4. building_directory (전역 검색용)
+CREATE TABLE building_directory (
+                                    id                    uuid PRIMARY KEY,    -- building.id 와 동일값 사용
+                                    tenant_id             uuid NOT NULL REFERENCES tenant(id),
+                                    name                  text NOT NULL,
+                                    address               text,
+                                    category              text,
+                                    centroid              geography(Point, 4326),
+                                    bbox                  geography(Polygon, 4326),
+                                    is_public             boolean NOT NULL DEFAULT false,
+                                    published_version_id  uuid,                -- map_version 만든 후 FK 추가
+                                    updated_at            timestamptz NOT NULL DEFAULT now(),
+                                    FOREIGN KEY (tenant_id, id) REFERENCES building(tenant_id, id) ON DELETE CASCADE
+);
+CREATE INDEX building_dir_centroid_gix ON building_directory USING GIST (centroid);
+
+-- B-2. floor
+CREATE TABLE floor (
+                       id           uuid    PRIMARY KEY DEFAULT gen_random_uuid(),
+                       tenant_id    uuid    NOT NULL,
+                       building_id  uuid    NOT NULL,
+                       level        int     NOT NULL,
+                       name         text    NOT NULL,
+                       elevation_m  numeric,
+                       UNIQUE (tenant_id, building_id, level),
+                       UNIQUE (tenant_id, id),
+                       FOREIGN KEY (tenant_id, building_id) REFERENCES building(tenant_id, id) ON DELETE CASCADE
+);
+CREATE INDEX floor_tenant_building_idx ON floor (tenant_id, building_id);
+
+-- B-3. floorplan
+CREATE TABLE floorplan (
+                           id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+                           tenant_id     uuid        NOT NULL,
+                           floor_id      uuid        NOT NULL,
+                           image_url     text        NOT NULL,
+                           image_sha256  text,
+                           width_px      int         NOT NULL,
+                           height_px     int         NOT NULL,
+                           uploaded_by   uuid REFERENCES app_user(id),
+                           is_current    boolean     NOT NULL DEFAULT false,
+                           uploaded_at   timestamptz NOT NULL DEFAULT now(),
+                           UNIQUE (tenant_id, id),
+                           FOREIGN KEY (tenant_id, floor_id) REFERENCES floor(tenant_id, id) ON DELETE CASCADE
+);
+CREATE INDEX floorplan_floor_idx ON floorplan (tenant_id, floor_id);
+
+-- B-4. floorplan_calibration
+CREATE TABLE floorplan_calibration (
+                                       id             uuid              PRIMARY KEY DEFAULT gen_random_uuid(),
+                                       tenant_id      uuid              NOT NULL,
+                                       floorplan_id   uuid              NOT NULL,
+                                       gcp            jsonb             NOT NULL,
+                                       affine         double precision[],
+                                       rotation_deg   numeric,
+                                       rmse_m         numeric,
+                                       created_at     timestamptz       NOT NULL DEFAULT now(),
+                                       FOREIGN KEY (tenant_id, floorplan_id) REFERENCES floorplan(tenant_id, id) ON DELETE CASCADE
+);
+
+
+-- =====================================================================
+-- C. 지도 버전 관리
+-- =====================================================================
+
+CREATE TABLE map_version (
+                             id                 uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+                             tenant_id          uuid        NOT NULL,
+                             building_id        uuid        NOT NULL,
+                             label              text        NOT NULL,
+                             status             text        NOT NULL DEFAULT 'draft'
+                                 CHECK (status IN ('draft','published','archived')),
+                             parent_version_id  uuid        REFERENCES map_version(id),
+                             created_by         uuid        REFERENCES app_user(id),
+                             created_at         timestamptz NOT NULL DEFAULT now(),
+                             published_at       timestamptz,
+                             UNIQUE (tenant_id, id),
+                             FOREIGN KEY (tenant_id, building_id) REFERENCES building(tenant_id, id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX one_published_per_building
+    ON map_version (tenant_id, building_id) WHERE status = 'published';
+
+-- building_directory.published_version_id FK는 map_version 만든 뒤에 추가
+ALTER TABLE building_directory
+    ADD CONSTRAINT fk_dir_published_version
+        FOREIGN KEY (published_version_id) REFERENCES map_version(id) ON DELETE SET NULL;
+
+
+-- =====================================================================
+-- D. AI 원시 데이터
+-- =====================================================================
+
+CREATE TABLE ai_job (
+                        id             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+                        tenant_id      uuid        NOT NULL,
+                        floorplan_id   uuid        NOT NULL,
+                        status         text        NOT NULL DEFAULT 'queued'
+                            CHECK (status IN ('queued','running','succeeded','failed')),
+                        model_version  text,
+                        params         jsonb,
+                        started_at     timestamptz,
+                        finished_at    timestamptz,
+                        error          text,
+                        FOREIGN KEY (tenant_id, floorplan_id) REFERENCES floorplan(tenant_id, id) ON DELETE CASCADE
+);
+
+CREATE TABLE ai_detection (
+                              id                     uuid     PRIMARY KEY DEFAULT gen_random_uuid(),
+                              tenant_id              uuid     NOT NULL,
+                              job_id                 uuid     NOT NULL REFERENCES ai_job(id) ON DELETE CASCADE,
+                              floorplan_id           uuid     NOT NULL,
+                              detect_type            text     NOT NULL CHECK (detect_type IN
+                                                                              ('wall','door','corridor','room','elevator','stair','escalator',
+                                                                               'restroom_sign','text','poi_candidate','node_candidate','edge_candidate')),
+                              label                  text,
+                              confidence             numeric  CHECK (confidence BETWEEN 0 AND 1),
+                              geom_px                geometry(Geometry, 0) NOT NULL,
+                              bbox_px                box2d,
+                              ocr_text               text,
+                              attrs                  jsonb,
+                              status                 text     NOT NULL DEFAULT 'pending'
+                                  CHECK (status IN ('pending','accepted','rejected','merged')),
+                              committed_entity_type  text     CHECK (committed_entity_type IN ('node','edge','poi','zone')),
+                              committed_entity_id    uuid,
+                              FOREIGN KEY (tenant_id, floorplan_id) REFERENCES floorplan(tenant_id, id) ON DELETE CASCADE
+);
+CREATE INDEX ai_detection_geom_gix ON ai_detection USING GIST (geom_px);
+CREATE INDEX ai_detection_job_idx  ON ai_detection (job_id, status);
+
+
+-- =====================================================================
+-- E. 그래프 엔티티
+-- =====================================================================
+
+-- E-1. node
+CREATE TABLE node (
+                      id              uuid              PRIMARY KEY DEFAULT gen_random_uuid(),
+                      tenant_id       uuid              NOT NULL,
+                      map_version_id  uuid              NOT NULL,
+                      floor_id        uuid              NOT NULL,
+                      kind            text              NOT NULL REFERENCES node_kind(code),
+                      geom_px         geometry(Point, 0) NOT NULL,
+                      geom_wgs84      geography(PointZ, 4326),
+                      name_ko         text,
+                      properties      jsonb             NOT NULL DEFAULT '{}'::jsonb,
+                      source          text              NOT NULL DEFAULT 'manual'
+                          CHECK (source IN ('ai','ai_confirmed','manual')),
+                      ai_detection_id uuid              REFERENCES ai_detection(id) ON DELETE SET NULL,
+                      created_at      timestamptz       NOT NULL DEFAULT now(),
+                      UNIQUE (tenant_id, id),
+                      FOREIGN KEY (tenant_id, map_version_id) REFERENCES map_version(tenant_id, id) ON DELETE CASCADE,
+                      FOREIGN KEY (tenant_id, floor_id)       REFERENCES floor(tenant_id, id)       ON DELETE CASCADE
+);
+CREATE INDEX node_geom_gix    ON node USING GIST (geom_px);
+CREATE INDEX node_wgs84_gix   ON node USING GIST (geom_wgs84);
+CREATE INDEX node_version_idx ON node (tenant_id, map_version_id, floor_id);
+
+-- E-2. edge
+CREATE TABLE edge (
+                      id              uuid                   PRIMARY KEY DEFAULT gen_random_uuid(),
+                      tenant_id       uuid                   NOT NULL,
+                      map_version_id  uuid                   NOT NULL,
+                      from_node_id    uuid                   NOT NULL,
+                      to_node_id      uuid                   NOT NULL,
+                      kind            text                   NOT NULL REFERENCES edge_kind(code),
+                      geom_px         geometry(LineString, 0),
+                      geom_wgs84      geography(LineStringZ, 4326),
+                      length_m        numeric,
+                      is_directed     boolean                NOT NULL DEFAULT false,
+                      base_weight     numeric                NOT NULL DEFAULT 1.0,
+                      properties      jsonb                  NOT NULL DEFAULT '{}'::jsonb,
+                      source          text                   NOT NULL DEFAULT 'manual'
+                          CHECK (source IN ('ai','ai_confirmed','manual')),
+                      ai_detection_id uuid                   REFERENCES ai_detection(id) ON DELETE SET NULL,
+                      created_at      timestamptz            NOT NULL DEFAULT now(),
+                      FOREIGN KEY (tenant_id, map_version_id) REFERENCES map_version(tenant_id, id) ON DELETE CASCADE,
+                      FOREIGN KEY (tenant_id, from_node_id)   REFERENCES node(tenant_id, id),
+                      FOREIGN KEY (tenant_id, to_node_id)     REFERENCES node(tenant_id, id)
+);
+CREATE INDEX edge_geom_gix      ON edge USING GIST (geom_px);
+CREATE INDEX edge_version_idx   ON edge (tenant_id, map_version_id);
+CREATE INDEX edge_from_node_idx ON edge (tenant_id, from_node_id);
+CREATE INDEX edge_to_node_idx   ON edge (tenant_id, to_node_id);
+
+-- E-3. poi
+CREATE TABLE poi (
+                     id               uuid                  PRIMARY KEY DEFAULT gen_random_uuid(),
+                     tenant_id        uuid                  NOT NULL,
+                     map_version_id   uuid                  NOT NULL,
+                     floor_id         uuid                  NOT NULL,
+                     category_id      bigint                REFERENCES poi_category(id),
+                     name             text                  NOT NULL,
+                     code             text,
+                     geom_px          geometry(Point, 0)    NOT NULL,
+                     footprint_px     geometry(Polygon, 0),
+                     geom_wgs84       geography(Point, 4326),
+                     anchor_node_id   uuid,
+                     tags             text[],
+                     attrs            jsonb                 NOT NULL DEFAULT '{}'::jsonb,
+                     external_api_id  text,
+                     source           text                  NOT NULL DEFAULT 'manual'
+                         CHECK (source IN ('ai','ai_confirmed','manual')),
+                     ai_detection_id  uuid                  REFERENCES ai_detection(id) ON DELETE SET NULL,
+                     created_at       timestamptz           NOT NULL DEFAULT now(),
+                     FOREIGN KEY (tenant_id, map_version_id) REFERENCES map_version(tenant_id, id) ON DELETE CASCADE,
+                     FOREIGN KEY (tenant_id, floor_id)       REFERENCES floor(tenant_id, id),
+                     FOREIGN KEY (tenant_id, anchor_node_id) REFERENCES node(tenant_id, id) ON DELETE SET NULL
+);
+CREATE INDEX poi_geom_gix    ON poi USING GIST (geom_px);
+CREATE INDEX poi_version_idx ON poi (tenant_id, map_version_id);
+CREATE INDEX poi_tags_gin    ON poi USING GIN (tags);
+
+-- E-4. zone
+CREATE TABLE zone (
+                      id              uuid                  PRIMARY KEY DEFAULT gen_random_uuid(),
+                      tenant_id       uuid                  NOT NULL,
+                      map_version_id  uuid                  NOT NULL,
+                      floor_id        uuid                  NOT NULL,
+                      kind            text                  NOT NULL CHECK (kind IN
+                                                                            ('corridor','room','restricted','public_space','outdoor_boundary')),
+                      name            text,
+                      geom_px         geometry(Polygon, 0)  NOT NULL,
+                      properties      jsonb                 NOT NULL DEFAULT '{}'::jsonb,
+                      created_at      timestamptz           NOT NULL DEFAULT now(),
+                      FOREIGN KEY (tenant_id, map_version_id) REFERENCES map_version(tenant_id, id) ON DELETE CASCADE,
+                      FOREIGN KEY (tenant_id, floor_id)       REFERENCES floor(tenant_id, id)       ON DELETE CASCADE
+);
+CREATE INDEX zone_geom_gix    ON zone USING GIST (geom_px);
+CREATE INDEX zone_version_idx ON zone (tenant_id, map_version_id);
+
+
+-- =====================================================================
+-- F. 층간 이동 / 동적 장애물
+-- =====================================================================
+
+-- F-1. vertical_connector
+CREATE TABLE vertical_connector (
+                                    id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+                                    tenant_id         uuid        NOT NULL,
+                                    map_version_id    uuid        NOT NULL,
+                                    building_id       uuid        NOT NULL,
+                                    kind              text        NOT NULL CHECK (kind IN ('elevator','stair','escalator','ramp')),
+                                    name              text,
+                                    capacity          int,
+                                    avg_wait_seconds  int,
+                                    direction         text        CHECK (direction IN ('up','down','both')),
+                                    accessibility     jsonb       NOT NULL DEFAULT '{}'::jsonb,
+                                    UNIQUE (tenant_id, id),
+                                    FOREIGN KEY (tenant_id, map_version_id) REFERENCES map_version(tenant_id, id) ON DELETE CASCADE,
+                                    FOREIGN KEY (tenant_id, building_id)    REFERENCES building(tenant_id, id)    ON DELETE CASCADE
+);
+
+-- F-2. vertical_connector_node
+CREATE TABLE vertical_connector_node (
+                                         tenant_id     uuid NOT NULL,
+                                         connector_id  uuid NOT NULL,
+                                         node_id       uuid NOT NULL,
+                                         floor_id      uuid NOT NULL,
+                                         PRIMARY KEY (connector_id, node_id),
+                                         FOREIGN KEY (tenant_id, connector_id) REFERENCES vertical_connector(tenant_id, id) ON DELETE CASCADE,
+                                         FOREIGN KEY (tenant_id, node_id)      REFERENCES node(tenant_id, id)               ON DELETE CASCADE,
+                                         FOREIGN KEY (tenant_id, floor_id)     REFERENCES floor(tenant_id, id)              ON DELETE CASCADE
+);
+
+-- F-3. obstacle
+CREATE TABLE obstacle (
+                          id                 uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+                          tenant_id          uuid        NOT NULL,
+                          building_id        uuid        NOT NULL,
+                          floor_id           uuid,
+                          kind               text        NOT NULL CHECK (kind IN ('construction','closed','slippery','event')),
+                          geom_px            geometry,
+                          affected_edge_ids  uuid[],
+                          extra_cost         numeric     NOT NULL DEFAULT 0,
+                          is_blocking        boolean     NOT NULL DEFAULT false,
+                          active_from        timestamptz,
+                          active_to          timestamptz,
+                          note               text,
+                          created_at         timestamptz NOT NULL DEFAULT now(),
+                          FOREIGN KEY (tenant_id, building_id) REFERENCES building(tenant_id, id) ON DELETE CASCADE,
+                          FOREIGN KEY (tenant_id, floor_id)    REFERENCES floor(tenant_id, id)    ON DELETE CASCADE
+);
+CREATE INDEX obstacle_active_idx ON obstacle (active_from, active_to) WHERE is_blocking = true;
+
+
+-- =====================================================================
+-- 시드 데이터 (마스터 테이블)
+-- =====================================================================
+
+INSERT INTO node_kind (code, name_ko, is_vertical, needs_connector) VALUES
+                                                                        ('corridor',   '복도 교차점',     false, false),
+                                                                        ('door',       '문',             false, false),
+                                                                        ('entrance',   '건물 출입구',     false, false),
+                                                                        ('stair',      '계단',           true,  true),
+                                                                        ('elevator',   '엘리베이터',      true,  true),
+                                                                        ('escalator',  '에스컬레이터',    true,  true),
+                                                                        ('poi_anchor', 'POI 앵커',       false, false),
+                                                                        ('portal',     '포탈(가상노드)',  true,  false);
+
+INSERT INTO edge_kind (code, name_ko, is_directed, default_cost_multiplier) VALUES
+                                                                                ('walkway',   '일반 보행',      false, 1.0),
+                                                                                ('stair',     '계단 이동',      false, 3.0),
+                                                                                ('elevator',  '엘리베이터 이동', false, 5.0),
+                                                                                ('escalator', '에스컬레이터',   true,  2.0),
+                                                                                ('door',      '문 통과',        false, 1.2),
+                                                                                ('outdoor',   '실외 보행',      false, 1.0);
+
+INSERT INTO poi_category (code, path, name_ko) VALUES
+                                                   ('facility',           'facility',           '시설'),
+                                                   ('facility.restroom',  'facility.restroom',  '화장실'),
+                                                   ('facility.elevator',  'facility.elevator',  '엘리베이터'),
+                                                   ('facility.stair',     'facility.stair',     '계단'),
+                                                   ('facility.parking',   'facility.parking',   '주차장'),
+                                                   ('store',              'store',              '상점'),
+                                                   ('store.cafe',         'store.cafe',         '카페'),
+                                                   ('store.food',         'store.food',         '음식점'),
+                                                   ('store.retail',       'store.retail',       '판매점'),
+                                                   ('academic',           'academic',           '학술'),
+                                                   ('academic.classroom', 'academic.classroom', '강의실'),
+                                                   ('academic.lab',       'academic.lab',       '실험실'),
+                                                   ('academic.office',    'academic.office',    '사무실');

--- a/src/main/resources/db/migration/V6__fix_fk_on_delete_cascade.sql
+++ b/src/main/resources/db/migration/V6__fix_fk_on_delete_cascade.sql
@@ -1,0 +1,21 @@
+-- V6: Edge → Node FK에 ON DELETE CASCADE 추가
+--     POI → Floor FK에 ON DELETE CASCADE 추가 (map_version_id와 동작 일관성 맞춤)
+
+-- 1. edge 테이블: from_node_id, to_node_id FK 재설정
+ALTER TABLE edge
+    DROP CONSTRAINT IF EXISTS edge_tenant_id_from_node_id_fkey,
+    DROP CONSTRAINT IF EXISTS edge_tenant_id_to_node_id_fkey;
+
+ALTER TABLE edge
+    ADD CONSTRAINT edge_tenant_id_from_node_id_fkey
+        FOREIGN KEY (tenant_id, from_node_id) REFERENCES node(tenant_id, id) ON DELETE CASCADE,
+    ADD CONSTRAINT edge_tenant_id_to_node_id_fkey
+        FOREIGN KEY (tenant_id, to_node_id)   REFERENCES node(tenant_id, id) ON DELETE CASCADE;
+
+-- 2. poi 테이블: floor_id FK 재설정
+ALTER TABLE poi
+    DROP CONSTRAINT IF EXISTS poi_tenant_id_floor_id_fkey;
+
+ALTER TABLE poi
+    ADD CONSTRAINT poi_tenant_id_floor_id_fkey
+        FOREIGN KEY (tenant_id, floor_id) REFERENCES floor(tenant_id, id) ON DELETE CASCADE;


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #17 

## 📝작업 내용

- 데이터 설계 기반 fly-way migration용 sql 작성
- DB 설정을 위한 yml 파일 수정
- 외부 지도 맵핑을 위한 라이브러리 추가 (hibernate-spatial)
- user 엔티티를 제외한 나머지 엔티티 작성
- repository 생성
- 길찾기에서 필요로 하는 서비스 클래스 생성
- navigation에서 사용할 서비스 생성 (예시)

### 스크린샷(선택)
<img width="247" height="578" alt="스크린샷 2026-05-02 오전 2 03 23" src="https://github.com/user-attachments/assets/4ceb9c9c-c206-47e6-b572-fdd0597d125a" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

BaseTimeEntity는 사용하지 않았습니다. 

엔티티의 주석으로 설명을 적어놓았으니 확인해보면 좋을 것 같습니다! 구조가 어려워서 일단 위경도 맵핑 컬럼은 모두 nullable=true로 해두었고 필요시에만 사용하도록 설계했습니다. 설명이 필요하다면 연락주세요!

만약 테이블 구조를 바꿔야한다면 디스코드 또는 카톡으로 알려주시고 flyway로 테이블을 관리하는 방법에 대해 찾아본 후 그 방식에 맞춰 테이블을 수정하면 될 것 같습니다.

`navigation`에서 길찾기 알고리즘을 작성할 때 필요한 데이터를 `domain/map/facade`에서 구현하면 됩니다.
`navigation` 서비스에서 직접 `repository`를 주입받는 것이 아닌 `map/facade`의 `MapQueryFacade`주입 받아 사용하며 이를 통해 데이터를 받습니다. 이는 앱에서 길찾기를 요청할때 필요한 데이터를 `dto/request`에 작성하여 매개변수로 사용하고 반환하여 `navigation` 로직에서 사용할 데이터는 `dto/response`에 작성해 반환값으로 사용합니다. 
필요하다면 `converter`를 사용해도 됩니다.
domain/navigation/service/NavigationService.java의 위치에 TODO로 표시해두었으며 이는 예시 서비스로 그대로 사용하셔도 되고 삭제 후 다시 만들어도 좋습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 건물/층/도면 관리, 실내 지도(노드·경로·POI·구역), 수직 이동시설, 장애물, 테넌트·멤버십 기능 추가
  * AI 기반 도면 분석 작업과 검출 결과 저장(작업 기록·검출 항목·검토 상태 등) 지원

* **기타 개선 사항**
  * 대규모 데이터베이스 마이그레이션 추가/수정(인덱스·제약·초기 데이터 포함)
  * 개발 설정 변경(기본 활성 프로파일을 dev로 전환, 마이그레이션 활성화 및 스키마 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->