### PR TITLE
[refactor] 공통 응답 반환 타입 변경 (#19)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/insideout/backend/domain/user/controller/UserController.java
@@ -5,9 +5,10 @@ import com.insideout.backend.domain.user.dto.request.SignupRequest;
 import com.insideout.backend.domain.user.dto.response.LoginResponse;
 import com.insideout.backend.domain.user.dto.response.SignupResponse;
 import com.insideout.backend.domain.user.service.UserService;
+import com.insideout.backend.global.apiPayload.ApiResponse;
+import com.insideout.backend.global.apiPayload.code.GeneralSuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,15 +19,13 @@ public class UserController {
 	private final UserService userService;
 
 	@PostMapping("/signup")
-	@ResponseStatus(HttpStatus.CREATED)
-	public SignupResponse signup(@Valid @RequestBody SignupRequest request) {
-		return userService.signup(request);
+	public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
+		return ApiResponse.success(GeneralSuccessCode.CREATED, userService.signup(request));
 	}
 
 	@PostMapping("/login")
-	@ResponseStatus(HttpStatus.OK)
-	public LoginResponse login(@Valid @RequestBody LoginRequest request) {
-		return userService.login(request);
+	public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+		return ApiResponse.success(GeneralSuccessCode.OK, userService.login(request));
 	}
 
 }

--- a/src/main/java/com/insideout/backend/domain/user/controller/UserQueryController.java
+++ b/src/main/java/com/insideout/backend/domain/user/controller/UserQueryController.java
@@ -1,6 +1,8 @@
 package com.insideout.backend.domain.user.controller;
 
 import com.insideout.backend.domain.user.dto.response.CurrentUserResponse;
+import com.insideout.backend.global.apiPayload.ApiResponse;
+import com.insideout.backend.global.apiPayload.code.GeneralSuccessCode;
 import com.insideout.backend.global.security.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,11 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserQueryController {
 
 	@GetMapping("/me")
-	public CurrentUserResponse me(@AuthenticationPrincipal CustomUserDetails userDetails) {
-		return new CurrentUserResponse(
-			userDetails.getUserId(),
-			userDetails.getEmail(),
-			userDetails.getGlobalRole()
+	public ApiResponse<CurrentUserResponse> me(@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return ApiResponse.success(GeneralSuccessCode.OK,
+			new CurrentUserResponse(
+				userDetails.getUserId(),
+				userDetails.getEmail(),
+				userDetails.getGlobalRole()
+			)
 		);
 	}
 }

--- a/src/main/java/com/insideout/backend/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/ApiResponse.java
@@ -38,24 +38,9 @@ public class ApiResponse<T> {
         this.result = result;
     }
 
-    // [성공] 가장 많이 쓰는 200 OK (결과 데이터 있음)
-    public static <T> ResponseEntity<ApiResponse<T>> OK(T result) {
-        return of(GeneralSuccessCode.OK, result);
-    }
-
-    // [성공] 가장 많이 쓰는 200 OK (결과 데이터 없음)
-    public static <T> ResponseEntity<ApiResponse<T>> OK() {
-        return of(GeneralSuccessCode.OK, null);
-    }
-
-    // [성공] 201, 202 등 커스텀 성공 상태가 필요할 때
-    public static <T> ResponseEntity<ApiResponse<T>> of(BaseSuccessCode code, T result) {
-        if (code.getStatus() == HttpStatus.NO_CONTENT) {
-            return ResponseEntity.noContent().build();
-        }
-        return ResponseEntity
-                .status(code.getStatus())
-                .body(onSuccessBody(code, result));
+    // [성공]
+    public static <T> ApiResponse<T> success(BaseSuccessCode code, T result) {
+        return new ApiResponse<>(true, code.getCode(), code.getMessage(), result);
     }
 
     // [실패] 에러 핸들러에서 사용 (데이터 없는 일반 에러)
@@ -70,10 +55,6 @@ public class ApiResponse<T> {
         return ResponseEntity
                 .status(code.getStatus())
                 .body(onFailureBody(code, result));
-    }
-
-    private static <T> ApiResponse<T> onSuccessBody(BaseSuccessCode code, T result) {
-        return new ApiResponse<>(true, code.getCode(), code.getMessage(), result);
     }
 
     private static <T> ApiResponse<T> onFailureBody(BaseErrorCode code, T result) {


### PR DESCRIPTION
## #️⃣연관된 이슈

 Closed #19 

## 📝작업 내용

 ApiResponse 성공 반환 타입을 변경했습니다. 항상 동일한 레퍼토리로 반환합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * API 응답 형식이 표준화되었습니다. 가입, 로그인, 사용자 정보 조회 등 주요 엔드포인트의 응답 구조가 일관성 있게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->