### PR TITLE
feat: 티맵 API 연동 및 실외 앵커 보정 로직 구현 (#27)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/building/repository/BuildingDirectoryRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/BuildingDirectoryRepository.java
@@ -2,10 +2,37 @@ package com.insideout.backend.domain.building.repository;
 
 import com.insideout.backend.domain.building.entity.BuildingDirectory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface BuildingDirectoryRepository extends JpaRepository<BuildingDirectory, UUID> {
+
+    Optional<BuildingDirectory> findByIdAndIsPublicTrue(UUID id);
+
+    @Query(value = """
+            SELECT *
+            FROM building_directory
+            WHERE is_public = true
+              AND centroid IS NOT NULL
+              AND ST_DWithin(
+                    centroid,
+                    ST_SetSRID(ST_MakePoint(:x, :y), 4326)::geography,
+                    :radiusMeters
+              )
+            ORDER BY ST_Distance(
+                    centroid,
+                    ST_SetSRID(ST_MakePoint(:x, :y), 4326)::geography
+              )
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<BuildingDirectory> findNearestPublicBuilding(
+            @Param("x") double x,
+            @Param("y") double y,
+            @Param("radiusMeters") double radiusMeters
+    );
 }

--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -1,8 +1,16 @@
 package com.insideout.backend.domain.map.facade;
 
+import com.insideout.backend.domain.building.entity.BuildingDirectory;
+import com.insideout.backend.domain.building.repository.BuildingDirectoryRepository;
+import com.insideout.backend.domain.map.entity.Node;
+import com.insideout.backend.domain.map.repository.NodeRepository;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * 타 도메인(예: Navigation)에서 Map 도메인의 데이터를 안전하게 조회하기 위한 읽기 전용 서비스.
@@ -15,10 +23,57 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MapQueryFacade {
 
+    private static final double REGISTERED_BUILDING_SEARCH_RADIUS_METERS = 50.0;
+
     // 내부적으로 자기 도메인의 Repository는 자유롭게 주입받아 사용합니다.
-    // private final NodeRepository nodeRepository;
+    private final NodeRepository nodeRepository;
+    private final BuildingDirectoryRepository buildingDirectoryRepository;
     // private final EdgeRepository edgeRepository;
     // private final ObstacleRepository obstacleRepository;
+
+    public Optional<IndoorDestinationAnchor> findIndoorDestinationAnchor(
+            UUID destinationBuildingId,
+            double destinationX,
+            double destinationY
+    ) {
+        Optional<BuildingDirectory> building = destinationBuildingId != null
+                ? buildingDirectoryRepository.findByIdAndIsPublicTrue(destinationBuildingId)
+                : buildingDirectoryRepository.findNearestPublicBuilding(
+                        destinationX,
+                        destinationY,
+                        REGISTERED_BUILDING_SEARCH_RADIUS_METERS
+                );
+
+        return building.flatMap(directory -> nodeRepository
+                .findNearestEntranceByBuildingId(directory.getId(), destinationX, destinationY)
+                .flatMap(node -> toIndoorDestinationAnchor(directory, node)));
+    }
+
+    private Optional<IndoorDestinationAnchor> toIndoorDestinationAnchor(BuildingDirectory building, Node node) {
+        Point point = node.getGeomWgs84();
+        if (point == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new IndoorDestinationAnchor(
+                building.getId(),
+                building.getName(),
+                node.getId(),
+                node.getNameKo(),
+                point.getX(),
+                point.getY()
+        ));
+    }
+
+    public record IndoorDestinationAnchor(
+            UUID buildingId,
+            String buildingName,
+            UUID entranceNodeId,
+            String entranceName,
+            double x,
+            double y
+    ) {
+    }
 
     /*
     // 예시: Navigation 팀원이 호출할 메서드 껍데기

--- a/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
@@ -2,10 +2,32 @@ package com.insideout.backend.domain.map.repository;
 
 import com.insideout.backend.domain.map.entity.Node;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface NodeRepository extends JpaRepository<Node, UUID> {
+
+    @Query(value = """
+            SELECT n.*
+            FROM node n
+            JOIN map_version mv ON mv.id = n.map_version_id
+            WHERE mv.building_id = :buildingId
+              AND n.kind = 'entrance'
+              AND n.geom_wgs84 IS NOT NULL
+            ORDER BY ST_Distance(
+                    n.geom_wgs84,
+                    ST_SetSRID(ST_MakePoint(:x, :y), 4326)::geography
+              )
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<Node> findNearestEntranceByBuildingId(
+            @Param("buildingId") UUID buildingId,
+            @Param("x") double x,
+            @Param("y") double y
+    );
 }

--- a/src/main/java/com/insideout/backend/domain/navigation/controller/NavigationController.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/controller/NavigationController.java
@@ -1,0 +1,35 @@
+package com.insideout.backend.domain.navigation.controller;
+
+import com.insideout.backend.domain.navigation.dto.NavigationRequestDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto;
+import com.insideout.backend.domain.navigation.service.NavigationService;
+import com.insideout.backend.global.apiPayload.ApiResponse;
+import com.insideout.backend.global.apiPayload.code.GeneralSuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/navigation")
+@RequiredArgsConstructor
+public class NavigationController {
+
+    private final NavigationService navigationService;
+
+    @PostMapping("/routes")
+    public ApiResponse<NavigationResponseDto> findRoutes(
+            @Valid @RequestBody NavigationRequestDto request
+    ) {
+        return ApiResponse.success(GeneralSuccessCode.OK, navigationService.findRoutes(request));
+    }
+
+    @PostMapping("/transit/routes")
+    public ApiResponse<NavigationResponseDto> findTransitRoute(
+            @Valid @RequestBody NavigationRequestDto request
+    ) {
+        return ApiResponse.success(GeneralSuccessCode.OK, navigationService.findTransitRoutes(request));
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationRequestDto.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationRequestDto.java
@@ -1,0 +1,25 @@
+package com.insideout.backend.domain.navigation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.UUID;
+
+public record NavigationRequestDto(
+        @NotNull Double startX,
+        @NotNull Double startY,
+        @NotNull Double endX,
+        @NotNull Double endY,
+        String startName,
+        String endName,
+        UUID destinationBuildingId,
+        Boolean includeIndoor,
+        List<RouteType> routeTypes
+) {
+
+    public enum RouteType {
+        TRANSIT,
+        CAR,
+        WALK
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
@@ -1,0 +1,86 @@
+package com.insideout.backend.domain.navigation.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record NavigationResponseDto(
+        CoordinateDto requestedDestination,
+        CoordinateDto routedDestination,
+        IndoorInfoDto indoor,
+        List<RouteDto> routes
+) {
+
+    public record CoordinateDto(
+            Double x,
+            Double y,
+            String name
+    ) {
+    }
+
+    public record IndoorInfoDto(
+            Boolean included,
+            UUID buildingId,
+            String buildingName,
+            UUID entranceNodeId,
+            String entranceName
+    ) {
+    }
+
+    public record RouteDto(
+            RouteMode routeType,
+            RouteOption routeOption,
+            Integer totalTimeSeconds,
+            Integer totalDistanceMeters,
+            String totalDuration,
+            List<LegDto> legs
+    ) {
+    }
+
+    public record LegDto(
+            LegMode mode,
+            String routeName,
+            String transitType,
+            Integer durationSeconds,
+            Integer distanceMeters,
+            Integer stationCount,
+            String startName,
+            String endName,
+            List<StepDto> steps
+    ) {
+    }
+
+    public record StepDto(
+            String instruction,
+            Integer distanceMeters,
+            Integer durationSeconds,
+            Double x,
+            Double y,
+            Integer turnType,
+            String mode,
+            String streetName
+    ) {
+    }
+
+    public enum RouteMode {
+        TRANSIT,
+        CAR,
+        WALK
+    }
+
+    public enum RouteOption {
+        TRANSIT_CANDIDATE,
+        RECOMMENDED,
+        MIN_TIME,
+        SHORTEST,
+        COMFORTABLE
+    }
+
+    public enum LegMode {
+        WALK,
+        BUS,
+        SUBWAY,
+        CAR,
+        INDOOR,
+        OTHER
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
@@ -7,7 +7,9 @@ public record NavigationResponseDto(
         CoordinateDto requestedDestination,
         CoordinateDto routedDestination,
         IndoorInfoDto indoor,
-        List<RouteDto> routes
+        List<RouteDto> routes,
+        List<RouteMode> notFoundRouteTypes,
+        String message
 ) {
 
     public record CoordinateDto(

--- a/src/main/java/com/insideout/backend/domain/navigation/exception/NavigationErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/exception/NavigationErrorCode.java
@@ -1,0 +1,46 @@
+package com.insideout.backend.domain.navigation.exception;
+
+import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NavigationErrorCode implements BaseErrorCode {
+
+    TMAP_EMPTY_RESPONSE(
+            HttpStatus.BAD_GATEWAY,
+            "NAVIGATION502_1",
+            "TMAP API 응답이 비어 있습니다."
+    ),
+    TMAP_REQUEST_FAILED(
+            HttpStatus.BAD_GATEWAY,
+            "NAVIGATION502_2",
+            "TMAP API 요청 중 오류가 발생했습니다."
+    ),
+    TMAP_CONNECTION_FAILED(
+            HttpStatus.BAD_GATEWAY,
+            "NAVIGATION502_3",
+            "TMAP API 서버와 통신할 수 없습니다."
+    ),
+    INVALID_TRANSIT_RESPONSE(
+            HttpStatus.BAD_GATEWAY,
+            "NAVIGATION502_4",
+            "TMAP 대중교통 경로 응답 형식이 올바르지 않습니다."
+    ),
+    INVALID_CAR_RESPONSE(
+            HttpStatus.BAD_GATEWAY,
+            "NAVIGATION502_5",
+            "TMAP 자동차 경로 응답 형식이 올바르지 않습니다."
+    ),
+    INVALID_WALK_RESPONSE(
+            HttpStatus.BAD_GATEWAY,
+            "NAVIGATION502_6",
+            "TMAP 도보 경로 응답 형식이 올바르지 않습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/insideout/backend/domain/navigation/exception/NavigationException.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/exception/NavigationException.java
@@ -1,0 +1,15 @@
+package com.insideout.backend.domain.navigation.exception;
+
+import com.insideout.backend.global.apiPayload.exception.ProjectException;
+
+public class NavigationException extends ProjectException {
+
+    public NavigationException(NavigationErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NavigationException(NavigationErrorCode errorCode, Throwable cause) {
+        super(errorCode);
+        initCause(cause);
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -14,8 +14,8 @@ import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteDt
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteMode;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteOption;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.StepDto;
-import com.insideout.backend.global.apiPayload.code.GeneralErrorCode;
-import com.insideout.backend.global.apiPayload.exception.ProjectException;
+import com.insideout.backend.domain.navigation.exception.NavigationErrorCode;
+import com.insideout.backend.domain.navigation.exception.NavigationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -214,20 +214,19 @@ public class NavigationService {
             JsonNode response = restTemplate.postForObject(url, new HttpEntity<>(body, headers), JsonNode.class);
             if (response == null || response.isNull()) {
                 log.warn("TMAP API returned empty response. url={}", url);
-                throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+                throw new NavigationException(NavigationErrorCode.TMAP_EMPTY_RESPONSE);
             }
             return response;
         } catch (RestClientResponseException e) {
             log.warn(
-                    "TMAP API returned error. url={}, status={}, body={}",
+                    "TMAP API returned error. url={}, status={}",
                     url,
-                    e.getStatusCode(),
-                    abbreviate(e.getResponseBodyAsString())
+                    e.getStatusCode()
             );
-            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY, e);
+            throw new NavigationException(NavigationErrorCode.TMAP_REQUEST_FAILED, e);
         } catch (RestClientException e) {
             log.warn("TMAP API request failed. url={}", url, e);
-            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY, e);
+            throw new NavigationException(NavigationErrorCode.TMAP_CONNECTION_FAILED, e);
         }
     }
 
@@ -238,8 +237,8 @@ public class NavigationService {
                 .path("itineraries");
 
         if (!itineraries.isArray()) {
-            log.warn("TMAP transit response has invalid structure. response={}", abbreviate(response.toString()));
-            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+            log.warn("TMAP transit response has invalid structure.");
+            throw new NavigationException(NavigationErrorCode.INVALID_TRANSIT_RESPONSE);
         }
         if (itineraries.isEmpty()) {
             return List.of();
@@ -342,8 +341,8 @@ public class NavigationService {
     ) {
         JsonNode features = response.path("features");
         if (!features.isArray()) {
-            log.warn("TMAP {} response has invalid structure. response={}", routeMode, abbreviate(response.toString()));
-            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+            log.warn("TMAP {} response has invalid structure.", routeMode);
+            throw new NavigationException(resolveInvalidFeatureResponseErrorCode(routeMode));
         }
         if (features.isEmpty()) {
             return Optional.empty();
@@ -375,6 +374,14 @@ public class NavigationService {
                 formatDuration(totalTimeSeconds, target.includesIndoor()),
                 legs
         ));
+    }
+
+    private NavigationErrorCode resolveInvalidFeatureResponseErrorCode(RouteMode routeMode) {
+        return switch (routeMode) {
+            case CAR -> NavigationErrorCode.INVALID_CAR_RESPONSE;
+            case WALK -> NavigationErrorCode.INVALID_WALK_RESPONSE;
+            default -> NavigationErrorCode.TMAP_REQUEST_FAILED;
+        };
     }
 
     private List<StepDto> parseFeatureSteps(JsonNode features) {
@@ -530,13 +537,6 @@ public class NavigationService {
 
     private Double firstNonNull(Double first, Double second) {
         return first != null ? first : second;
-    }
-
-    private String abbreviate(String value) {
-        if (value == null || value.length() <= 500) {
-            return value;
-        }
-        return value.substring(0, 500) + "...";
     }
 
     private String getNullableText(JsonNode node) {

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -16,8 +16,8 @@ import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteOp
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.StepDto;
 import com.insideout.backend.domain.navigation.exception.NavigationErrorCode;
 import com.insideout.backend.domain.navigation.exception.NavigationException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -42,7 +42,6 @@ import java.util.Optional;
  * 다른 도메인의 Service를 주입받아 필요한 데이터를 가져옵니다.
  */
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
 public class NavigationService {
@@ -56,6 +55,14 @@ public class NavigationService {
 
     @Value("${tmap.api.key}")
     private String tmapApiKey;
+
+    public NavigationService(
+            MapQueryFacade mapQueryFacade,
+            @Qualifier("tmapRestTemplate") RestTemplate restTemplate
+    ) {
+        this.mapQueryFacade = mapQueryFacade;
+        this.restTemplate = restTemplate;
+    }
 
     public NavigationResponseDto findRoutes(NavigationRequestDto request) {
         RouteTarget target = resolveRouteTarget(request);

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -1,13 +1,42 @@
 package com.insideout.backend.domain.navigation.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.insideout.backend.domain.map.facade.MapQueryFacade;
+import com.insideout.backend.domain.map.facade.MapQueryFacade.IndoorDestinationAnchor;
+import com.insideout.backend.domain.navigation.dto.NavigationRequestDto;
+import com.insideout.backend.domain.navigation.dto.NavigationRequestDto.RouteType;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.CoordinateDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.IndoorInfoDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.LegDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.LegMode;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteMode;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteOption;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.StepDto;
+import com.insideout.backend.global.apiPayload.code.GeneralErrorCode;
+import com.insideout.backend.global.apiPayload.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * 실내외 길찾기(Navigation) 기능을 담당하는 핵심 서비스.
- * 
+ *
  * <p>Repository를 직접 참조하지 않고, MapQueryFacade 등
  * 다른 도메인의 Service를 주입받아 필요한 데이터를 가져옵니다.
  */
@@ -16,9 +45,534 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class NavigationService {
 
-    // 타 도메인의 Repository를 직접 쓰지 않고 Service를 주입받아 사용합니다.
-    private final MapQueryFacade mapQueryFacade;
+    private static final String TMAP_TRANSIT_ROUTES_URL = "https://apis.openapi.sk.com/transit/routes";
+    private static final String TMAP_CAR_ROUTES_URL = "https://apis.openapi.sk.com/tmap/routes?version=1&format=json";
+    private static final String TMAP_WALK_ROUTES_URL = "https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1";
 
-    // TODO: A* 알고리즘 등 경로 탐색 로직 작성
-    
+    private final MapQueryFacade mapQueryFacade;
+    private final RestTemplateBuilder restTemplateBuilder;
+
+    @Value("${tmap.api.key}")
+    private String tmapApiKey;
+
+    public NavigationResponseDto findRoutes(NavigationRequestDto request) {
+        RouteTarget target = resolveRouteTarget(request);
+        EnumSet<RouteType> routeTypes = resolveRouteTypes(request);
+        List<RouteDto> routes = new ArrayList<>();
+
+        if (routeTypes.contains(RouteType.TRANSIT)) {
+            routes.addAll(findTransitRouteDtos(request, target));
+        }
+        if (routeTypes.contains(RouteType.CAR)) {
+            routes.add(findCarRouteDto(request, target, RouteOption.RECOMMENDED, 0));
+            routes.add(findCarRouteDto(request, target, RouteOption.MIN_TIME, 2));
+        }
+        if (routeTypes.contains(RouteType.WALK)) {
+            routes.add(findWalkRouteDto(request, target, RouteOption.SHORTEST, "10"));
+            routes.add(findWalkRouteDto(request, target, RouteOption.COMFORTABLE, "30"));
+        }
+
+        return new NavigationResponseDto(
+                new CoordinateDto(request.endX(), request.endY(), request.endName()),
+                new CoordinateDto(target.endX(), target.endY(), target.endName()),
+                target.toIndoorInfo(),
+                routes
+        );
+    }
+
+    public NavigationResponseDto findTransitRoutes(NavigationRequestDto request) {
+        NavigationRequestDto transitOnlyRequest = new NavigationRequestDto(
+                request.startX(),
+                request.startY(),
+                request.endX(),
+                request.endY(),
+                request.startName(),
+                request.endName(),
+                request.destinationBuildingId(),
+                request.includeIndoor(),
+                List.of(RouteType.TRANSIT)
+        );
+        return findRoutes(transitOnlyRequest);
+    }
+
+    private RouteTarget resolveRouteTarget(NavigationRequestDto request) {
+        if (Boolean.FALSE.equals(request.includeIndoor())) {
+            return RouteTarget.outdoorOnly(request.endX(), request.endY(), request.endName());
+        }
+
+        Optional<IndoorDestinationAnchor> anchor = mapQueryFacade.findIndoorDestinationAnchor(
+                request.destinationBuildingId(),
+                request.endX(),
+                request.endY()
+        );
+
+        return anchor
+                .map(value -> RouteTarget.withIndoor(value, request.endName()))
+                .orElseGet(() -> RouteTarget.outdoorOnly(request.endX(), request.endY(), request.endName()));
+    }
+
+    private EnumSet<RouteType> resolveRouteTypes(NavigationRequestDto request) {
+        if (request.routeTypes() == null || request.routeTypes().isEmpty()) {
+            return EnumSet.allOf(RouteType.class);
+        }
+
+        EnumSet<RouteType> routeTypes = EnumSet.noneOf(RouteType.class);
+        routeTypes.addAll(request.routeTypes());
+        return routeTypes;
+    }
+
+    private List<RouteDto> findTransitRouteDtos(NavigationRequestDto request, RouteTarget target) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("startX", request.startX());
+        body.put("startY", request.startY());
+        body.put("endX", target.endX());
+        body.put("endY", target.endY());
+        body.put("format", "json");
+        body.put("count", 10);
+
+        JsonNode response = postForJson(TMAP_TRANSIT_ROUTES_URL, body);
+        return parseTransitRoutes(response, target);
+    }
+
+    private RouteDto findCarRouteDto(
+            NavigationRequestDto request,
+            RouteTarget target,
+            RouteOption routeOption,
+            int searchOption
+    ) {
+        Map<String, Object> body = baseOutdoorRouteBody(request, target);
+        body.put("searchOption", searchOption);
+        body.put("carType", 1);
+        body.put("totalValue", 1);
+        body.put("trafficInfo", "N");
+
+        JsonNode response = postForJson(TMAP_CAR_ROUTES_URL, body);
+        return parseFeatureCollectionRoute(response, RouteMode.CAR, routeOption, LegMode.CAR, target);
+    }
+
+    private RouteDto findWalkRouteDto(
+            NavigationRequestDto request,
+            RouteTarget target,
+            RouteOption routeOption,
+            String searchOption
+    ) {
+        Map<String, Object> body = baseOutdoorRouteBody(request, target);
+        body.put("searchOption", searchOption);
+        body.put("sort", "index");
+
+        JsonNode response = postForJson(TMAP_WALK_ROUTES_URL, body);
+        return parseFeatureCollectionRoute(response, RouteMode.WALK, routeOption, LegMode.WALK, target);
+    }
+
+    private Map<String, Object> baseOutdoorRouteBody(NavigationRequestDto request, RouteTarget target) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("startX", request.startX());
+        body.put("startY", request.startY());
+        body.put("endX", target.endX());
+        body.put("endY", target.endY());
+        body.put("reqCoordType", "WGS84GEO");
+        body.put("resCoordType", "WGS84GEO");
+        body.put("startName", defaultName(request.startName(), "출발"));
+        body.put("endName", defaultName(target.endName(), "도착"));
+        return body;
+    }
+
+    private JsonNode postForJson(String url, Map<String, Object> body) {
+        RestTemplate restTemplate = restTemplateBuilder.build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("appKey", tmapApiKey);
+
+        try {
+            JsonNode response = restTemplate.postForObject(url, new HttpEntity<>(body, headers), JsonNode.class);
+            if (response == null || response.isNull()) {
+                throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+            }
+            return response;
+        } catch (RestClientException e) {
+            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+        }
+    }
+
+    private List<RouteDto> parseTransitRoutes(JsonNode response, RouteTarget target) {
+        JsonNode itineraries = response
+                .path("metaData")
+                .path("plan")
+                .path("itineraries");
+
+        if (!itineraries.isArray() || itineraries.isEmpty()) {
+            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+        }
+
+        List<RouteDto> routes = new ArrayList<>();
+        for (JsonNode itinerary : itineraries) {
+            Integer totalTimeSeconds = getNullableInt(itinerary.path("totalTime"));
+            Integer totalDistanceMeters = getNullableInt(itinerary.path("totalDistance"));
+            List<LegDto> legs = parseTransitLegs(itinerary.path("legs"));
+            addIndoorLegIfNeeded(legs, target);
+
+            routes.add(new RouteDto(
+                    RouteMode.TRANSIT,
+                    RouteOption.TRANSIT_CANDIDATE,
+                    totalTimeSeconds,
+                    totalDistanceMeters,
+                    formatDuration(totalTimeSeconds, target.includesIndoor()),
+                    legs
+            ));
+        }
+
+        return routes;
+    }
+
+    private List<LegDto> parseTransitLegs(JsonNode legsNode) {
+        List<LegDto> legs = new ArrayList<>();
+
+        if (!legsNode.isArray()) {
+            return legs;
+        }
+
+        for (JsonNode legNode : legsNode) {
+            LegMode mode = parseTransitLegMode(getNullableText(legNode.path("mode")));
+            legs.add(new LegDto(
+                    mode,
+                    resolveTransitRouteName(legNode),
+                    getNullableText(legNode.path("type")),
+                    getNullableInt(legNode.path("sectionTime")),
+                    getNullableInt(legNode.path("distance")),
+                    countTransitStations(legNode),
+                    getNullableText(legNode.path("start").path("name")),
+                    getNullableText(legNode.path("end").path("name")),
+                    parseTransitSteps(legNode)
+            ));
+        }
+
+        return legs;
+    }
+
+    private List<StepDto> parseTransitSteps(JsonNode legNode) {
+        List<StepDto> steps = new ArrayList<>();
+        JsonNode stepsNode = legNode.path("steps");
+
+        if (stepsNode.isArray()) {
+            for (JsonNode stepNode : stepsNode) {
+                CoordinateDto coordinate = firstLinestringCoordinate(stepNode.path("linestring"));
+                steps.add(new StepDto(
+                        firstText(stepNode, "description", "desc", "instruction"),
+                        getNullableInt(stepNode.path("distance")),
+                        getNullableInt(stepNode.path("sectionTime")),
+                        firstNonNull(getNullableDouble(stepNode.path("lon")), coordinate.x()),
+                        firstNonNull(getNullableDouble(stepNode.path("lat")), coordinate.y()),
+                        getNullableInt(stepNode.path("turnType")),
+                        getNullableText(legNode.path("mode")),
+                        firstText(stepNode, "streetName", "name")
+                ));
+            }
+        }
+
+        if (!steps.isEmpty()) {
+            return steps;
+        }
+
+        String startName = getNullableText(legNode.path("start").path("name"));
+        String endName = getNullableText(legNode.path("end").path("name"));
+        Integer distance = getNullableInt(legNode.path("distance"));
+        if (startName != null || endName != null || distance != null) {
+            steps.add(new StepDto(
+                    buildTransitInstruction(getNullableText(legNode.path("mode")), startName, endName, distance),
+                    distance,
+                    getNullableInt(legNode.path("sectionTime")),
+                    null,
+                    null,
+                    null,
+                    getNullableText(legNode.path("mode")),
+                    null
+            ));
+        }
+
+        return steps;
+    }
+
+    private RouteDto parseFeatureCollectionRoute(
+            JsonNode response,
+            RouteMode routeMode,
+            RouteOption routeOption,
+            LegMode legMode,
+            RouteTarget target
+    ) {
+        JsonNode features = response.path("features");
+        if (!features.isArray() || features.isEmpty()) {
+            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+        }
+
+        JsonNode summary = features.get(0).path("properties");
+        Integer totalTimeSeconds = getNullableInt(summary.path("totalTime"));
+        Integer totalDistanceMeters = getNullableInt(summary.path("totalDistance"));
+        List<StepDto> steps = parseFeatureSteps(features);
+        List<LegDto> legs = new ArrayList<>();
+        legs.add(new LegDto(
+                legMode,
+                null,
+                null,
+                totalTimeSeconds,
+                totalDistanceMeters,
+                null,
+                null,
+                target.endName(),
+                steps
+        ));
+        addIndoorLegIfNeeded(legs, target);
+
+        return new RouteDto(
+                routeMode,
+                routeOption,
+                totalTimeSeconds,
+                totalDistanceMeters,
+                formatDuration(totalTimeSeconds, target.includesIndoor()),
+                legs
+        );
+    }
+
+    private List<StepDto> parseFeatureSteps(JsonNode features) {
+        List<StepDto> steps = new ArrayList<>();
+
+        for (JsonNode feature : features) {
+            JsonNode properties = feature.path("properties");
+            String description = getNullableText(properties.path("description"));
+            if (description == null || description.isBlank()) {
+                continue;
+            }
+
+            CoordinateDto coordinate = firstPointCoordinate(feature.path("geometry").path("coordinates"));
+            steps.add(new StepDto(
+                    description,
+                    getNullableInt(properties.path("distance")),
+                    getNullableInt(properties.path("time")),
+                    coordinate.x(),
+                    coordinate.y(),
+                    getNullableInt(properties.path("turnType")),
+                    getNullableText(properties.path("facilityType")),
+                    getNullableText(properties.path("name"))
+            ));
+        }
+
+        return steps;
+    }
+
+    private CoordinateDto firstPointCoordinate(JsonNode coordinates) {
+        if (coordinates.isArray() && coordinates.size() >= 2 && coordinates.get(0).isNumber()) {
+            return new CoordinateDto(coordinates.get(0).asDouble(), coordinates.get(1).asDouble(), null);
+        }
+        return new CoordinateDto(null, null, null);
+    }
+
+    private void addIndoorLegIfNeeded(List<LegDto> legs, RouteTarget target) {
+        if (!target.includesIndoor()) {
+            return;
+        }
+
+        legs.add(new LegDto(
+                LegMode.INDOOR,
+                null,
+                null,
+                null,
+                null,
+                null,
+                target.entranceName(),
+                target.originalEndName(),
+                List.of(new StepDto("실내 이동", null, null, target.endX(), target.endY(), null, "INDOOR", null))
+        ));
+    }
+
+    private String resolveTransitRouteName(JsonNode legNode) {
+        String route = getNullableText(legNode.path("route"));
+        if (route != null) {
+            return route;
+        }
+
+        JsonNode lane = legNode.path("lane");
+        if (!lane.isArray() || lane.isEmpty()) {
+            lane = legNode.path("Lane");
+        }
+        if (lane.isArray() && !lane.isEmpty()) {
+            JsonNode firstLane = lane.get(0);
+            return firstText(firstLane, "route", "name", "busNo", "subwayCode");
+        }
+
+        return null;
+    }
+
+    private Integer countTransitStations(JsonNode legNode) {
+        JsonNode stationList = legNode.path("passStopList").path("stationList");
+        if (!stationList.isArray()) {
+            stationList = legNode.path("passStopList").path("stations");
+        }
+        if (stationList.isArray()) {
+            return stationList.size();
+        }
+        return null;
+    }
+
+    private LegMode parseTransitLegMode(String mode) {
+        if (mode == null) {
+            return LegMode.OTHER;
+        }
+
+        return switch (mode.toUpperCase()) {
+            case "WALK" -> LegMode.WALK;
+            case "BUS" -> LegMode.BUS;
+            case "SUBWAY" -> LegMode.SUBWAY;
+            default -> LegMode.OTHER;
+        };
+    }
+
+    private String buildTransitInstruction(String mode, String startName, String endName, Integer distance) {
+        String distanceText = distance == null ? "" : distance + "m ";
+        if ("WALK".equalsIgnoreCase(mode)) {
+            return distanceText + "도보 이동";
+        }
+        if (startName != null && endName != null) {
+            return startName + "에서 " + endName + "까지 이동";
+        }
+        return distanceText + "이동";
+    }
+
+    private String formatDuration(Integer totalTimeSeconds, boolean includesIndoor) {
+        if (totalTimeSeconds == null) {
+            return includesIndoor ? "실내 이동" : null;
+        }
+
+        int minutes = (int) Math.ceil(totalTimeSeconds / 60.0);
+        String duration = minutes + "분";
+        return includesIndoor ? duration + " + 실내 이동" : duration;
+    }
+
+    private String firstText(JsonNode node, String... fieldNames) {
+        for (String fieldName : fieldNames) {
+            String value = getNullableText(node.path(fieldName));
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private String defaultName(String value, String defaultValue) {
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private CoordinateDto firstLinestringCoordinate(JsonNode linestringNode) {
+        String linestring = getNullableText(linestringNode);
+        if (linestring == null || linestring.isBlank()) {
+            return new CoordinateDto(null, null, null);
+        }
+
+        String firstPair = linestring.trim().split("\\s+")[0];
+        String[] coordinates = firstPair.split(",");
+        if (coordinates.length < 2) {
+            return new CoordinateDto(null, null, null);
+        }
+
+        try {
+            return new CoordinateDto(
+                    Double.parseDouble(coordinates[0]),
+                    Double.parseDouble(coordinates[1]),
+                    null
+            );
+        } catch (NumberFormatException ignored) {
+            return new CoordinateDto(null, null, null);
+        }
+    }
+
+    private Double firstNonNull(Double first, Double second) {
+        return first != null ? first : second;
+    }
+
+    private String getNullableText(JsonNode node) {
+        return node.isMissingNode() || node.isNull() ? null : node.asText();
+    }
+
+    private Integer getNullableInt(JsonNode node) {
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (node.canConvertToInt()) {
+            return node.asInt();
+        }
+        if (node.isTextual()) {
+            try {
+                return Integer.parseInt(node.asText());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Double getNullableDouble(JsonNode node) {
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (node.isNumber()) {
+            return node.asDouble();
+        }
+        if (node.isTextual()) {
+            try {
+                return Double.parseDouble(node.asText());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private record RouteTarget(
+            double endX,
+            double endY,
+            String endName,
+            boolean includesIndoor,
+            String originalEndName,
+            IndoorDestinationAnchor anchor
+    ) {
+
+        private static RouteTarget outdoorOnly(double endX, double endY, String endName) {
+            return new RouteTarget(endX, endY, endName, false, endName, null);
+        }
+
+        private static RouteTarget withIndoor(IndoorDestinationAnchor anchor, String originalEndName) {
+            return new RouteTarget(
+                    anchor.x(),
+                    anchor.y(),
+                    defaultAnchorName(anchor),
+                    true,
+                    originalEndName,
+                    anchor
+            );
+        }
+
+        private IndoorInfoDto toIndoorInfo() {
+            if (!includesIndoor) {
+                return new IndoorInfoDto(false, null, null, null, null);
+            }
+            return new IndoorInfoDto(
+                    true,
+                    anchor.buildingId(),
+                    anchor.buildingName(),
+                    anchor.entranceNodeId(),
+                    anchor.entranceName()
+            );
+        }
+
+        private String entranceName() {
+            return anchor == null ? null : anchor.entranceName();
+        }
+
+        private static String defaultAnchorName(IndoorDestinationAnchor anchor) {
+            if (anchor.entranceName() != null && !anchor.entranceName().isBlank()) {
+                return anchor.entranceName();
+            }
+            return anchor.buildingName();
+        }
+    }
 }

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -17,14 +17,15 @@ import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.StepDto
 import com.insideout.backend.global.apiPayload.code.GeneralErrorCode;
 import com.insideout.backend.global.apiPayload.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class NavigationService {
 
     private static final String TMAP_TRANSIT_ROUTES_URL = "https://apis.openapi.sk.com/transit/routes";
@@ -50,7 +52,7 @@ public class NavigationService {
     private static final String TMAP_WALK_ROUTES_URL = "https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1";
 
     private final MapQueryFacade mapQueryFacade;
-    private final RestTemplateBuilder restTemplateBuilder;
+    private final RestTemplate restTemplate;
 
     @Value("${tmap.api.key}")
     private String tmapApiKey;
@@ -59,25 +61,50 @@ public class NavigationService {
         RouteTarget target = resolveRouteTarget(request);
         EnumSet<RouteType> routeTypes = resolveRouteTypes(request);
         List<RouteDto> routes = new ArrayList<>();
+        List<RouteMode> notFoundRouteTypes = new ArrayList<>();
 
         if (routeTypes.contains(RouteType.TRANSIT)) {
-            routes.addAll(findTransitRouteDtos(request, target));
+            List<RouteDto> transitRoutes = findTransitRouteDtos(request, target);
+            if (transitRoutes.isEmpty()) {
+                notFoundRouteTypes.add(RouteMode.TRANSIT);
+            }
+            routes.addAll(transitRoutes);
         }
         if (routeTypes.contains(RouteType.CAR)) {
-            routes.add(findCarRouteDto(request, target, RouteOption.RECOMMENDED, 0));
-            routes.add(findCarRouteDto(request, target, RouteOption.MIN_TIME, 2));
+            int beforeSize = routes.size();
+            findCarRouteDto(request, target, RouteOption.RECOMMENDED, 0).ifPresent(routes::add);
+            findCarRouteDto(request, target, RouteOption.MIN_TIME, 2).ifPresent(routes::add);
+            if (routes.size() == beforeSize) {
+                notFoundRouteTypes.add(RouteMode.CAR);
+            }
         }
         if (routeTypes.contains(RouteType.WALK)) {
-            routes.add(findWalkRouteDto(request, target, RouteOption.SHORTEST, "10"));
-            routes.add(findWalkRouteDto(request, target, RouteOption.COMFORTABLE, "30"));
+            int beforeSize = routes.size();
+            findWalkRouteDto(request, target, RouteOption.SHORTEST, "10").ifPresent(routes::add);
+            findWalkRouteDto(request, target, RouteOption.COMFORTABLE, "30").ifPresent(routes::add);
+            if (routes.size() == beforeSize) {
+                notFoundRouteTypes.add(RouteMode.WALK);
+            }
         }
 
         return new NavigationResponseDto(
                 new CoordinateDto(request.endX(), request.endY(), request.endName()),
                 new CoordinateDto(target.endX(), target.endY(), target.endName()),
                 target.toIndoorInfo(),
-                routes
+                routes,
+                notFoundRouteTypes,
+                resolveRouteMessage(routes, notFoundRouteTypes)
         );
+    }
+
+    private String resolveRouteMessage(List<RouteDto> routes, List<RouteMode> notFoundRouteTypes) {
+        if (notFoundRouteTypes.isEmpty()) {
+            return null;
+        }
+        if (routes.isEmpty()) {
+            return "경로를 찾을 수 없습니다.";
+        }
+        return "일부 이동 수단의 경로를 찾을 수 없습니다.";
     }
 
     public NavigationResponseDto findTransitRoutes(NavigationRequestDto request) {
@@ -134,7 +161,7 @@ public class NavigationService {
         return parseTransitRoutes(response, target);
     }
 
-    private RouteDto findCarRouteDto(
+    private Optional<RouteDto> findCarRouteDto(
             NavigationRequestDto request,
             RouteTarget target,
             RouteOption routeOption,
@@ -150,7 +177,7 @@ public class NavigationService {
         return parseFeatureCollectionRoute(response, RouteMode.CAR, routeOption, LegMode.CAR, target);
     }
 
-    private RouteDto findWalkRouteDto(
+    private Optional<RouteDto> findWalkRouteDto(
             NavigationRequestDto request,
             RouteTarget target,
             RouteOption routeOption,
@@ -178,8 +205,6 @@ public class NavigationService {
     }
 
     private JsonNode postForJson(String url, Map<String, Object> body) {
-        RestTemplate restTemplate = restTemplateBuilder.build();
-
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -188,11 +213,21 @@ public class NavigationService {
         try {
             JsonNode response = restTemplate.postForObject(url, new HttpEntity<>(body, headers), JsonNode.class);
             if (response == null || response.isNull()) {
+                log.warn("TMAP API returned empty response. url={}", url);
                 throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
             }
             return response;
+        } catch (RestClientResponseException e) {
+            log.warn(
+                    "TMAP API returned error. url={}, status={}, body={}",
+                    url,
+                    e.getStatusCode(),
+                    abbreviate(e.getResponseBodyAsString())
+            );
+            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY, e);
         } catch (RestClientException e) {
-            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+            log.warn("TMAP API request failed. url={}", url, e);
+            throw new ProjectException(GeneralErrorCode.BAD_GATEWAY, e);
         }
     }
 
@@ -202,8 +237,12 @@ public class NavigationService {
                 .path("plan")
                 .path("itineraries");
 
-        if (!itineraries.isArray() || itineraries.isEmpty()) {
+        if (!itineraries.isArray()) {
+            log.warn("TMAP transit response has invalid structure. response={}", abbreviate(response.toString()));
             throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+        }
+        if (itineraries.isEmpty()) {
+            return List.of();
         }
 
         List<RouteDto> routes = new ArrayList<>();
@@ -294,7 +333,7 @@ public class NavigationService {
         return steps;
     }
 
-    private RouteDto parseFeatureCollectionRoute(
+    private Optional<RouteDto> parseFeatureCollectionRoute(
             JsonNode response,
             RouteMode routeMode,
             RouteOption routeOption,
@@ -302,8 +341,12 @@ public class NavigationService {
             RouteTarget target
     ) {
         JsonNode features = response.path("features");
-        if (!features.isArray() || features.isEmpty()) {
+        if (!features.isArray()) {
+            log.warn("TMAP {} response has invalid structure. response={}", routeMode, abbreviate(response.toString()));
             throw new ProjectException(GeneralErrorCode.BAD_GATEWAY);
+        }
+        if (features.isEmpty()) {
+            return Optional.empty();
         }
 
         JsonNode summary = features.get(0).path("properties");
@@ -324,14 +367,14 @@ public class NavigationService {
         ));
         addIndoorLegIfNeeded(legs, target);
 
-        return new RouteDto(
+        return Optional.of(new RouteDto(
                 routeMode,
                 routeOption,
                 totalTimeSeconds,
                 totalDistanceMeters,
                 formatDuration(totalTimeSeconds, target.includesIndoor()),
                 legs
-        );
+        ));
     }
 
     private List<StepDto> parseFeatureSteps(JsonNode features) {
@@ -487,6 +530,13 @@ public class NavigationService {
 
     private Double firstNonNull(Double first, Double second) {
         return first != null ? first : second;
+    }
+
+    private String abbreviate(String value) {
+        if (value == null || value.length() <= 500) {
+            return value;
+        }
+        return value.substring(0, 500) + "...";
     }
 
     private String getNullableText(JsonNode node) {

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -64,24 +64,37 @@ public class NavigationService {
         List<RouteMode> notFoundRouteTypes = new ArrayList<>();
 
         if (routeTypes.contains(RouteType.TRANSIT)) {
-            List<RouteDto> transitRoutes = findTransitRouteDtos(request, target);
-            if (transitRoutes.isEmpty()) {
+            try {
+                List<RouteDto> transitRoutes = findTransitRouteDtos(request, target);
+                if (transitRoutes.isEmpty()) {
+                    notFoundRouteTypes.add(RouteMode.TRANSIT);
+                }
+                routes.addAll(transitRoutes);
+            } catch (NavigationException e) {
+                log.warn("TRANSIT route lookup failed.", e);
                 notFoundRouteTypes.add(RouteMode.TRANSIT);
             }
-            routes.addAll(transitRoutes);
         }
         if (routeTypes.contains(RouteType.CAR)) {
             int beforeSize = routes.size();
-            findCarRouteDto(request, target, RouteOption.RECOMMENDED, 0).ifPresent(routes::add);
-            findCarRouteDto(request, target, RouteOption.MIN_TIME, 2).ifPresent(routes::add);
+            try {
+                findCarRouteDto(request, target, RouteOption.RECOMMENDED, 0).ifPresent(routes::add);
+                findCarRouteDto(request, target, RouteOption.MIN_TIME, 2).ifPresent(routes::add);
+            } catch (NavigationException e) {
+                log.warn("CAR route lookup failed.", e);
+            }
             if (routes.size() == beforeSize) {
                 notFoundRouteTypes.add(RouteMode.CAR);
             }
         }
         if (routeTypes.contains(RouteType.WALK)) {
             int beforeSize = routes.size();
-            findWalkRouteDto(request, target, RouteOption.SHORTEST, "10").ifPresent(routes::add);
-            findWalkRouteDto(request, target, RouteOption.COMFORTABLE, "30").ifPresent(routes::add);
+            try {
+                findWalkRouteDto(request, target, RouteOption.SHORTEST, "10").ifPresent(routes::add);
+                findWalkRouteDto(request, target, RouteOption.COMFORTABLE, "30").ifPresent(routes::add);
+            } catch (NavigationException e) {
+                log.warn("WALK route lookup failed.", e);
+            }
             if (routes.size() == beforeSize) {
                 notFoundRouteTypes.add(RouteMode.WALK);
             }
@@ -134,7 +147,7 @@ public class NavigationService {
         );
 
         return anchor
-                .map(value -> RouteTarget.withIndoor(value, request.endName()))
+                .map(value -> RouteTarget.withIndoor(value, request.endX(), request.endY(), request.endName()))
                 .orElseGet(() -> RouteTarget.outdoorOnly(request.endX(), request.endY(), request.endName()));
     }
 
@@ -431,7 +444,16 @@ public class NavigationService {
                 null,
                 target.entranceName(),
                 target.originalEndName(),
-                List.of(new StepDto("실내 이동", null, null, target.endX(), target.endY(), null, "INDOOR", null))
+                List.of(new StepDto(
+                        "실내 이동",
+                        null,
+                        null,
+                        target.originalEndX(),
+                        target.originalEndY(),
+                        null,
+                        "INDOOR",
+                        null
+                ))
         ));
     }
 
@@ -580,6 +602,8 @@ public class NavigationService {
     private record RouteTarget(
             double endX,
             double endY,
+            double originalEndX,
+            double originalEndY,
             String endName,
             boolean includesIndoor,
             String originalEndName,
@@ -587,13 +611,20 @@ public class NavigationService {
     ) {
 
         private static RouteTarget outdoorOnly(double endX, double endY, String endName) {
-            return new RouteTarget(endX, endY, endName, false, endName, null);
+            return new RouteTarget(endX, endY, endX, endY, endName, false, endName, null);
         }
 
-        private static RouteTarget withIndoor(IndoorDestinationAnchor anchor, String originalEndName) {
+        private static RouteTarget withIndoor(
+                IndoorDestinationAnchor anchor,
+                double originalEndX,
+                double originalEndY,
+                String originalEndName
+        ) {
             return new RouteTarget(
                     anchor.x(),
                     anchor.y(),
+                    originalEndX,
+                    originalEndY,
                     defaultAnchorName(anchor),
                     true,
                     originalEndName,

--- a/src/main/java/com/insideout/backend/global/apiPayload/exception/ProjectException.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/exception/ProjectException.java
@@ -2,10 +2,17 @@ package com.insideout.backend.global.apiPayload.exception;
 
 import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class ProjectException extends RuntimeException {
     private final BaseErrorCode errorCode;
+
+    public ProjectException(BaseErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public ProjectException(BaseErrorCode errorCode, Throwable cause) {
+        super(cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/insideout/backend/global/apiPayload/exception/ProjectException.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/exception/ProjectException.java
@@ -2,17 +2,10 @@ package com.insideout.backend.global.apiPayload.exception;
 
 import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public class ProjectException extends RuntimeException {
     private final BaseErrorCode errorCode;
-
-    public ProjectException(BaseErrorCode errorCode) {
-        this.errorCode = errorCode;
-    }
-
-    public ProjectException(BaseErrorCode errorCode, Throwable cause) {
-        super(cause);
-        this.errorCode = errorCode;
-    }
 }

--- a/src/main/java/com/insideout/backend/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/insideout/backend/global/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package com.insideout.backend.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .connectTimeout(CONNECT_TIMEOUT)
+                .readTimeout(READ_TIMEOUT)
+                .build();
+    }
+}

--- a/src/main/java/com/insideout/backend/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/insideout/backend/global/config/RestTemplateConfig.java
@@ -14,7 +14,7 @@ public class RestTemplateConfig {
     private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
 
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+    public RestTemplate tmapRestTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
                 .connectTimeout(CONNECT_TIMEOUT)
                 .readTimeout(READ_TIMEOUT)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
         format_sql: true
         use_sql_comments: true
 
+tmap:
+  api:
+    key: ${TMAP_API_KEY:}
+
 server:
   port: 8080
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
 tmap:
   api:
-    key: ${TMAP_API_KEY:}
+    key: "APszqbEk6fCh6gy5dauBltyftW0JZz65YSAOnO10"
 
 server:
   port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
 tmap:
   api:
-    key: "APszqbEk6fCh6gy5dauBltyftW0JZz65YSAOnO10"
+    key: ${TMAP_API_KEY:}
 
 server:
   port: 8080

--- a/src/test/java/com/insideout/backend/BackendApplicationTests.java
+++ b/src/test/java/com/insideout/backend/BackendApplicationTests.java
@@ -1,10 +1,36 @@
 package com.insideout.backend;
 
+import com.insideout.backend.domain.building.repository.BuildingDirectoryRepository;
+import com.insideout.backend.domain.map.repository.NodeRepository;
+import com.insideout.backend.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+        "spring.autoconfigure.exclude="
+                + "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration",
+        "security.jwt.secret=test-secret-key-for-context-loads-123456",
+        "security.jwt.access-token-expiration-ms=3600000",
+        "security.jwt.refresh-token-expiration-ms=1209600000"
+})
 class BackendApplicationTests {
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private NodeRepository nodeRepository;
+
+    @MockitoBean
+    private BuildingDirectoryRepository buildingDirectoryRepository;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -1,0 +1,154 @@
+package com.insideout.backend.domain.navigation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.insideout.backend.domain.map.facade.MapQueryFacade;
+import com.insideout.backend.domain.map.facade.MapQueryFacade.IndoorDestinationAnchor;
+import com.insideout.backend.domain.navigation.dto.NavigationRequestDto;
+import com.insideout.backend.domain.navigation.dto.NavigationRequestDto.RouteType;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.LegDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.LegMode;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteMode;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.StepDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+class NavigationServiceTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Mock
+    private MapQueryFacade mapQueryFacade;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private NavigationService navigationService;
+
+    @BeforeEach
+    void setUp() {
+        navigationService = new NavigationService(mapQueryFacade, restTemplate);
+        ReflectionTestUtils.setField(navigationService, "tmapApiKey", "test-tmap-key");
+    }
+
+    @Test
+    void indoorLegStepUsesOriginalDestinationCoordinates() throws Exception {
+        UUID buildingId = UUID.randomUUID();
+        UUID entranceNodeId = UUID.randomUUID();
+        double originalEndX = 127.1000;
+        double originalEndY = 37.5000;
+        double entranceX = 127.2000;
+        double entranceY = 37.6000;
+
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, originalEndX, originalEndY))
+                .thenReturn(Optional.of(new IndoorDestinationAnchor(
+                        buildingId,
+                        "테스트 건물",
+                        entranceNodeId,
+                        "정문",
+                        entranceX,
+                        entranceY
+                )));
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(walkRouteResponse());
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                originalEndX,
+                originalEndY,
+                "출발지",
+                "실제 목적지",
+                buildingId,
+                true,
+                List.of(RouteType.WALK)
+        ));
+
+        RouteDto route = response.routes().get(0);
+        LegDto indoorLeg = route.legs().get(route.legs().size() - 1);
+        StepDto indoorStep = indoorLeg.steps().get(0);
+
+        assertThat(response.routedDestination().x()).isEqualTo(entranceX);
+        assertThat(response.routedDestination().y()).isEqualTo(entranceY);
+        assertThat(indoorLeg.mode()).isEqualTo(LegMode.INDOOR);
+        assertThat(indoorStep.x()).isEqualTo(originalEndX);
+        assertThat(indoorStep.y()).isEqualTo(originalEndY);
+    }
+
+    @Test
+    void routeLookupFailureIsIsolatedByRouteMode() throws Exception {
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes?version=1&format=json"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenThrow(new RestClientException("TMAP car failure"));
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(walkRouteResponse());
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발지",
+                "목적지",
+                null,
+                false,
+                List.of(RouteType.CAR, RouteType.WALK)
+        ));
+
+        assertThat(response.routes())
+                .extracting(RouteDto::routeType)
+                .containsOnly(RouteMode.WALK);
+        assertThat(response.notFoundRouteTypes()).containsExactly(RouteMode.CAR);
+        assertThat(response.message()).isEqualTo("일부 이동 수단의 경로를 찾을 수 없습니다.");
+    }
+
+    private JsonNode walkRouteResponse() throws Exception {
+        return OBJECT_MAPPER.readTree("""
+                {
+                  "features": [
+                    {
+                      "type": "Feature",
+                      "geometry": {
+                        "type": "Point",
+                        "coordinates": [127.0, 37.0]
+                      },
+                      "properties": {
+                        "description": "도보 이동",
+                        "totalTime": 600,
+                        "totalDistance": 800,
+                        "time": 600,
+                        "distance": 800
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+}

--- a/src/test/java/com/insideout/backend/global/config/RestTemplateConfigTest.java
+++ b/src/test/java/com/insideout/backend/global/config/RestTemplateConfigTest.java
@@ -16,8 +16,8 @@ class RestTemplateConfigTest {
     private final RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
 
     @Test
-    void restTemplateHasConnectAndReadTimeouts() {
-        RestTemplate restTemplate = restTemplateConfig.restTemplate(new RestTemplateBuilder());
+    void tmapRestTemplateHasConnectAndReadTimeouts() {
+        RestTemplate restTemplate = restTemplateConfig.tmapRestTemplate(new RestTemplateBuilder());
 
         assertThat(restTemplate.getRequestFactory()).isInstanceOf(JdkClientHttpRequestFactory.class);
 

--- a/src/test/java/com/insideout/backend/global/config/RestTemplateConfigTest.java
+++ b/src/test/java/com/insideout/backend/global/config/RestTemplateConfigTest.java
@@ -1,0 +1,31 @@
+package com.insideout.backend.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+class RestTemplateConfigTest {
+
+    private final RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
+
+    @Test
+    void restTemplateHasConnectAndReadTimeouts() {
+        RestTemplate restTemplate = restTemplateConfig.restTemplate(new RestTemplateBuilder());
+
+        assertThat(restTemplate.getRequestFactory()).isInstanceOf(JdkClientHttpRequestFactory.class);
+
+        JdkClientHttpRequestFactory requestFactory =
+                (JdkClientHttpRequestFactory) restTemplate.getRequestFactory();
+        HttpClient httpClient = (HttpClient) ReflectionTestUtils.getField(requestFactory, "httpClient");
+        assertThat(httpClient).isNotNull();
+        assertThat(httpClient.connectTimeout()).contains(Duration.ofSeconds(3));
+        assertThat(ReflectionTestUtils.getField(requestFactory, "readTimeout")).isEqualTo(Duration.ofSeconds(10));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #27

## 📝작업 내용

- 티맵 api 연동
- 실외 길찾기-이동수단별 총 소요시간, 총 거리, 턴바이턴 리스트 반환 구현
(대중교통: 티맵 추천 10개 후보 반환 / 자동차: 티맵 추천 경로 & 최소시간 경로 / 도보: 최단거리 & 편안한길로 정의한 최단거리 + 계단제외)
- 응답 DTO 정의
- 실내 이동 고려를 위한 실외 앵커 보정 로직 추가

### 스크린샷 (선택)
<img width="1112" height="494" alt="image" src="https://github.com/user-attachments/assets/8be6302c-d767-426f-a72c-905ca9efbb78" />
<img width="2806" height="1190" alt="image" src="https://github.com/user-attachments/assets/0526b0c1-7723-4667-a13f-d3a6610567a0" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
티맵 api key는 노션 secret .env에 추가해두었습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 실내외 네비게이션 경로 조회 API 추가 (대중교통, 자동차, 도보)
  * 복합 경로 옵션 지원 및 다양한 최적화 옵션(가장 빠른 경로, 최단 거리 등) 제공
  * 실내 네비게이션 통합으로 건물 내부 경로까지 연계 지원

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/insideout-CapstoneDesign/backend/pull/28)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->