### PR TITLE
[feat] 데이터베이스 스키마 수정 (신규 POI 카테고리 추가 설정 및 object 테이블 추가) (#35)

### DIFF
--- a/src/main/resources/db/migration/V8__add_poi_categories_and_floorplan_objects.sql
+++ b/src/main/resources/db/migration/V8__add_poi_categories_and_floorplan_objects.sql
@@ -1,0 +1,112 @@
+-- Add POI icon detection types and editable floorplan objects.
+
+ALTER TABLE ai_detection
+    DROP CONSTRAINT IF EXISTS ai_detection_detect_type_check;
+
+ALTER TABLE ai_detection
+    ADD CONSTRAINT ai_detection_detect_type_check
+        CHECK (detect_type IN (
+            -- Indoor structure
+            'wall',
+            'door',
+            'corridor',
+            'room',
+            'elevator',
+            'stair',
+            'escalator',
+            'restroom_sign',
+
+            -- Outdoor
+            'building',
+            'gate',
+            'road',
+            'sidewalk',
+            'crosswalk',
+            'parking',
+            'landmark',
+
+            -- POI icons
+            'accessible_restroom',
+            'aed',
+            'atm',
+            'cafe',
+            'clothing_alteration',
+            'family_restroom',
+            'infodesk',
+            'phone_charging',
+            'restroom_female',
+            'restroom_male',
+            'shoe_repair',
+            'storage_locker',
+            'subway_station',
+            'water_fountain',
+
+            -- Common
+            'text',
+            'poi_candidate',
+            'node_candidate',
+            'edge_candidate'
+        ));
+
+ALTER TABLE ai_detection
+    DROP CONSTRAINT IF EXISTS ai_detection_committed_entity_type_check;
+
+ALTER TABLE ai_detection
+    ADD CONSTRAINT ai_detection_committed_entity_type_check
+        CHECK (committed_entity_type IN (
+            'node',
+            'edge',
+            'poi',
+            'zone',
+            'floorplan_object'
+        ));
+
+INSERT INTO poi_category (code, path, name_ko)
+VALUES
+    ('facility.accessible_restroom', 'facility.accessible_restroom', '장애인 화장실'),
+    ('facility.aed',                 'facility.aed',                 'AED'),
+    ('facility.escalator',           'facility.escalator',           '에스컬레이터'),
+    ('facility.family_restroom',     'facility.family_restroom',     '가족 화장실'),
+    ('facility.infodesk',            'facility.infodesk',            '안내데스크'),
+    ('facility.phone_charging',      'facility.phone_charging',      '휴대폰 충전'),
+    ('facility.restroom_female',     'facility.restroom_female',     '여자 화장실'),
+    ('facility.restroom_male',       'facility.restroom_male',       '남자 화장실'),
+    ('facility.storage_locker',      'facility.storage_locker',      '물품보관함'),
+    ('facility.subway_station',      'facility.subway_station',      '지하철역'),
+    ('facility.water_fountain',      'facility.water_fountain',      '정수기'),
+    ('facility.atm',                 'facility.atm',                 'ATM'),
+    ('store.clothing_alteration',    'store.clothing_alteration',    '수선실'),
+    ('store.shoe_repair',            'store.shoe_repair',            '구두수선')
+ON CONFLICT (code) DO NOTHING;
+
+CREATE TABLE floorplan_object (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL,
+    map_version_id uuid NOT NULL,
+    floor_id uuid NOT NULL,
+    kind text NOT NULL CHECK (kind IN (
+        'wall',
+        'door',
+        'room_boundary',
+        'corridor_boundary'
+    )),
+    geom_px geometry NOT NULL,
+    properties jsonb NOT NULL DEFAULT '{}'::jsonb,
+    source text NOT NULL DEFAULT 'manual'
+        CHECK (source IN ('ai', 'ai_confirmed', 'manual')),
+    ai_detection_id uuid REFERENCES ai_detection(id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, id),
+    FOREIGN KEY (tenant_id, map_version_id) REFERENCES map_version(tenant_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (tenant_id, floor_id) REFERENCES floor(tenant_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX floorplan_object_geom_gix
+    ON floorplan_object USING GIST (geom_px);
+
+CREATE INDEX floorplan_object_version_idx
+    ON floorplan_object (tenant_id, map_version_id, floor_id);
+
+CREATE INDEX floorplan_object_kind_idx
+    ON floorplan_object (kind);

--- a/src/main/resources/db/migration/V9__fix_floorplan_object_geom_px_srid.sql
+++ b/src/main/resources/db/migration/V9__fix_floorplan_object_geom_px_srid.sql
@@ -1,0 +1,5 @@
+-- Specify the pixel coordinate SRID for editable floorplan object geometry.
+
+ALTER TABLE floorplan_object
+    ALTER COLUMN geom_px TYPE geometry(Geometry, 0)
+    USING ST_SetSRID(geom_px, 0)::geometry(Geometry, 0);


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #35 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

POI로 분류할 수 있는 카테고리를 추가하기 위해 DB 스키마를 수정했습니다.
 
- src/main/resources/db/migration에 V8__expand_poi_detect_types.sql 생성

- 기존 detect_type 값 + 신규 POI 카테고리를 포함해서 CHECK 제약 재생성

- ai_detection.committed_entity_type에 floorplan_object 허용값 추가

- poi_category에 신규 POI 카테고리 추가

- floorplan_object 테이블 추가

- floorplan_object 공간 인덱스 및 조회 인덱스 추가

- 애플리케이션 실행 시 Flyway V8 마이그레이션 정상 적용 확인

+ 코드래빗 리뷰를 반영하여 V9__fix_floorplan_object_geom_px_srid.sql 추가하여 
   geom_px 타입을 보정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * POI(관심장소) 감지 유형 확장: 접근성 화장실, AED, ATM, 지하철역 등 추가
  * 바닥 평면 객체 관리 기능 추가로 실내 매핑 정확도 향상
  * 한국어 POI 카테고리 데이터 추가

* **버그 수정**
  * 바닥 평면 객체의 지오메트리 SRID 처리 수정으로 공간 데이터 일관성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/insideout-CapstoneDesign/backend/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->