### PR TITLE
[feat] places search 위치기반 정렬 및 반경 필터 적용 (#52)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/place/controller/PlaceSearchController.java
+++ b/src/main/java/com/insideout/backend/domain/place/controller/PlaceSearchController.java
@@ -27,9 +27,12 @@ public class PlaceSearchController {
     @Operation(summary = "장소 키워드 검색", description = "키워드로 장소를 검색합니다.")
     @GetMapping("/search")
     public ApiResponse<List<PlaceSearchItemResponse>> search(
-            @RequestParam("q") String query
+            @RequestParam("q") String query,
+            @RequestParam(value = "lat", required = false) Double lat,
+            @RequestParam(value = "lng", required = false) Double lng,
+            @RequestParam(value = "radius", required = false) Integer radius
     ) {
-        return ApiResponse.success(GeneralSuccessCode.OK, placeSearchService.search(query));
+        return ApiResponse.success(GeneralSuccessCode.OK, placeSearchService.search(query, lat, lng, radius));
     }
 
     @Operation(

--- a/src/main/java/com/insideout/backend/domain/place/service/KakaoPlaceSearchClient.java
+++ b/src/main/java/com/insideout/backend/domain/place/service/KakaoPlaceSearchClient.java
@@ -21,16 +21,31 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class KakaoPlaceSearchClient {
 
-    private static final int DEFAULT_SIZE = 10;
+    private static final int DEFAULT_SIZE = 15;
     private final @Qualifier("kakaoLocalRestClient") RestClient kakaoLocalRestClient;
 
     public List<PlaceSearchItemResponse> searchByKeyword(String query) {
+        return searchByKeyword(query, null, null, null);
+    }
+
+    public List<PlaceSearchItemResponse> searchByKeyword(String query, Double lat, Double lng) {
+        return searchByKeyword(query, lat, lng, null);
+    }
+
+    public List<PlaceSearchItemResponse> searchByKeyword(String query, Double lat, Double lng, Integer radius) {
         try {
             KakaoKeywordSearchResponse response = kakaoLocalRestClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path("/v2/local/search/keyword.json")
                             .queryParam("query", query)
                             .queryParam("size", DEFAULT_SIZE)
+                            .queryParamIfPresent("x", Optional.ofNullable(lng))
+                            .queryParamIfPresent("y", Optional.ofNullable(lat))
+                            .queryParamIfPresent("radius", Optional.ofNullable(radius))
+                            .queryParamIfPresent(
+                                    "sort",
+                                    (lat != null && lng != null) ? Optional.of("distance") : Optional.empty()
+                            )
                             .build())
                     .accept(MediaType.APPLICATION_JSON)
                     .retrieve()

--- a/src/main/java/com/insideout/backend/domain/place/service/PlaceSearchService.java
+++ b/src/main/java/com/insideout/backend/domain/place/service/PlaceSearchService.java
@@ -29,6 +29,9 @@ public class PlaceSearchService {
             throw new ProjectException(GeneralErrorCode.BAD_REQUEST);
         }
         if (lat == null && lng == null) {
+            if (radius != null) {
+                throw new PlaceException(PlaceErrorCode.INVALID_COORDINATE);
+            }
             return kakaoPlaceSearchClient.searchByKeyword(query.trim());
         }
 

--- a/src/main/java/com/insideout/backend/domain/place/service/PlaceSearchService.java
+++ b/src/main/java/com/insideout/backend/domain/place/service/PlaceSearchService.java
@@ -9,6 +9,7 @@ import com.insideout.backend.global.apiPayload.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,16 +18,29 @@ import java.util.Optional;
 public class PlaceSearchService {
 
     private static final int DEFAULT_RADIUS_METER = 30;
+    private static final int DEFAULT_SEARCH_RADIUS_METER = 5_000;
     private static final int MIN_RADIUS_METER = 1;
     private static final int MAX_RADIUS_METER = 20_000;
 
     private final KakaoPlaceSearchClient kakaoPlaceSearchClient;
 
-    public List<PlaceSearchItemResponse> search(String query) {
+    public List<PlaceSearchItemResponse> search(String query, Double lat, Double lng, Integer radius) {
         if (query == null || query.isBlank()) {
             throw new ProjectException(GeneralErrorCode.BAD_REQUEST);
         }
-        return kakaoPlaceSearchClient.searchByKeyword(query.trim());
+        if (lat == null && lng == null) {
+            return kakaoPlaceSearchClient.searchByKeyword(query.trim());
+        }
+
+        validateCoordinate(lat, lng);
+        int resolvedRadius = normalizeSearchRadius(radius);
+        return kakaoPlaceSearchClient.searchByKeyword(query.trim(), lat, lng, resolvedRadius).stream()
+                .filter(item -> item.lat() != null && item.lng() != null)
+                .map(item -> new ScoredPlace(item, distanceInMeter(lat, lng, item.lat(), item.lng())))
+                .filter(scored -> scored.distanceMeter() <= resolvedRadius)
+                .sorted(Comparator.comparingDouble(ScoredPlace::distanceMeter))
+                .map(ScoredPlace::item)
+                .toList();
     }
 
     public Optional<PlaceNearestResponse> findNearest(Double lat, Double lng, Integer radius) {
@@ -55,5 +69,31 @@ public class PlaceSearchService {
         }
 
         return radius;
+    }
+
+    private int normalizeSearchRadius(Integer radius) {
+        if (radius == null) {
+            return DEFAULT_SEARCH_RADIUS_METER;
+        }
+
+        if (radius < MIN_RADIUS_METER || radius > MAX_RADIUS_METER) {
+            throw new PlaceException(PlaceErrorCode.INVALID_RADIUS);
+        }
+
+        return radius;
+    }
+
+    private double distanceInMeter(double lat1, double lng1, double lat2, double lng2) {
+        double earthRadius = 6_371_000.0;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return earthRadius * c;
+    }
+
+    private record ScoredPlace(PlaceSearchItemResponse item, double distanceMeter) {
     }
 }

--- a/src/test/java/com/insideout/backend/domain/place/service/PlaceSearchServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/place/service/PlaceSearchServiceTest.java
@@ -50,6 +50,14 @@ class PlaceSearchServiceTest {
     }
 
     @Test
+    void search_withoutCoordinatesButRadius_throwsInvalidCoordinate() {
+        assertThatThrownBy(() -> placeSearchService.search("스타벅스", null, null, 3000))
+                .isInstanceOf(PlaceException.class)
+                .extracting(ex -> ((PlaceException) ex).getErrorCode())
+                .isEqualTo(PlaceErrorCode.INVALID_COORDINATE);
+    }
+
+    @Test
     void search_withCoordinates_usesDistanceSearch() {
         when(kakaoPlaceSearchClient.searchByKeyword("스타벅스", 37.5, 127.0, 5_000))
                 .thenReturn(List.of());

--- a/src/test/java/com/insideout/backend/domain/place/service/PlaceSearchServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/place/service/PlaceSearchServiceTest.java
@@ -1,6 +1,7 @@
 package com.insideout.backend.domain.place.service;
 
 import com.insideout.backend.domain.place.dto.response.PlaceNearestResponse;
+import com.insideout.backend.domain.place.dto.response.PlaceSearchItemResponse;
 import com.insideout.backend.domain.place.exception.PlaceErrorCode;
 import com.insideout.backend.domain.place.exception.PlaceException;
 import com.insideout.backend.global.apiPayload.code.GeneralErrorCode;
@@ -11,10 +12,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,10 +32,85 @@ class PlaceSearchServiceTest {
 
     @Test
     void search_blankQuery_throwsBadRequest() {
-        assertThatThrownBy(() -> placeSearchService.search("   "))
+        assertThatThrownBy(() -> placeSearchService.search("   ", null, null, null))
                 .isInstanceOf(ProjectException.class)
                 .extracting(ex -> ((ProjectException) ex).getErrorCode())
                 .isEqualTo(GeneralErrorCode.BAD_REQUEST);
+    }
+
+    @Test
+    void search_withoutCoordinates_usesKeywordSearch() {
+        when(kakaoPlaceSearchClient.searchByKeyword("스타벅스"))
+                .thenReturn(List.of());
+
+        placeSearchService.search("스타벅스", null, null, null);
+
+        verify(kakaoPlaceSearchClient).searchByKeyword("스타벅스");
+        verify(kakaoPlaceSearchClient, never()).searchByKeyword("스타벅스", 37.5, 127.0, 5_000);
+    }
+
+    @Test
+    void search_withCoordinates_usesDistanceSearch() {
+        when(kakaoPlaceSearchClient.searchByKeyword("스타벅스", 37.5, 127.0, 5_000))
+                .thenReturn(List.of());
+
+        placeSearchService.search("스타벅스", 37.5, 127.0, null);
+
+        verify(kakaoPlaceSearchClient).searchByKeyword("스타벅스", 37.5, 127.0, 5_000);
+    }
+
+    @Test
+    void search_withCoordinatesAndRadius_usesProvidedRadius() {
+        when(kakaoPlaceSearchClient.searchByKeyword("스타벅스", 37.5, 127.0, 1500))
+                .thenReturn(List.of());
+
+        placeSearchService.search("스타벅스", 37.5, 127.0, 1500);
+
+        verify(kakaoPlaceSearchClient).searchByKeyword("스타벅스", 37.5, 127.0, 1500);
+    }
+
+    @Test
+    void search_withCoordinates_filtersByRadiusAndSortsByDistance() {
+        PlaceSearchItemResponse near = new PlaceSearchItemResponse(
+                "근처 매장",
+                "서울시",
+                null,
+                37.5005,
+                127.0005,
+                false,
+                "1"
+        );
+        PlaceSearchItemResponse far = new PlaceSearchItemResponse(
+                "먼 매장",
+                "제주도",
+                null,
+                33.4996,
+                126.5312,
+                false,
+                "2"
+        );
+        when(kakaoPlaceSearchClient.searchByKeyword("스타벅스", 37.5, 127.0, 3000))
+                .thenReturn(List.of(far, near));
+
+        List<PlaceSearchItemResponse> result = placeSearchService.search("스타벅스", 37.5, 127.0, 3000);
+
+        assertThat(result).containsExactly(near);
+    }
+
+    @Test
+    void search_withPartialCoordinates_throwsInvalidCoordinate() {
+        assertThatThrownBy(() -> placeSearchService.search("스타벅스", 37.5, null, null))
+                .isInstanceOf(PlaceException.class)
+                .extracting(ex -> ((PlaceException) ex).getErrorCode())
+                .isEqualTo(PlaceErrorCode.INVALID_COORDINATE);
+    }
+
+    @Test
+    void search_withInvalidRadius_throwsInvalidRadius() {
+        assertThatThrownBy(() -> placeSearchService.search("스타벅스", 37.5, 127.0, 0))
+                .isInstanceOf(PlaceException.class)
+                .extracting(ex -> ((PlaceException) ex).getErrorCode())
+                .isEqualTo(PlaceErrorCode.INVALID_RADIUS);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #52 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `/api/v1/places/search`에 `lat`, `lng`, `radius`(선택) 파라미터 지원 추가했어요
- `lat/lng`가 있으면 거리순 정렬(`sort=distance`) 적용했어요
- `radius` 미전달 시 기본 반경(5000m) 적용했어요
- 서버에서 반경 필터 + 거리 재정렬을 한 번 더 적용해 원거리 결과(예: 타 지역) 제거했어요
- `lat/lng` 한쪽만 전달되거나 잘못된 반경일 때 예외 처리


### 스크린샷 (선택)
해당 좌표의 lat, lng은 동국대 위치 입니다
<img width="991" height="578" alt="스크린샷 2026-05-27 오전 12 21 16" src="https://github.com/user-attachments/assets/e519b453-2319-4c95-afcc-35c596a870e5" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 장소 검색 API가 위도/경도/반경을 선택적으로 받아 좌표 기반 검색을 지원
  * 좌표 제공 시 결과를 거리순으로 정렬하고 지정 반경 내 항목만 반환

* **검증/오류 처리**
  * 반쪽 좌표 또는 반경 단독 제공 등 잘못된 입력에 대해 명확한 검증 오류 발생

* **테스트**
  * 좌표 기반 검색 및 입력 유효성 관련 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/insideout-CapstoneDesign/backend/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->