### PR TITLE
[feat]네비게이션 응답 구조 보강(#55)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/map/entity/MapVersion.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/MapVersion.java
@@ -2,6 +2,7 @@ package com.insideout.backend.domain.map.entity;
 
 import com.insideout.backend.domain.building.entity.Campus;
 import com.insideout.backend.domain.building.entity.Building;
+import com.insideout.backend.domain.map.enums.MapType;
 import com.insideout.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/insideout/backend/domain/map/entity/Node.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Node.java
@@ -114,32 +114,6 @@ public class Node {
         }
     }
 
-    // TODO: Node 생성 시 mapVersion과 floor가 동일한 Building을 참조하는지 반드시 검증해야 합니다.
-    //       LAZY 로딩 특성상 이 생성자 안에서 검증하면 LazyInitializationException이 발생할 수 있으므로,
-    //       NodeService에서 두 엔티티를 완전히 로딩한 후 아래와 같이 검증하고 생성하세요:
-    //
-    //       if (!floor.getBuilding().getId().equals(mapVersion.getBuilding().getId())) {
-    //           throw new MapException(MapErrorCode.BUILDING_MISMATCH);
-    //       }
-
-//    // NodeService 또는 NodeFactory 내부 (트랜잭션 컨텍스트 안)
-//    public Node createNode(CreateNodeRequest request) {
-//        MapVersion mapVersion = mapVersionRepository.findById(request.mapVersionId())
-//                .orElseThrow(...);
-//        Floor floor = floorRepository.findById(request.floorId())
-//                .orElseThrow(...);
-//
-//        // Building 일관성 검증 — 두 엔티티가 이미 로드된 상태이므로 안전
-//        if (!floor.getBuilding().getId().equals(mapVersion.getBuilding().getId())) {
-//            throw new MapException(MapErrorCode.BUILDING_MISMATCH);
-//        }
-//
-//        return nodeRepository.save(Node.builder()
-//                .mapVersion(mapVersion)
-//                .floor(floor)
-//        ...
-//        .build());
-//    }
     @Builder
     public Node(UUID tenantId, MapVersion mapVersion, Floor floor, String kindCode, Point geomPx, Point geomWgs84, String nameKo, Map<String, Object> properties, String source, UUID aiDetectionId) {
         this.tenantId = tenantId;

--- a/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Obstacle.java
@@ -127,23 +127,10 @@ public class Obstacle {
         }
     }
 
-    // TODO: Obstacle 생성 시 아래 불변식을 Service에서 반드시 검증해야 합니다.
-    //       building.getTenant() 및 floor.getBuilding()은 LAZY 로딩 연관 엔티티 호출이므로
-    //       생성자 안에서 호출 시 LazyInitializationException이 발생합니다.
-    //       ObstacleService에서 building, floor를 완전히 로딩한 후 검증하세요:
-    //
-    //       1. tenantId가 building의 tenant와 일치하는지:
-    //          if (!tenantId.equals(building.getTenant().getId()))
-    //              throw new MapException(MapErrorCode.OBSTACLE_TENANT_MISMATCH);
-    //
-    //       2. floor가 building 소속인지:
-    //          if (!floor.getBuilding().getId().equals(building.getId()))
-    //              throw new MapException(MapErrorCode.OBSTACLE_BUILDING_MISMATCH);
     @Builder
     public Obstacle(UUID tenantId, Building building, Campus campus, Floor floor, String kind, Geometry geomPx, List<UUID> affectedEdgeIds, BigDecimal extraCost, boolean isBlocking, OffsetDateTime activeFrom, OffsetDateTime activeTo, String note) {
         BigDecimal finalExtraCost = extraCost != null ? extraCost : BigDecimal.ZERO;
 
-        // 필수 필드 null 선검증 (DB nullable=false 콜럼과 동기화)
         Objects.requireNonNull(tenantId, "tenantId must not be null");
         Objects.requireNonNull(kind, "kind must not be null");
 
@@ -160,7 +147,6 @@ public class Obstacle {
         if (activeFrom != null && activeTo != null && activeFrom.isAfter(activeTo)) {
             throw new MapException(MapErrorCode.INVALID_ACTIVE_PERIOD);
         }
-        // floor.getTenantId()는 UUID 직접 필드이므로 생성자에서 안전하게 검증 가능
         if (floor != null && floor.getTenantId() != null
                 && !tenantId.equals(floor.getTenantId())) {
             throw new MapException(MapErrorCode.OBSTACLE_TENANT_MISMATCH);

--- a/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
@@ -138,13 +138,6 @@ public class Poi {
         }
     }
 
-    // TODO: Poi 생성 시 mapVersion과 floor가 동일한 Building을 참조하는지 반드시 검증해야 합니다.
-    //       Node와 동일한 이유(LAZY 로딩)로 생성자 안에서 검증하면 LazyInitializationException이 발생합니다.
-    //       PoiService에서 두 엔티티를 완전히 로딩한 후 아래와 같이 검증하고 생성하세요:
-    //
-    //       if (!floor.getBuilding().getId().equals(mapVersion.getBuilding().getId())) {
-    //           throw new MapException(MapErrorCode.BUILDING_MISMATCH);
-    //       }
     @Builder
     public Poi(UUID tenantId, MapVersion mapVersion, Floor floor, Long categoryId, String name, String code, Point geomPx, Polygon footprintPx, Point geomWgs84, UUID anchorNodeId, List<String> tags, Map<String, Object> attrs, String externalApiId, String source, UUID aiDetectionId) {
         this.tenantId = tenantId;

--- a/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNode.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/VerticalConnectorNode.java
@@ -44,21 +44,6 @@ public class VerticalConnectorNode {
     @JoinColumn(name = "floor_id", nullable = false)
     private Floor floor;
 
-    // TODO: VerticalConnectorNode 생성 시 아래 3가지 불변식을 Service에서 반드시 검증해야 합니다.
-    //       LAZY 로딩 특성상 이 생성자 안에서 연관 엔티티를 호출하면 LazyInitializationException이 발생합니다.
-    //       Service에서 connector, node, floor를 완전히 로딩한 후 검증하세요:
-    //
-    //       1. floor가 node의 floor와 일치하는지:
-    //          if (!node.getFloor().getId().equals(floor.getId()))
-    //              throw new MapException(MapErrorCode.VERTICAL_CONNECTOR_FLOOR_MISMATCH);
-    //
-    //       2. tenantId가 connector의 tenantId와 일치하는지:
-    //          if (!tenantId.equals(connector.getTenantId()))
-    //              throw new MapException(MapErrorCode.VERTICAL_CONNECTOR_TENANT_MISMATCH);
-    //
-    //       3. tenantId가 node의 tenantId와 일치하는지:
-    //          if (!tenantId.equals(node.getTenantId()))
-    //              throw new MapException(MapErrorCode.VERTICAL_CONNECTOR_TENANT_MISMATCH);
     @Builder
     public VerticalConnectorNode(UUID tenantId, VerticalConnector connector, Node node, Floor floor) {
         this.tenantId = tenantId;

--- a/src/main/java/com/insideout/backend/domain/map/entity/Zone.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Zone.java
@@ -84,18 +84,6 @@ public class Zone {
         }
     }
 
-    // TODO: Zone 생성 시 아래 불변식을 Service에서 반드시 검증해야 합니다.
-    //       mapVersion.getTenantId() 및 floor.getTenantId()는 LAZY 로딩 연관 엔티티 호출이므로
-    //       @PrePersist/@PreUpdate 또는 생성자 안에서 호출 시 LazyInitializationException이 발생합니다.
-    //       Service에서 mapVersion, floor를 완전히 로딩한 후 검증하세요:
-    //
-    //       1. tenantId가 mapVersion의 tenantId와 일치하는지:
-    //          if (!tenantId.equals(mapVersion.getTenantId()))
-    //              throw new MapException(MapErrorCode.ZONE_TENANT_MISMATCH);
-    //
-    //       2. tenantId가 floor의 tenantId와 일치하는지:
-    //          if (!tenantId.equals(floor.getTenantId()))
-    //              throw new MapException(MapErrorCode.ZONE_TENANT_MISMATCH);
     @Builder
     public Zone(UUID tenantId, MapVersion mapVersion, Floor floor, ZoneKind kind, String name, Polygon geomPx, Map<String, Object> properties) {
         this.tenantId = Objects.requireNonNull(tenantId, "tenantId must not be null");

--- a/src/main/java/com/insideout/backend/domain/map/enums/MapType.java
+++ b/src/main/java/com/insideout/backend/domain/map/enums/MapType.java
@@ -1,4 +1,4 @@
-package com.insideout.backend.domain.map.entity;
+package com.insideout.backend.domain.map.enums;
 
 public enum MapType {
     CAMPUS,

--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -7,13 +7,13 @@ import com.insideout.backend.domain.building.entity.BuildingDirectory;
 import com.insideout.backend.domain.building.repository.BuildingRepository;
 import com.insideout.backend.domain.building.repository.BuildingDirectoryRepository;
 import com.insideout.backend.domain.map.entity.Edge;
-import com.insideout.backend.domain.map.entity.MapType;
 import com.insideout.backend.domain.map.entity.MapVersion;
 import com.insideout.backend.domain.map.entity.Node;
 import com.insideout.backend.domain.map.entity.Obstacle;
 import com.insideout.backend.domain.map.entity.Poi;
 import com.insideout.backend.domain.map.entity.VerticalConnector;
 import com.insideout.backend.domain.map.entity.VerticalConnectorNode;
+import com.insideout.backend.domain.map.enums.MapType;
 import com.insideout.backend.domain.map.repository.EdgeRepository;
 import com.insideout.backend.domain.map.repository.MapVersionRepository;
 import com.insideout.backend.domain.map.repository.NodeRepository;
@@ -21,6 +21,7 @@ import com.insideout.backend.domain.map.repository.ObstacleRepository;
 import com.insideout.backend.domain.map.repository.PoiRepository;
 import com.insideout.backend.domain.map.repository.VerticalConnectorNodeRepository;
 import com.insideout.backend.domain.map.storage.MapAssetStorage;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
@@ -46,7 +47,6 @@ public class MapQueryFacade {
 
     private static final double REGISTERED_BUILDING_SEARCH_RADIUS_METERS = 50.0;
 
-    // 내부적으로 자기 도메인의 Repository는 자유롭게 주입받아 사용합니다.
     private final NodeRepository nodeRepository;
     private final BuildingDirectoryRepository buildingDirectoryRepository;
     private final BuildingRepository buildingRepository;
@@ -133,41 +133,41 @@ public class MapQueryFacade {
                 .flatMap(this::toVerticalRoutingLinks)
                 .toList();
 
-        return new RoutingGraph(
-                mapVersion.getId(),
-                mapType,
-                resolveMapImageUrl(mapType, ownerId),
-                nodes,
-                edges,
-                verticalLinks,
-                findActiveObstacles(mapType, ownerId)
-        );
+        return RoutingGraph.builder()
+                .mapVersionId(mapVersion.getId())
+                .mapType(mapType)
+                .mapImageUrl(resolveMapImageUrl(mapType, ownerId))
+                .nodes(nodes)
+                .edges(edges)
+                .verticalLinks(verticalLinks)
+                .obstacles(findActiveObstacles(mapType, ownerId))
+                .build();
     }
 
     private RoutingNode toRoutingNode(Node node) {
         Point point = node.getGeomPx();
         Floor floor = node.getFloor();
-        return new RoutingNode(
-                node.getId(),
-                node.getKindCode(),
-                node.getNameKo(),
-                floor == null ? null : floor.getId(),
-                floor == null ? null : floor.getName(),
-                point.getX(),
-                point.getY()
-        );
+        return RoutingNode.builder()
+                .id(node.getId())
+                .kind(node.getKindCode())
+                .name(node.getNameKo())
+                .floorId(floor == null ? null : floor.getId())
+                .floorName(floor == null ? null : floor.getName())
+                .x(point.getX())
+                .y(point.getY())
+                .build();
     }
 
     private RoutingEdge toRoutingEdge(Edge edge) {
-        return new RoutingEdge(
-                edge.getId(),
-                edge.getFromNode().getId(),
-                edge.getToNode().getId(),
-                edge.getKindCode(),
-                edge.isDirected(),
-                decimalToDouble(edge.getLengthM()),
-                decimalToDouble(edge.getBaseWeight())
-        );
+        return RoutingEdge.builder()
+                .id(edge.getId())
+                .fromNodeId(edge.getFromNode().getId())
+                .toNodeId(edge.getToNode().getId())
+                .kind(edge.getKindCode())
+                .directed(edge.isDirected())
+                .length(decimalToDouble(edge.getLengthM()))
+                .baseWeight(decimalToDouble(edge.getBaseWeight()))
+                .build();
     }
 
     private java.util.stream.Stream<VerticalRoutingLink> toVerticalRoutingLinks(List<VerticalConnectorNode> nodes) {
@@ -179,15 +179,15 @@ public class MapQueryFacade {
 
     private VerticalRoutingLink toVerticalRoutingLink(VerticalConnectorNode from, VerticalConnectorNode to) {
         VerticalConnector connector = from.getConnector();
-        return new VerticalRoutingLink(
-                from.getNode().getId(),
-                to.getNode().getId(),
-                connector.getKind(),
-                connector.getName(),
-                from.getFloor().getName(),
-                to.getFloor().getName(),
-                connector.getAvgWaitSeconds()
-        );
+        return VerticalRoutingLink.builder()
+                .fromNodeId(from.getNode().getId())
+                .toNodeId(to.getNode().getId())
+                .connectorKind(connector.getKind())
+                .connectorName(connector.getName())
+                .fromFloorName(from.getFloor().getName())
+                .toFloorName(to.getFloor().getName())
+                .avgWaitSeconds(connector.getAvgWaitSeconds())
+                .build();
     }
 
     private String resolveMapImageUrl(MapType mapType, UUID ownerId) {
@@ -212,11 +212,11 @@ public class MapQueryFacade {
     }
 
     private RoutingObstacle toRoutingObstacle(Obstacle obstacle) {
-        return new RoutingObstacle(
-                obstacle.getAffectedEdgeIds() == null ? List.of() : obstacle.getAffectedEdgeIds(),
-                decimalToDouble(obstacle.getExtraCost()),
-                obstacle.isBlocking()
-        );
+        return RoutingObstacle.builder()
+                .affectedEdgeIds(obstacle.getAffectedEdgeIds() == null ? List.of() : obstacle.getAffectedEdgeIds())
+                .extraCost(decimalToDouble(obstacle.getExtraCost()))
+                .blocking(obstacle.isBlocking())
+                .build();
     }
 
     private double decimalToDouble(BigDecimal value) {
@@ -233,19 +233,19 @@ public class MapQueryFacade {
         Campus campus = buildingEntity.map(Building::getCampus).orElse(null);
         Point campusEntrance = campus == null ? null : campus.getPrimaryEntrance();
 
-        return Optional.of(new IndoorDestinationAnchor(
-                campus == null ? null : campus.getId(),
-                campus == null ? null : campus.getName(),
-                campus == null ? null : campus.getPrimaryEntranceName(),
-                campusEntrance == null ? null : campusEntrance.getX(),
-                campusEntrance == null ? null : campusEntrance.getY(),
-                building.getId(),
-                building.getName(),
-                node.getId(),
-                node.getNameKo(),
-                point.getX(),
-                point.getY()
-        ));
+        return Optional.of(IndoorDestinationAnchor.builder()
+                .campusId(campus == null ? null : campus.getId())
+                .campusName(campus == null ? null : campus.getName())
+                .campusEntranceName(campus == null ? null : campus.getPrimaryEntranceName())
+                .campusEntranceX(campusEntrance == null ? null : campusEntrance.getX())
+                .campusEntranceY(campusEntrance == null ? null : campusEntrance.getY())
+                .buildingId(building.getId())
+                .buildingName(building.getName())
+                .entranceNodeId(node.getId())
+                .entranceName(node.getNameKo())
+                .x(point.getX())
+                .y(point.getY())
+                .build());
     }
 
     private Optional<IndoorPoiDestination> toIndoorPoiDestination(Poi poi) {
@@ -260,20 +260,21 @@ public class MapQueryFacade {
         }
 
         Campus campus = building.getCampus();
-        return Optional.of(new IndoorPoiDestination(
-                poi.getPublicId(),
-                poi.getId(),
-                poi.getName(),
-                poi.getAnchorNodeId(),
-                floor.getId(),
-                floor.getName(),
-                building.getId(),
-                building.getName(),
-                campus == null ? null : campus.getId(),
-                campus == null ? null : campus.getName()
-        ));
+        return Optional.of(IndoorPoiDestination.builder()
+                .publicId(poi.getPublicId())
+                .poiId(poi.getId())
+                .name(poi.getName())
+                .anchorNodeId(poi.getAnchorNodeId())
+                .floorId(floor.getId())
+                .floorName(floor.getName())
+                .buildingId(building.getId())
+                .buildingName(building.getName())
+                .campusId(campus == null ? null : campus.getId())
+                .campusName(campus == null ? null : campus.getName())
+                .build());
     }
 
+    @Builder
     public record IndoorDestinationAnchor(
             UUID campusId,
             String campusName,
@@ -324,6 +325,7 @@ public class MapQueryFacade {
         }
     }
 
+    @Builder
     public record IndoorPoiDestination(
             Long publicId,
             UUID poiId,
@@ -341,6 +343,7 @@ public class MapQueryFacade {
         }
     }
 
+    @Builder
     public record RoutingGraph(
             UUID mapVersionId,
             MapType mapType,
@@ -355,6 +358,7 @@ public class MapQueryFacade {
         }
     }
 
+    @Builder
     public record RoutingNode(
             UUID id,
             String kind,
@@ -369,6 +373,7 @@ public class MapQueryFacade {
         }
     }
 
+    @Builder
     public record RoutingEdge(
             UUID id,
             UUID fromNodeId,
@@ -380,6 +385,7 @@ public class MapQueryFacade {
     ) {
     }
 
+    @Builder
     public record RoutingObstacle(
             List<UUID> affectedEdgeIds,
             double extraCost,
@@ -387,6 +393,7 @@ public class MapQueryFacade {
     ) {
     }
 
+    @Builder
     public record VerticalRoutingLink(
             UUID fromNodeId,
             UUID toNodeId,
@@ -400,11 +407,4 @@ public class MapQueryFacade {
             return connectorName == null || connectorName.isBlank() ? connectorKind : connectorName;
         }
     }
-
-    /*
-    // 예시: Navigation 팀원이 호출할 메서드 껍데기
-    public List<Node> getNodesForRouting(UUID mapVersionId) {
-        return nodeRepository.findByMapVersionId(mapVersionId);
-    }
-    */
 }

--- a/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
@@ -1,7 +1,7 @@
 package com.insideout.backend.domain.map.repository;
 
 import com.insideout.backend.domain.map.entity.MapVersion;
-import com.insideout.backend.domain.map.entity.MapType;
+import com.insideout.backend.domain.map.enums.MapType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/insideout/backend/domain/map/storage/MapAssetDescriptor.java
+++ b/src/main/java/com/insideout/backend/domain/map/storage/MapAssetDescriptor.java
@@ -1,6 +1,6 @@
 package com.insideout.backend.domain.map.storage;
 
-import com.insideout.backend.domain.map.entity.MapType;
+import com.insideout.backend.domain.map.enums.MapType;
 
 import java.util.UUID;
 

--- a/src/main/java/com/insideout/backend/domain/map/storage/MapAssetStorage.java
+++ b/src/main/java/com/insideout/backend/domain/map/storage/MapAssetStorage.java
@@ -1,6 +1,6 @@
 package com.insideout.backend.domain.map.storage;
 
-import com.insideout.backend.domain.map.entity.MapType;
+import com.insideout.backend.domain.map.enums.MapType;
 
 import java.util.Optional;
 import java.util.UUID;

--- a/src/main/java/com/insideout/backend/domain/map/storage/S3MapAssetStorage.java
+++ b/src/main/java/com/insideout/backend/domain/map/storage/S3MapAssetStorage.java
@@ -4,7 +4,7 @@ import com.insideout.backend.domain.building.entity.CampusMap;
 import com.insideout.backend.domain.building.entity.Floorplan;
 import com.insideout.backend.domain.building.repository.CampusMapRepository;
 import com.insideout.backend.domain.building.repository.FloorplanRepository;
-import com.insideout.backend.domain.map.entity.MapType;
+import com.insideout.backend.domain.map.enums.MapType;
 import com.insideout.backend.global.infra.storage.service.S3StorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
@@ -90,6 +90,7 @@ public record NavigationResponseDto(
             String floorName,
             CoordinateType coordinateType,
             List<CoordinateDto> path,
+            List<FloorSegmentDto> floorSegments,
             List<StepDto> steps
     ) {
         public LegDto(
@@ -104,8 +105,19 @@ public record NavigationResponseDto(
                 List<StepDto> steps
         ) {
             this(mode, routeName, transitType, durationSeconds, distanceMeters, stationCount,
-                    startName, endName, null, null, null, null, null, null, steps);
+                    startName, endName, null, null, null, null, null, null, List.of(), steps);
         }
+    }
+
+    public record FloorSegmentDto(
+            MapType mapType,
+            UUID floorId,
+            String floorName,
+            String mapImageUrl,
+            CoordinateType coordinateType,
+            List<CoordinateDto> path,
+            List<StepDto> steps
+    ) {
     }
 
     public record StepDto(

--- a/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
@@ -1,6 +1,6 @@
 package com.insideout.backend.domain.navigation.dto;
 
-import com.insideout.backend.domain.map.entity.MapType;
+import com.insideout.backend.domain.map.enums.MapType;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -785,7 +785,7 @@ public class NavigationService {
             int endIndex = startIndex + 1;
 
             while (endIndex < route.nodes().size()
-                    && sameFloor(route.nodes().get(endIndex).floorId(), startNode.floorId())) {
+                    && sameFloor(firstNonNull(route.nodes().get(endIndex).floorId(), fallbackFloorId), segmentFloorId)) {
                 endIndex++;
             }
 
@@ -801,7 +801,7 @@ public class NavigationService {
                     resolveSegmentMapImageUrl(segmentFloorId, fallbackMapImageUrl, floorImageUrlCache),
                     CoordinateType.PIXEL,
                     segmentPath,
-                    filterStepsForNodes(route.steps(), segmentNodes)
+                    stepsForNodeRange(route.steps(), startIndex, endIndex, route.nodes().size())
             ));
 
             startIndex = endIndex;
@@ -820,23 +820,25 @@ public class NavigationService {
         );
     }
 
-    private List<StepDto> filterStepsForNodes(List<StepDto> steps, List<RoutingNode> nodes) {
-        if (steps.isEmpty() || nodes.isEmpty()) {
+    private List<StepDto> stepsForNodeRange(List<StepDto> steps, int startIndex, int endIndex, int nodeCount) {
+        if (steps.isEmpty() || startIndex >= endIndex) {
             return List.of();
         }
 
-        return steps.stream()
-                .filter(step -> step.x() != null && step.y() != null)
-                .filter(step -> nodes.stream().anyMatch(node -> samePixel(node.x(), step.x()) && samePixel(node.y(), step.y())))
-                .toList();
+        int fromIndex = Math.min(Math.max(startIndex, 0), steps.size());
+        int toIndex = Math.min(endIndex, steps.size());
+        List<StepDto> segmentSteps = new ArrayList<>(steps.subList(fromIndex, toIndex));
+
+        int arrivalStepIndex = nodeCount;
+        if (endIndex == nodeCount && arrivalStepIndex < steps.size()) {
+            segmentSteps.add(steps.get(arrivalStepIndex));
+        }
+
+        return segmentSteps;
     }
 
     private boolean sameFloor(UUID first, UUID second) {
         return first == null ? second == null : first.equals(second);
-    }
-
-    private boolean samePixel(double first, double second) {
-        return Math.abs(first - second) < 0.000001;
     }
 
     private LegDto createFallbackCampusLeg(RouteTarget target) {

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -9,7 +9,7 @@ import com.insideout.backend.domain.map.facade.MapQueryFacade.RoutingGraph;
 import com.insideout.backend.domain.map.facade.MapQueryFacade.RoutingNode;
 import com.insideout.backend.domain.map.facade.MapQueryFacade.RoutingObstacle;
 import com.insideout.backend.domain.map.facade.MapQueryFacade.VerticalRoutingLink;
-import com.insideout.backend.domain.map.entity.MapType;
+import com.insideout.backend.domain.map.enums.MapType;
 import com.insideout.backend.domain.navigation.dto.NavigationRequestDto;
 import com.insideout.backend.domain.navigation.dto.NavigationRequestDto.RouteType;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto;

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -15,6 +15,7 @@ import com.insideout.backend.domain.navigation.dto.NavigationRequestDto.RouteTyp
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.CoordinateType;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.CoordinateDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.FloorSegmentDto;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.IndoorInfoDto;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.LegDto;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.LegMode;
@@ -744,8 +745,98 @@ public class NavigationService {
                 floorName,
                 CoordinateType.PIXEL,
                 route.path(),
+                buildFloorSegments(mode, mapType, mapImageUrl, floorId, floorName, route),
                 route.steps()
         );
+    }
+
+    private List<FloorSegmentDto> buildFloorSegments(
+            LegMode mode,
+            MapType mapType,
+            String fallbackMapImageUrl,
+            UUID fallbackFloorId,
+            String fallbackFloorName,
+            ComputedIndoorRoute route
+    ) {
+        if (route.nodes().isEmpty()) {
+            return List.of();
+        }
+
+        if (mapType == MapType.CAMPUS || mode == LegMode.CAMPUS) {
+            return List.of(new FloorSegmentDto(
+                    mapType,
+                    null,
+                    null,
+                    fallbackMapImageUrl,
+                    CoordinateType.PIXEL,
+                    route.path(),
+                    route.steps()
+            ));
+        }
+
+        List<FloorSegmentDto> segments = new ArrayList<>();
+        Map<UUID, String> floorImageUrlCache = new HashMap<>();
+        int startIndex = 0;
+
+        while (startIndex < route.nodes().size()) {
+            RoutingNode startNode = route.nodes().get(startIndex);
+            UUID segmentFloorId = firstNonNull(startNode.floorId(), fallbackFloorId);
+            String segmentFloorName = firstNonNull(startNode.floorName(), fallbackFloorName);
+            int endIndex = startIndex + 1;
+
+            while (endIndex < route.nodes().size()
+                    && sameFloor(route.nodes().get(endIndex).floorId(), startNode.floorId())) {
+                endIndex++;
+            }
+
+            List<RoutingNode> segmentNodes = route.nodes().subList(startIndex, endIndex);
+            List<CoordinateDto> segmentPath = segmentNodes.stream()
+                    .map(node -> new CoordinateDto(node.x(), node.y(), node.displayName()))
+                    .toList();
+
+            segments.add(new FloorSegmentDto(
+                    mapType,
+                    segmentFloorId,
+                    segmentFloorName,
+                    resolveSegmentMapImageUrl(segmentFloorId, fallbackMapImageUrl, floorImageUrlCache),
+                    CoordinateType.PIXEL,
+                    segmentPath,
+                    filterStepsForNodes(route.steps(), segmentNodes)
+            ));
+
+            startIndex = endIndex;
+        }
+
+        return segments;
+    }
+
+    private String resolveSegmentMapImageUrl(UUID floorId, String fallbackMapImageUrl, Map<UUID, String> cache) {
+        if (floorId == null) {
+            return fallbackMapImageUrl;
+        }
+        return cache.computeIfAbsent(
+                floorId,
+                key -> mapQueryFacade.findCurrentFloorplanImageUrl(key).orElse(fallbackMapImageUrl)
+        );
+    }
+
+    private List<StepDto> filterStepsForNodes(List<StepDto> steps, List<RoutingNode> nodes) {
+        if (steps.isEmpty() || nodes.isEmpty()) {
+            return List.of();
+        }
+
+        return steps.stream()
+                .filter(step -> step.x() != null && step.y() != null)
+                .filter(step -> nodes.stream().anyMatch(node -> samePixel(node.x(), step.x()) && samePixel(node.y(), step.y())))
+                .toList();
+    }
+
+    private boolean sameFloor(UUID first, UUID second) {
+        return first == null ? second == null : first.equals(second);
+    }
+
+    private boolean samePixel(double first, double second) {
+        return Math.abs(first - second) < 0.000001;
     }
 
     private LegDto createFallbackCampusLeg(RouteTarget target) {
@@ -763,6 +854,7 @@ public class NavigationService {
                 null,
                 null,
                 CoordinateType.PIXEL,
+                List.of(),
                 List.of(),
                 List.of(new StepDto("경로를 찾을 수 없습니다.", null, null, target.buildingEntranceX(), target.buildingEntranceY(), null, "CAMPUS", null))
         );
@@ -788,6 +880,7 @@ public class NavigationService {
                 floorName,
                 CoordinateType.PIXEL,
                 List.of(),
+                List.of(),
                 List.of(new StepDto("경로를 찾을 수 없습니다.", null, null, target.originalEndX(), target.originalEndY(), null, "INDOOR", null))
         );
     }
@@ -812,6 +905,7 @@ public class NavigationService {
                 floorName,
                 CoordinateType.PIXEL,
                 List.of(),
+                List.of(),
                 List.of(new StepDto("경로를 찾을 수 없습니다.", null, null, target.buildingEntranceX(), target.buildingEntranceY(), null, "INDOOR", null))
         );
     }
@@ -831,6 +925,7 @@ public class NavigationService {
                 null,
                 null,
                 CoordinateType.PIXEL,
+                List.of(),
                 List.of(),
                 List.of(new StepDto("경로를 찾을 수 없습니다.", null, null, target.resolvedOutdoorStartX(), target.resolvedOutdoorStartY(), null, "CAMPUS", null))
         );
@@ -898,7 +993,7 @@ public class NavigationService {
                 .map(node -> new CoordinateDto(node.x(), node.y(), node.displayName()))
                 .toList();
         List<StepDto> steps = buildIndoorSteps(routeNodes, links);
-        return Optional.of(new ComputedIndoorRoute(path, steps));
+        return Optional.of(new ComputedIndoorRoute(path, steps, routeNodes));
     }
 
     private Map<UUID, List<RouteLink>> buildAdjacency(
@@ -1159,7 +1254,7 @@ public class NavigationService {
         }
     }
 
-    private Double firstNonNull(Double first, Double second) {
+    private <T> T firstNonNull(T first, T second) {
         return first != null ? first : second;
     }
 
@@ -1203,7 +1298,8 @@ public class NavigationService {
 
     private record ComputedIndoorRoute(
             List<CoordinateDto> path,
-            List<StepDto> steps
+            List<StepDto> steps,
+            List<RoutingNode> nodes
     ) {
     }
 

--- a/src/test/java/com/insideout/backend/domain/map/storage/S3MapAssetStorageTest.java
+++ b/src/test/java/com/insideout/backend/domain/map/storage/S3MapAssetStorageTest.java
@@ -11,7 +11,7 @@ import com.insideout.backend.domain.building.entity.CampusMap;
 import com.insideout.backend.domain.building.entity.Floorplan;
 import com.insideout.backend.domain.building.repository.CampusMapRepository;
 import com.insideout.backend.domain.building.repository.FloorplanRepository;
-import com.insideout.backend.domain.map.entity.MapType;
+import com.insideout.backend.domain.map.enums.MapType;
 import com.insideout.backend.global.infra.storage.service.S3StorageService;
 import java.time.Duration;
 import java.util.Optional;

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -14,7 +14,7 @@ import com.insideout.backend.domain.map.facade.MapQueryFacade.RoutingEdge;
 import com.insideout.backend.domain.map.facade.MapQueryFacade.RoutingGraph;
 import com.insideout.backend.domain.map.facade.MapQueryFacade.RoutingNode;
 import com.insideout.backend.domain.map.facade.MapQueryFacade.VerticalRoutingLink;
-import com.insideout.backend.domain.map.entity.MapType;
+import com.insideout.backend.domain.map.enums.MapType;
 import com.insideout.backend.domain.navigation.dto.NavigationRequestDto;
 import com.insideout.backend.domain.navigation.dto.NavigationRequestDto.RouteType;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto;

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -10,6 +10,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.insideout.backend.domain.map.facade.MapQueryFacade;
 import com.insideout.backend.domain.map.facade.MapQueryFacade.IndoorDestinationAnchor;
 import com.insideout.backend.domain.map.facade.MapQueryFacade.IndoorPoiDestination;
+import com.insideout.backend.domain.map.facade.MapQueryFacade.RoutingEdge;
+import com.insideout.backend.domain.map.facade.MapQueryFacade.RoutingGraph;
+import com.insideout.backend.domain.map.facade.MapQueryFacade.RoutingNode;
+import com.insideout.backend.domain.map.facade.MapQueryFacade.VerticalRoutingLink;
+import com.insideout.backend.domain.map.entity.MapType;
 import com.insideout.backend.domain.navigation.dto.NavigationRequestDto;
 import com.insideout.backend.domain.navigation.dto.NavigationRequestDto.RouteType;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto;
@@ -193,6 +198,107 @@ class NavigationServiceTest {
         assertThat(response.failures())
                 .extracting(RouteFailureDto::routeOption)
                 .containsOnly(RouteOption.TRANSIT_CANDIDATE);
+    }
+
+    @Test
+    void indoorLegSplitsPathByFloorSegments() throws Exception {
+        UUID buildingId = UUID.randomUUID();
+        UUID mapVersionId = UUID.randomUUID();
+        UUID entranceNodeId = UUID.randomUUID();
+        UUID firstFloorConnectorNodeId = UUID.randomUUID();
+        UUID secondFloorConnectorNodeId = UUID.randomUUID();
+        UUID destinationNodeId = UUID.randomUUID();
+        UUID firstFloorId = UUID.randomUUID();
+        UUID secondFloorId = UUID.randomUUID();
+        Long destinationPoiId = 1001L;
+
+        when(mapQueryFacade.findIndoorPoiDestination(null)).thenReturn(Optional.empty());
+        when(mapQueryFacade.findIndoorPoiDestination(destinationPoiId))
+                .thenReturn(Optional.of(new IndoorPoiDestination(
+                        destinationPoiId,
+                        UUID.randomUUID(),
+                        "목적지 POI",
+                        destinationNodeId,
+                        secondFloorId,
+                        "2F",
+                        buildingId,
+                        "테스트 건물",
+                        null,
+                        null
+                )));
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000))
+                .thenReturn(Optional.of(new IndoorDestinationAnchor(
+                        buildingId,
+                        "테스트 건물",
+                        entranceNodeId,
+                        "정문",
+                        127.2000,
+                        37.6000
+                )));
+        when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
+                .thenReturn(Optional.of(new RoutingGraph(
+                        mapVersionId,
+                        MapType.BUILDING,
+                        "https://signed.example/fallback.png",
+                        List.of(
+                                new RoutingNode(entranceNodeId, "entrance", "정문", firstFloorId, "1F", 10, 10),
+                                new RoutingNode(firstFloorConnectorNodeId, "elevator", "엘리베이터", firstFloorId, "1F", 20, 20),
+                                new RoutingNode(secondFloorConnectorNodeId, "elevator", "엘리베이터", secondFloorId, "2F", 30, 30),
+                                new RoutingNode(destinationNodeId, "poi", "목적지 POI", secondFloorId, "2F", 40, 40)
+                        ),
+                        List.of(
+                                new RoutingEdge(UUID.randomUUID(), entranceNodeId, firstFloorConnectorNodeId, "corridor", false, 10, 1),
+                                new RoutingEdge(UUID.randomUUID(), secondFloorConnectorNodeId, destinationNodeId, "corridor", false, 10, 1)
+                        ),
+                        List.of(new VerticalRoutingLink(
+                                firstFloorConnectorNodeId,
+                                secondFloorConnectorNodeId,
+                                "elevator",
+                                "엘리베이터",
+                                "1F",
+                                "2F",
+                                10
+                        )),
+                        List.of()
+                )));
+        when(mapQueryFacade.findCurrentFloorplanImageUrl(firstFloorId))
+                .thenReturn(Optional.of("https://signed.example/1f.png"));
+        when(mapQueryFacade.findCurrentFloorplanImageUrl(secondFloorId))
+                .thenReturn(Optional.of("https://signed.example/2f.png"));
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(walkRouteResponse());
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발지",
+                "목적지",
+                buildingId,
+                destinationPoiId,
+                true,
+                List.of(RouteType.WALK)
+        ));
+
+        LegDto indoorLeg = response.routes().get(0).legs().stream()
+                .filter(leg -> leg.mode() == LegMode.INDOOR)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(indoorLeg.path()).hasSize(4);
+        assertThat(indoorLeg.floorSegments()).hasSize(2);
+        assertThat(indoorLeg.floorSegments())
+                .extracting(segment -> segment.floorId())
+                .containsExactly(firstFloorId, secondFloorId);
+        assertThat(indoorLeg.floorSegments())
+                .extracting(segment -> segment.mapImageUrl())
+                .containsExactly("https://signed.example/1f.png", "https://signed.example/2f.png");
+        assertThat(indoorLeg.floorSegments().get(0).path()).hasSize(2);
+        assertThat(indoorLeg.floorSegments().get(1).path()).hasSize(2);
     }
 
     private JsonNode walkRouteResponse() throws Exception {

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -212,7 +212,7 @@ class NavigationServiceTest {
                         .nodes(List.of(
                                 routingNode(entranceNodeId, "entrance", "정문", firstFloorId, "1F", 10, 10),
                                 routingNode(firstFloorConnectorNodeId, "elevator", "엘리베이터", firstFloorId, "1F", 20, 20),
-                                routingNode(secondFloorConnectorNodeId, "elevator", "엘리베이터", secondFloorId, "2F", 30, 30),
+                                routingNode(secondFloorConnectorNodeId, "elevator", "엘리베이터", secondFloorId, "2F", 20, 20),
                                 routingNode(destinationNodeId, "poi", "목적지 POI", secondFloorId, "2F", 40, 40)
                         ))
                         .edges(List.of(
@@ -268,6 +268,81 @@ class NavigationServiceTest {
                 .containsExactly("https://signed.example/1f.png", "https://signed.example/2f.png");
         assertThat(indoorLeg.floorSegments().get(0).path()).hasSize(2);
         assertThat(indoorLeg.floorSegments().get(1).path()).hasSize(2);
+        assertThat(indoorLeg.floorSegments().get(0).steps())
+                .extracting(StepDto::instruction)
+                .doesNotContain("엘리베이터를 타고 2F으로 이동");
+        assertThat(indoorLeg.floorSegments().get(1).steps())
+                .extracting(StepDto::instruction)
+                .contains("엘리베이터를 타고 2F으로 이동");
+    }
+
+    @Test
+    void indoorLegGroupsFloorSegmentsUsingFallbackFloorId() throws Exception {
+        UUID buildingId = UUID.randomUUID();
+        UUID mapVersionId = UUID.randomUUID();
+        UUID entranceNodeId = UUID.randomUUID();
+        UUID middleNodeId = UUID.randomUUID();
+        UUID destinationNodeId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Long destinationPoiId = 1001L;
+
+        when(mapQueryFacade.findIndoorPoiDestination(null)).thenReturn(Optional.empty());
+        when(mapQueryFacade.findIndoorPoiDestination(destinationPoiId))
+                .thenReturn(Optional.of(indoorPoiDestination(
+                        destinationPoiId,
+                        destinationNodeId,
+                        floorId,
+                        "1F",
+                        buildingId
+                )));
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000))
+                .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
+        when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
+                .thenReturn(Optional.of(RoutingGraph.builder()
+                        .mapVersionId(mapVersionId)
+                        .mapType(MapType.BUILDING)
+                        .mapImageUrl("https://signed.example/fallback.png")
+                        .nodes(List.of(
+                                routingNode(entranceNodeId, "entrance", "정문", null, null, 10, 10),
+                                routingNode(middleNodeId, "corridor", "복도", floorId, "1F", 20, 20),
+                                routingNode(destinationNodeId, "poi", "목적지 POI", null, null, 30, 30)
+                        ))
+                        .edges(List.of(
+                                routingEdge(entranceNodeId, middleNodeId),
+                                routingEdge(middleNodeId, destinationNodeId)
+                        ))
+                        .verticalLinks(List.of())
+                        .obstacles(List.of())
+                        .build()));
+        when(mapQueryFacade.findCurrentFloorplanImageUrl(floorId))
+                .thenReturn(Optional.of("https://signed.example/1f.png"));
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(walkRouteResponse());
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발지",
+                "목적지",
+                buildingId,
+                destinationPoiId,
+                true,
+                List.of(RouteType.WALK)
+        ));
+
+        LegDto indoorLeg = response.routes().get(0).legs().stream()
+                .filter(leg -> leg.mode() == LegMode.INDOOR)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(indoorLeg.floorSegments()).hasSize(1);
+        assertThat(indoorLeg.floorSegments().get(0).floorId()).isEqualTo(floorId);
+        assertThat(indoorLeg.floorSegments().get(0).path()).hasSize(3);
     }
 
     private JsonNode walkRouteResponse() throws Exception {

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -68,14 +68,7 @@ class NavigationServiceTest {
         double entranceY = 37.6000;
 
         when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, originalEndX, originalEndY))
-                .thenReturn(Optional.of(new IndoorDestinationAnchor(
-                        buildingId,
-                        "테스트 건물",
-                        entranceNodeId,
-                        "정문",
-                        entranceX,
-                        entranceY
-                )));
+                .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, entranceX, entranceY)));
         when(restTemplate.postForObject(
                 eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
                 any(HttpEntity.class),
@@ -149,27 +142,15 @@ class NavigationServiceTest {
 
         when(mapQueryFacade.findIndoorPoiDestination(null)).thenReturn(Optional.empty());
         when(mapQueryFacade.findIndoorPoiDestination(destinationPoiId))
-                .thenReturn(Optional.of(new IndoorPoiDestination(
+                .thenReturn(Optional.of(indoorPoiDestination(
                         destinationPoiId,
-                        UUID.randomUUID(),
-                        "목적지 POI",
                         destinationNodeId,
                         floorId,
                         "1F",
-                        buildingId,
-                        "테스트 건물",
-                        null,
-                        null
+                        buildingId
                 )));
         when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000))
-                .thenReturn(Optional.of(new IndoorDestinationAnchor(
-                        buildingId,
-                        "테스트 건물",
-                        entranceNodeId,
-                        "정문",
-                        127.2000,
-                        37.6000
-                )));
+                .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
         when(restTemplate.postForObject(
                 eq("https://apis.openapi.sk.com/transit/routes"),
                 any(HttpEntity.class),
@@ -214,53 +195,41 @@ class NavigationServiceTest {
 
         when(mapQueryFacade.findIndoorPoiDestination(null)).thenReturn(Optional.empty());
         when(mapQueryFacade.findIndoorPoiDestination(destinationPoiId))
-                .thenReturn(Optional.of(new IndoorPoiDestination(
+                .thenReturn(Optional.of(indoorPoiDestination(
                         destinationPoiId,
-                        UUID.randomUUID(),
-                        "목적지 POI",
                         destinationNodeId,
                         secondFloorId,
                         "2F",
-                        buildingId,
-                        "테스트 건물",
-                        null,
-                        null
+                        buildingId
                 )));
         when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000))
-                .thenReturn(Optional.of(new IndoorDestinationAnchor(
-                        buildingId,
-                        "테스트 건물",
-                        entranceNodeId,
-                        "정문",
-                        127.2000,
-                        37.6000
-                )));
+                .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
         when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
-                .thenReturn(Optional.of(new RoutingGraph(
-                        mapVersionId,
-                        MapType.BUILDING,
-                        "https://signed.example/fallback.png",
-                        List.of(
-                                new RoutingNode(entranceNodeId, "entrance", "정문", firstFloorId, "1F", 10, 10),
-                                new RoutingNode(firstFloorConnectorNodeId, "elevator", "엘리베이터", firstFloorId, "1F", 20, 20),
-                                new RoutingNode(secondFloorConnectorNodeId, "elevator", "엘리베이터", secondFloorId, "2F", 30, 30),
-                                new RoutingNode(destinationNodeId, "poi", "목적지 POI", secondFloorId, "2F", 40, 40)
-                        ),
-                        List.of(
-                                new RoutingEdge(UUID.randomUUID(), entranceNodeId, firstFloorConnectorNodeId, "corridor", false, 10, 1),
-                                new RoutingEdge(UUID.randomUUID(), secondFloorConnectorNodeId, destinationNodeId, "corridor", false, 10, 1)
-                        ),
-                        List.of(new VerticalRoutingLink(
-                                firstFloorConnectorNodeId,
-                                secondFloorConnectorNodeId,
-                                "elevator",
-                                "엘리베이터",
-                                "1F",
-                                "2F",
-                                10
-                        )),
-                        List.of()
-                )));
+                .thenReturn(Optional.of(RoutingGraph.builder()
+                        .mapVersionId(mapVersionId)
+                        .mapType(MapType.BUILDING)
+                        .mapImageUrl("https://signed.example/fallback.png")
+                        .nodes(List.of(
+                                routingNode(entranceNodeId, "entrance", "정문", firstFloorId, "1F", 10, 10),
+                                routingNode(firstFloorConnectorNodeId, "elevator", "엘리베이터", firstFloorId, "1F", 20, 20),
+                                routingNode(secondFloorConnectorNodeId, "elevator", "엘리베이터", secondFloorId, "2F", 30, 30),
+                                routingNode(destinationNodeId, "poi", "목적지 POI", secondFloorId, "2F", 40, 40)
+                        ))
+                        .edges(List.of(
+                                routingEdge(entranceNodeId, firstFloorConnectorNodeId),
+                                routingEdge(secondFloorConnectorNodeId, destinationNodeId)
+                        ))
+                        .verticalLinks(List.of(VerticalRoutingLink.builder()
+                                .fromNodeId(firstFloorConnectorNodeId)
+                                .toNodeId(secondFloorConnectorNodeId)
+                                .connectorKind("elevator")
+                                .connectorName("엘리베이터")
+                                .fromFloorName("1F")
+                                .toFloorName("2F")
+                                .avgWaitSeconds(10)
+                                .build()))
+                        .obstacles(List.of())
+                        .build()));
         when(mapQueryFacade.findCurrentFloorplanImageUrl(firstFloorId))
                 .thenReturn(Optional.of("https://signed.example/1f.png"));
         when(mapQueryFacade.findCurrentFloorplanImageUrl(secondFloorId))
@@ -322,6 +291,73 @@ class NavigationServiceTest {
                   ]
                 }
                 """);
+    }
+
+    private IndoorDestinationAnchor indoorAnchor(
+            UUID buildingId,
+            UUID entranceNodeId,
+            double entranceX,
+            double entranceY
+    ) {
+        return IndoorDestinationAnchor.builder()
+                .buildingId(buildingId)
+                .buildingName("테스트 건물")
+                .entranceNodeId(entranceNodeId)
+                .entranceName("정문")
+                .x(entranceX)
+                .y(entranceY)
+                .build();
+    }
+
+    private IndoorPoiDestination indoorPoiDestination(
+            Long publicId,
+            UUID anchorNodeId,
+            UUID floorId,
+            String floorName,
+            UUID buildingId
+    ) {
+        return IndoorPoiDestination.builder()
+                .publicId(publicId)
+                .poiId(UUID.randomUUID())
+                .name("목적지 POI")
+                .anchorNodeId(anchorNodeId)
+                .floorId(floorId)
+                .floorName(floorName)
+                .buildingId(buildingId)
+                .buildingName("테스트 건물")
+                .build();
+    }
+
+    private RoutingNode routingNode(
+            UUID id,
+            String kind,
+            String name,
+            UUID floorId,
+            String floorName,
+            double x,
+            double y
+    ) {
+        return RoutingNode.builder()
+                .id(id)
+                .kind(kind)
+                .name(name)
+                .floorId(floorId)
+                .floorName(floorName)
+                .x(x)
+                .y(y)
+                .build();
+    }
+
+    private RoutingEdge routingEdge(UUID fromNodeId, UUID toNodeId) {
+        return RoutingEdge.builder()
+                .id(UUID.randomUUID())
+                .fromNodeId(fromNodeId)
+                .toNodeId(toNodeId)
+                .kind("corridor")
+                .directed(false)
+                .length(10)
+                .baseWeight(1)
+                .build();
     }
 
     private JsonNode transitRouteResponse() throws Exception {


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #55 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

다층(Multi-floor) 실내외 하이브리드 길찾기 화면을 프론트엔드에서 정확하게 렌더링할 수 있도록 API 구조를 개선하고 테스트 코드를 보강했습니다.
### 1. 기능 변경 및 보강 (`feat`)
- **네비게이션 응답 스펙 개선**: `LegDto` 내에 층별 정보를 분리해 내려줄 수 있는 `floorSegments` 필드를 추가했습니다.
- **실내 다층 경로 분리 로직 구현**: 실내 경로가 여러 층을 지나는 경우 층별로 `floorId`, `floorName`, `mapImageUrl`, 픽셀 좌표 `path`, `steps`를 나누어 반환하도록 `NavigationService`를 보강했습니다.
- **조회 효율화**: 층별 도면 URL은 `MapQueryFacade.findCurrentFloorplanImageUrl()`을 활용하며, 동일 층의 중복 조회를 방지하기 위해 캐싱을 적용했습니다.
- **예외 및 예외 케이스 처리**: 캠퍼스 경로는 단일 segment로 처리하고, fallback leg에는 빈 `floorSegments`를 할당하여 응답 구조의 안정성을 확보했습니다.

### 2. 코드 리뷰 반영 및 구조 개선 (`refactor`)
- **패키지 구조 정돈**: `MapType`을 기존 `domain.map.entity`에서 의미에 맞게 `domain.map.enums` 패키지로 이동했습니다.
- **빌더 패턴 적용**: `MapQueryFacade` 내부 record 생성 로직을 직접 생성(`new`) 방식에서 Lombok `@Builder` 기반으로 전환하여 가독성을 높였습니다.

### 3. 테스트 코드 보강 및 리팩토링 (`test` / `refactor`)
- **검증 추가**: `NavigationServiceTest`에 다층 이동 시 `floorSegments`가 정상적으로 생성되고 분리되는지 검증하는 단위 테스트를 추가했습니다.
- **테스트 픽스처 리팩토링**: 테스트용 픽스처 생성 방식을 builder 기반으로 통일하고, 중복되던 생성 코드(`IndoorDestinationAnchor`, `IndoorPoiDestination`, `RoutingNode`, `RoutingEdge`)를 하단 헬퍼 메서드로 분리하였습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 실내 네비게이션 응답에 플로어 단위 경로 세그먼트(floorSegments) 추가 — 층별 지도, 경로 및 단계 정보를 제공

* **Refactor**
  * 내부 패키지 정리 및 타입 참조 경로 개선
  * 빌더 기반 일관된 객체 생성 방식 적용으로 유지보수성 향상

* **Tests**
  * 플로어 세그먼트 분할 및 폴백 동작 검증 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/insideout-CapstoneDesign/backend/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->