### PR TITLE
[feat] 통합 검색 및 거리 정렬 정책 개선 (#32)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/BuildingRepository.java
@@ -1,9 +1,12 @@
 package com.insideout.backend.domain.building.repository;
 
 import com.insideout.backend.domain.building.entity.Building;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,4 +17,59 @@ public interface BuildingRepository extends JpaRepository<Building, UUID> {
     Optional<Building> findByIdAndCampusIsNotNull(UUID id);
 
     List<Building> findByTenant_IdOrderByCreatedAtDesc(UUID tenantId);
+
+    @Query(value = """
+            SELECT
+                b.id AS id,
+                b.name AS name,
+                b.address AS address,
+                CAST(ST_Y(ST_Centroid(b.footprint::geometry)) AS double precision) AS lat,
+                CAST(ST_X(ST_Centroid(b.footprint::geometry)) AS double precision) AS lng,
+                b.external_api_id AS externalApiId
+            FROM building b
+            WHERE b.name ILIKE CONCAT('%', :query, '%')
+               OR b.address ILIKE CONCAT('%', :query, '%')
+            ORDER BY b.created_at DESC
+            """, nativeQuery = true)
+    List<BuildingSearchProjection> searchRegisteredPlaces(@Param("query") String query);
+
+    @Query(value = """
+            SELECT
+                b.id AS id,
+                b.name AS name,
+                b.address AS address,
+                CAST(ST_Y(ST_Centroid(b.footprint::geometry)) AS double precision) AS lat,
+                CAST(ST_X(ST_Centroid(b.footprint::geometry)) AS double precision) AS lng,
+                b.external_api_id AS externalApiId
+            FROM building b
+            WHERE b.external_api_id IN (:externalApiIds)
+            """, nativeQuery = true)
+    List<BuildingSearchProjection> findRegisteredPlacesByExternalApiIds(@Param("externalApiIds") Collection<String> externalApiIds);
+
+    @Query(value = """
+            SELECT
+                b.id AS id,
+                b.name AS name,
+                b.address AS address,
+                CAST(ST_Y(ST_Centroid(b.footprint::geometry)) AS double precision) AS lat,
+                CAST(ST_X(ST_Centroid(b.footprint::geometry)) AS double precision) AS lng,
+                b.external_api_id AS externalApiId
+            FROM building b
+            WHERE b.footprint IS NOT NULL
+              AND ST_DWithin(
+                    b.footprint,
+                    CAST(ST_SetSRID(ST_MakePoint(:lng, :lat), 4326) AS geography),
+                    :radius
+              )
+            ORDER BY ST_Distance(
+                    b.footprint,
+                    CAST(ST_SetSRID(ST_MakePoint(:lng, :lat), 4326) AS geography)
+              )
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<BuildingSearchProjection> findNearestRegisteredPlace(
+            @Param("lat") double lat,
+            @Param("lng") double lng,
+            @Param("radius") int radius
+    );
 }

--- a/src/main/java/com/insideout/backend/domain/building/repository/BuildingSearchProjection.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/BuildingSearchProjection.java
@@ -1,0 +1,17 @@
+package com.insideout.backend.domain.building.repository;
+
+import java.util.UUID;
+
+public interface BuildingSearchProjection {
+    UUID getId();
+
+    String getName();
+
+    String getAddress();
+
+    Double getLat();
+
+    Double getLng();
+
+    String getExternalApiId();
+}

--- a/src/main/java/com/insideout/backend/domain/place/dto/response/PlaceSearchItemResponse.java
+++ b/src/main/java/com/insideout/backend/domain/place/dto/response/PlaceSearchItemResponse.java
@@ -7,6 +7,7 @@ public record PlaceSearchItemResponse(
         Double lat,
         Double lng,
         boolean isRegistered,
-        String externalApiId
+        String externalApiId,
+        Double distanceMeters
 ) {
 }

--- a/src/main/java/com/insideout/backend/domain/place/service/KakaoPlaceSearchClient.java
+++ b/src/main/java/com/insideout/backend/domain/place/service/KakaoPlaceSearchClient.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 public class KakaoPlaceSearchClient {
 
     private static final int DEFAULT_SIZE = 15;
+    private static final int MAX_PAGE = 45;
     private final @Qualifier("kakaoLocalRestClient") RestClient kakaoLocalRestClient;
 
     public List<PlaceSearchItemResponse> searchByKeyword(String query) {
@@ -34,28 +35,12 @@ public class KakaoPlaceSearchClient {
 
     public List<PlaceSearchItemResponse> searchByKeyword(String query, Double lat, Double lng, Integer radius) {
         try {
-            KakaoKeywordSearchResponse response = kakaoLocalRestClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path("/v2/local/search/keyword.json")
-                            .queryParam("query", query)
-                            .queryParam("size", DEFAULT_SIZE)
-                            .queryParamIfPresent("x", Optional.ofNullable(lng))
-                            .queryParamIfPresent("y", Optional.ofNullable(lat))
-                            .queryParamIfPresent("radius", Optional.ofNullable(radius))
-                            .queryParamIfPresent(
-                                    "sort",
-                                    (lat != null && lng != null) ? Optional.of("distance") : Optional.empty()
-                            )
-                            .build())
-                    .accept(MediaType.APPLICATION_JSON)
-                    .retrieve()
-                    .body(KakaoKeywordSearchResponse.class);
-
-            if (response == null || response.documents() == null) {
+            List<KakaoKeywordSearchDocument> documents = fetchAllKeywordSearchDocuments(query, lat, lng, radius);
+            if (documents.isEmpty()) {
                 return Collections.emptyList();
             }
 
-            return response.documents().stream()
+            return documents.stream()
                     .map(document -> new PlaceSearchItemResponse(
                             document.placeName(),
                             document.addressName(),
@@ -63,12 +48,75 @@ public class KakaoPlaceSearchClient {
                             parseDouble(document.y()),
                             parseDouble(document.x()),
                             false,
-                            document.id()
+                            document.id(),
+                            null
                     ))
                     .toList();
         } catch (RestClientException e) {
             throw new PlaceException(PlaceErrorCode.KAKAO_LOCAL_API_UNAVAILABLE);
         }
+    }
+
+    private List<KakaoKeywordSearchDocument> fetchAllKeywordSearchDocuments(
+            String query,
+            Double lat,
+            Double lng,
+            Integer radius
+    ) {
+        List<KakaoKeywordSearchDocument> allDocuments = new java.util.ArrayList<>();
+        int page = 1;
+
+        while (page <= MAX_PAGE) {
+            KakaoKeywordSearchResponse response = requestKeywordSearchPage(query, lat, lng, radius, page);
+            if (response == null || response.documents() == null || response.documents().isEmpty()) {
+                break;
+            }
+
+            allDocuments.addAll(response.documents());
+
+            KakaoKeywordSearchMeta meta = response.meta();
+            if (meta == null) {
+                break;
+            }
+
+            if (Boolean.TRUE.equals(meta.isEnd())) {
+                break;
+            }
+
+            Integer pageableCount = meta.pageableCount();
+            if (pageableCount != null && pageableCount > 0) {
+                int maxPageByCount = Math.min(MAX_PAGE, (int) Math.ceil((double) pageableCount / DEFAULT_SIZE));
+                if (page >= maxPageByCount) {
+                    break;
+                }
+            }
+
+            page++;
+        }
+
+        return allDocuments;
+    }
+
+    private KakaoKeywordSearchResponse requestKeywordSearchPage(
+            String query,
+            Double lat,
+            Double lng,
+            Integer radius,
+            int page
+    ) {
+        return kakaoLocalRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v2/local/search/keyword.json")
+                        .queryParam("query", query)
+                        .queryParam("size", DEFAULT_SIZE)
+                        .queryParam("page", page)
+                        .queryParamIfPresent("x", Optional.ofNullable(lng))
+                        .queryParamIfPresent("y", Optional.ofNullable(lat))
+                        .queryParamIfPresent("radius", Optional.ofNullable(radius))
+                        .build())
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .body(KakaoKeywordSearchResponse.class);
     }
 
     public Optional<PlaceNearestResponse> findNearestByCoordinate(double lat, double lng, int radius) {
@@ -188,7 +236,16 @@ public class KakaoPlaceSearchClient {
     }
 
     private record KakaoKeywordSearchResponse(
+            KakaoKeywordSearchMeta meta,
             List<KakaoKeywordSearchDocument> documents
+    ) {
+    }
+
+    private record KakaoKeywordSearchMeta(
+            @JsonProperty("is_end")
+            Boolean isEnd,
+            @JsonProperty("pageable_count")
+            Integer pageableCount
     ) {
     }
 

--- a/src/main/java/com/insideout/backend/domain/place/service/PlaceSearchService.java
+++ b/src/main/java/com/insideout/backend/domain/place/service/PlaceSearchService.java
@@ -1,5 +1,7 @@
 package com.insideout.backend.domain.place.service;
 
+import com.insideout.backend.domain.building.repository.BuildingRepository;
+import com.insideout.backend.domain.building.repository.BuildingSearchProjection;
 import com.insideout.backend.domain.place.dto.response.PlaceNearestResponse;
 import com.insideout.backend.domain.place.dto.response.PlaceSearchItemResponse;
 import com.insideout.backend.domain.place.exception.PlaceErrorCode;
@@ -7,11 +9,17 @@ import com.insideout.backend.domain.place.exception.PlaceException;
 import com.insideout.backend.global.apiPayload.code.GeneralErrorCode;
 import com.insideout.backend.global.apiPayload.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,33 +30,52 @@ public class PlaceSearchService {
     private static final int MIN_RADIUS_METER = 1;
     private static final int MAX_RADIUS_METER = 20_000;
 
+    private final BuildingRepository buildingRepository;
     private final KakaoPlaceSearchClient kakaoPlaceSearchClient;
 
     public List<PlaceSearchItemResponse> search(String query, Double lat, Double lng, Integer radius) {
         if (query == null || query.isBlank()) {
             throw new ProjectException(GeneralErrorCode.BAD_REQUEST);
         }
-        if (lat == null && lng == null) {
-            if (radius != null) {
-                throw new PlaceException(PlaceErrorCode.INVALID_COORDINATE);
-            }
-            return kakaoPlaceSearchClient.searchByKeyword(query.trim());
+
+        String normalizedQuery = query.trim();
+        boolean hasCoordinate = lat != null || lng != null;
+
+        Integer resolvedSearchRadius = null;
+        if (hasCoordinate) {
+            validateCoordinate(lat, lng);
+            resolvedSearchRadius = normalizeSearchRadius(radius);
+        } else if (radius != null) {
+            throw new PlaceException(PlaceErrorCode.INVALID_COORDINATE);
         }
 
-        validateCoordinate(lat, lng);
-        int resolvedRadius = normalizeSearchRadius(radius);
-        return kakaoPlaceSearchClient.searchByKeyword(query.trim(), lat, lng, resolvedRadius).stream()
-                .filter(item -> item.lat() != null && item.lng() != null)
-                .map(item -> new ScoredPlace(item, distanceInMeter(lat, lng, item.lat(), item.lng())))
-                .filter(scored -> scored.distanceMeter() <= resolvedRadius)
-                .sorted(Comparator.comparingDouble(ScoredPlace::distanceMeter))
-                .map(ScoredPlace::item)
+        List<PlaceSearchItemResponse> registeredPlaces = buildingRepository.searchRegisteredPlaces(normalizedQuery).stream()
+                .map(this::toRegisteredSearchItem)
                 .toList();
+
+        List<PlaceSearchItemResponse> externalPlaces = resolvedSearchRadius == null
+                ? kakaoPlaceSearchClient.searchByKeyword(normalizedQuery)
+                : kakaoPlaceSearchClient.searchByKeyword(normalizedQuery, lat, lng, resolvedSearchRadius);
+
+        List<PlaceSearchItemResponse> merged = mergeRegisteredAndExternal(registeredPlaces, externalPlaces, normalizedQuery, lat, lng);
+        if (resolvedSearchRadius != null) {
+            return sortWithCoordinates(merged, normalizedQuery, lat, lng, resolvedSearchRadius);
+        }
+
+        return sortWithoutCoordinates(merged, normalizedQuery);
     }
 
     public Optional<PlaceNearestResponse> findNearest(Double lat, Double lng, Integer radius) {
         validateCoordinate(lat, lng);
         int resolvedRadius = normalizeRadius(radius);
+        Optional<PlaceNearestResponse> registeredPlace = buildingRepository
+                .findNearestRegisteredPlace(lat, lng, resolvedRadius)
+                .map(this::toRegisteredNearestResponse);
+
+        if (registeredPlace.isPresent()) {
+            return registeredPlace;
+        }
+
         return kakaoPlaceSearchClient.findNearestByCoordinate(lat, lng, resolvedRadius);
     }
 
@@ -97,6 +124,211 @@ public class PlaceSearchService {
         return earthRadius * c;
     }
 
-    private record ScoredPlace(PlaceSearchItemResponse item, double distanceMeter) {
+    private List<PlaceSearchItemResponse> mergeRegisteredAndExternal(
+            List<PlaceSearchItemResponse> registeredPlaces,
+            List<PlaceSearchItemResponse> externalPlaces,
+            String query,
+            Double lat,
+            Double lng
+    ) {
+        Map<String, PlaceSearchItemResponse> registeredByExternalApiId = registeredPlaces.stream()
+                .filter(item -> StringUtils.hasText(item.externalApiId()))
+                .collect(Collectors.toMap(
+                        item -> item.externalApiId().trim(),
+                        item -> item,
+                        (left, right) -> left
+                ));
+
+        Map<String, PlaceSearchItemResponse> deduplicated = new LinkedHashMap<>();
+        registeredPlaces.forEach(item -> putBest(deduplicated, item, query, lat, lng));
+
+        Set<String> externalIds = externalPlaces.stream()
+                .map(PlaceSearchItemResponse::externalApiId)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toSet());
+
+        if (!externalIds.isEmpty()) {
+            List<PlaceSearchItemResponse> additionalRegistered = buildingRepository
+                    .findRegisteredPlacesByExternalApiIds(externalIds)
+                    .stream()
+                    .map(this::toRegisteredSearchItem)
+                    .toList();
+            additionalRegistered.forEach(item -> registeredByExternalApiId.putIfAbsent(item.externalApiId(), item));
+        }
+
+        for (PlaceSearchItemResponse external : externalPlaces) {
+            PlaceSearchItemResponse matched = applyRegisteredMatch(external, registeredByExternalApiId);
+            putBest(deduplicated, matched, query, lat, lng);
+        }
+
+        return new ArrayList<>(deduplicated.values());
+    }
+
+    private List<PlaceSearchItemResponse> sortWithoutCoordinates(List<PlaceSearchItemResponse> items, String query) {
+        return items.stream()
+                .sorted(Comparator
+                        .comparingInt((PlaceSearchItemResponse item) -> keywordScore(item.name(), query)).reversed()
+                        .thenComparing(PlaceSearchItemResponse::isRegistered, Comparator.reverseOrder())
+                        .thenComparing(item -> normalizeText(item.name())))
+                .toList();
+    }
+
+    private List<PlaceSearchItemResponse> sortWithCoordinates(
+            List<PlaceSearchItemResponse> items,
+            String query,
+            double lat,
+            double lng,
+            int radius
+    ) {
+        return items.stream()
+                .filter(item -> item.lat() != null && item.lng() != null)
+                .map(item -> new ScoredPlace(item, distanceInMeter(lat, lng, item.lat(), item.lng()), keywordScore(item.name(), query)))
+                .filter(scored -> scored.distanceMeter() <= radius)
+                .sorted(Comparator
+                        .comparingInt(ScoredPlace::keywordScore).reversed()
+                        .thenComparingDouble(ScoredPlace::distanceMeter)
+                        .thenComparing(scored -> scored.item().isRegistered(), Comparator.reverseOrder())
+                        .thenComparing(scored -> normalizeText(scored.item().name())))
+                .map(ScoredPlace::item)
+                .toList();
+    }
+
+    private PlaceSearchItemResponse toRegisteredSearchItem(BuildingSearchProjection building) {
+        return new PlaceSearchItemResponse(
+                building.getName(),
+                building.getAddress(),
+                null,
+                building.getLat(),
+                building.getLng(),
+                true,
+                building.getExternalApiId()
+        );
+    }
+
+    private PlaceNearestResponse toRegisteredNearestResponse(BuildingSearchProjection building) {
+        return new PlaceNearestResponse(
+                building.getName(),
+                building.getAddress(),
+                null,
+                building.getLat(),
+                building.getLng(),
+                true,
+                building.getExternalApiId()
+        );
+    }
+
+    private PlaceSearchItemResponse applyRegisteredMatch(
+            PlaceSearchItemResponse external,
+            Map<String, PlaceSearchItemResponse> registeredByExternalApiId
+    ) {
+        if (!StringUtils.hasText(external.externalApiId())) {
+            return external;
+        }
+
+        PlaceSearchItemResponse registered = registeredByExternalApiId.get(external.externalApiId().trim());
+        if (registered == null) {
+            return external;
+        }
+
+        return new PlaceSearchItemResponse(
+                registered.name(),
+                registered.address(),
+                external.roadAddress(),
+                registered.lat() != null ? registered.lat() : external.lat(),
+                registered.lng() != null ? registered.lng() : external.lng(),
+                true,
+                registered.externalApiId()
+        );
+    }
+
+    private void putBest(
+            Map<String, PlaceSearchItemResponse> deduplicated,
+            PlaceSearchItemResponse candidate,
+            String query,
+            Double lat,
+            Double lng
+    ) {
+        String key = dedupeKey(candidate);
+        PlaceSearchItemResponse existing = deduplicated.get(key);
+        if (existing == null || compareCandidate(existing, candidate, query, lat, lng) < 0) {
+            deduplicated.put(key, candidate);
+        }
+    }
+
+    private int compareCandidate(
+            PlaceSearchItemResponse existing,
+            PlaceSearchItemResponse candidate,
+            String query,
+            Double lat,
+            Double lng
+    ) {
+        if (existing.isRegistered() != candidate.isRegistered()) {
+            return existing.isRegistered() ? 1 : -1;
+        }
+
+        int existingScore = keywordScore(existing.name(), query);
+        int candidateScore = keywordScore(candidate.name(), query);
+        if (existingScore != candidateScore) {
+            return Integer.compare(existingScore, candidateScore);
+        }
+
+        if (lat != null && lng != null
+                && existing.lat() != null && existing.lng() != null
+                && candidate.lat() != null && candidate.lng() != null) {
+            double existingDistance = distanceInMeter(lat, lng, existing.lat(), existing.lng());
+            double candidateDistance = distanceInMeter(lat, lng, candidate.lat(), candidate.lng());
+            return Double.compare(candidateDistance, existingDistance);
+        }
+
+        boolean existingHasCoordinate = existing.lat() != null && existing.lng() != null;
+        boolean candidateHasCoordinate = candidate.lat() != null && candidate.lng() != null;
+        if (existingHasCoordinate != candidateHasCoordinate) {
+            return existingHasCoordinate ? 1 : -1;
+        }
+
+        return 0;
+    }
+
+    private String dedupeKey(PlaceSearchItemResponse item) {
+        if (StringUtils.hasText(item.externalApiId())) {
+            return "ext:" + item.externalApiId().trim();
+        }
+        if (item.lat() != null && item.lng() != null) {
+            return "geo:" + normalizeText(item.name()) + ":" + round(item.lat(), 4) + ":" + round(item.lng(), 4);
+        }
+        return "name:" + normalizeText(item.name()) + "|" + normalizeText(item.address());
+    }
+
+    private int keywordScore(String name, String query) {
+        String target = normalizeText(name);
+        String keyword = normalizeText(query);
+        if (!StringUtils.hasText(target) || !StringUtils.hasText(keyword)) {
+            return 0;
+        }
+        if (target.equals(keyword)) {
+            return 3;
+        }
+        if (target.startsWith(keyword)) {
+            return 2;
+        }
+        if (target.contains(keyword)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    private String normalizeText(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        return value.replaceAll("\\s+", "").toLowerCase();
+    }
+
+    private double round(double value, int precision) {
+        double scale = Math.pow(10, precision);
+        return Math.round(value * scale) / scale;
+    }
+
+    private record ScoredPlace(PlaceSearchItemResponse item, double distanceMeter, int keywordScore) {
     }
 }

--- a/src/main/java/com/insideout/backend/domain/place/service/PlaceSearchService.java
+++ b/src/main/java/com/insideout/backend/domain/place/service/PlaceSearchService.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 public class PlaceSearchService {
 
     private static final int DEFAULT_RADIUS_METER = 30;
-    private static final int DEFAULT_SEARCH_RADIUS_METER = 5_000;
     private static final int MIN_RADIUS_METER = 1;
     private static final int MAX_RADIUS_METER = 20_000;
 
@@ -44,7 +43,9 @@ public class PlaceSearchService {
         Integer resolvedSearchRadius = null;
         if (hasCoordinate) {
             validateCoordinate(lat, lng);
-            resolvedSearchRadius = normalizeSearchRadius(radius);
+            if (radius != null) {
+                resolvedSearchRadius = normalizeRadius(radius);
+            }
         } else if (radius != null) {
             throw new PlaceException(PlaceErrorCode.INVALID_COORDINATE);
         }
@@ -53,13 +54,13 @@ public class PlaceSearchService {
                 .map(this::toRegisteredSearchItem)
                 .toList();
 
-        List<PlaceSearchItemResponse> externalPlaces = resolvedSearchRadius == null
-                ? kakaoPlaceSearchClient.searchByKeyword(normalizedQuery)
-                : kakaoPlaceSearchClient.searchByKeyword(normalizedQuery, lat, lng, resolvedSearchRadius);
+        List<PlaceSearchItemResponse> externalPlaces = hasCoordinate
+                ? kakaoPlaceSearchClient.searchByKeyword(normalizedQuery, lat, lng, resolvedSearchRadius)
+                : kakaoPlaceSearchClient.searchByKeyword(normalizedQuery);
 
         List<PlaceSearchItemResponse> merged = mergeRegisteredAndExternal(registeredPlaces, externalPlaces, normalizedQuery, lat, lng);
-        if (resolvedSearchRadius != null) {
-            return sortWithCoordinates(merged, normalizedQuery, lat, lng, resolvedSearchRadius);
+        if (hasCoordinate) {
+            return sortWithCoordinates(merged, lat, lng, resolvedSearchRadius);
         }
 
         return sortWithoutCoordinates(merged, normalizedQuery);
@@ -92,18 +93,6 @@ public class PlaceSearchService {
     private int normalizeRadius(Integer radius) {
         if (radius == null) {
             return DEFAULT_RADIUS_METER;
-        }
-
-        if (radius < MIN_RADIUS_METER || radius > MAX_RADIUS_METER) {
-            throw new PlaceException(PlaceErrorCode.INVALID_RADIUS);
-        }
-
-        return radius;
-    }
-
-    private int normalizeSearchRadius(Integer radius) {
-        if (radius == null) {
-            return DEFAULT_SEARCH_RADIUS_METER;
         }
 
         if (radius < MIN_RADIUS_METER || radius > MAX_RADIUS_METER) {
@@ -175,21 +164,18 @@ public class PlaceSearchService {
 
     private List<PlaceSearchItemResponse> sortWithCoordinates(
             List<PlaceSearchItemResponse> items,
-            String query,
             double lat,
             double lng,
-            int radius
+            Integer radius
     ) {
         return items.stream()
-                .filter(item -> item.lat() != null && item.lng() != null)
-                .map(item -> new ScoredPlace(item, distanceInMeter(lat, lng, item.lat(), item.lng()), keywordScore(item.name(), query)))
-                .filter(scored -> scored.distanceMeter() <= radius)
+                .map(item -> toScoredPlace(item, lat, lng))
+                .filter(scored -> radius == null || (scored.distanceMeter() != null && scored.distanceMeter() <= radius))
                 .sorted(Comparator
-                        .comparingInt(ScoredPlace::keywordScore).reversed()
-                        .thenComparingDouble(ScoredPlace::distanceMeter)
+                        .comparing(ScoredPlace::distanceMeter, Comparator.nullsLast(Double::compareTo))
                         .thenComparing(scored -> scored.item().isRegistered(), Comparator.reverseOrder())
                         .thenComparing(scored -> normalizeText(scored.item().name())))
-                .map(ScoredPlace::item)
+                .map(ScoredPlace::toResponse)
                 .toList();
     }
 
@@ -201,7 +187,8 @@ public class PlaceSearchService {
                 building.getLat(),
                 building.getLng(),
                 true,
-                building.getExternalApiId()
+                building.getExternalApiId(),
+                null
         );
     }
 
@@ -237,7 +224,8 @@ public class PlaceSearchService {
                 registered.lat() != null ? registered.lat() : external.lat(),
                 registered.lng() != null ? registered.lng() : external.lng(),
                 true,
-                registered.externalApiId()
+                registered.externalApiId(),
+                external.distanceMeters()
         );
     }
 
@@ -329,6 +317,26 @@ public class PlaceSearchService {
         return Math.round(value * scale) / scale;
     }
 
-    private record ScoredPlace(PlaceSearchItemResponse item, double distanceMeter, int keywordScore) {
+    private ScoredPlace toScoredPlace(PlaceSearchItemResponse item, double lat, double lng) {
+        if (item.lat() == null || item.lng() == null) {
+            return new ScoredPlace(item, null);
+        }
+
+        return new ScoredPlace(item, distanceInMeter(lat, lng, item.lat(), item.lng()));
+    }
+
+    private record ScoredPlace(PlaceSearchItemResponse item, Double distanceMeter) {
+        PlaceSearchItemResponse toResponse() {
+            return new PlaceSearchItemResponse(
+                    item.name(),
+                    item.address(),
+                    item.roadAddress(),
+                    item.lat(),
+                    item.lng(),
+                    item.isRegistered(),
+                    item.externalApiId(),
+                    distanceMeter
+            );
+        }
     }
 }

--- a/src/test/java/com/insideout/backend/domain/place/service/PlaceSearchServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/place/service/PlaceSearchServiceTest.java
@@ -78,12 +78,12 @@ class PlaceSearchServiceTest {
 
     @Test
     void search_withCoordinates_usesDistanceSearch() {
-        when(kakaoPlaceSearchClient.searchByKeyword("스타벅스", 37.5, 127.0, 5_000))
+        when(kakaoPlaceSearchClient.searchByKeyword("스타벅스", 37.5, 127.0, null))
                 .thenReturn(List.of());
 
         placeSearchService.search("스타벅스", 37.5, 127.0, null);
 
-        verify(kakaoPlaceSearchClient).searchByKeyword("스타벅스", 37.5, 127.0, 5_000);
+        verify(kakaoPlaceSearchClient).searchByKeyword("스타벅스", 37.5, 127.0, null);
     }
 
     @Test
@@ -105,7 +105,8 @@ class PlaceSearchServiceTest {
                 37.5005,
                 127.0005,
                 false,
-                "1"
+                "1",
+                null
         );
         PlaceSearchItemResponse far = new PlaceSearchItemResponse(
                 "먼 매장",
@@ -114,14 +115,18 @@ class PlaceSearchServiceTest {
                 33.4996,
                 126.5312,
                 false,
-                "2"
+                "2",
+                null
         );
         when(kakaoPlaceSearchClient.searchByKeyword("스타벅스", 37.5, 127.0, 3000))
                 .thenReturn(List.of(far, near));
 
         List<PlaceSearchItemResponse> result = placeSearchService.search("스타벅스", 37.5, 127.0, 3000);
 
-        assertThat(result).containsExactly(near);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo("근처 매장");
+        assertThat(result.get(0).externalApiId()).isEqualTo("1");
+        assertThat(result.get(0).distanceMeters()).isNotNull();
     }
 
     @Test
@@ -134,7 +139,7 @@ class PlaceSearchServiceTest {
                 ));
         when(kakaoPlaceSearchClient.searchByKeyword("신세계"))
                 .thenReturn(List.of(
-                        new PlaceSearchItemResponse("외부 건물명", "서울 중구 소공로 63", null, 37.5609, 126.9810, false, "7969138")
+                        new PlaceSearchItemResponse("외부 건물명", "서울 중구 소공로 63", null, 37.5609, 126.9810, false, "7969138", null)
                 ));
 
         List<PlaceSearchItemResponse> result = placeSearchService.search("신세계", null, null, null);

--- a/src/test/java/com/insideout/backend/domain/place/service/PlaceSearchServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/place/service/PlaceSearchServiceTest.java
@@ -1,11 +1,14 @@
 package com.insideout.backend.domain.place.service;
 
+import com.insideout.backend.domain.building.repository.BuildingRepository;
+import com.insideout.backend.domain.building.repository.BuildingSearchProjection;
 import com.insideout.backend.domain.place.dto.response.PlaceNearestResponse;
 import com.insideout.backend.domain.place.dto.response.PlaceSearchItemResponse;
 import com.insideout.backend.domain.place.exception.PlaceErrorCode;
 import com.insideout.backend.domain.place.exception.PlaceException;
 import com.insideout.backend.global.apiPayload.code.GeneralErrorCode;
 import com.insideout.backend.global.apiPayload.exception.ProjectException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,9 +17,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,8 +36,18 @@ class PlaceSearchServiceTest {
     @Mock
     private KakaoPlaceSearchClient kakaoPlaceSearchClient;
 
+    @Mock
+    private BuildingRepository buildingRepository;
+
     @InjectMocks
     private PlaceSearchService placeSearchService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(buildingRepository.searchRegisteredPlaces(anyString())).thenReturn(List.of());
+        lenient().when(buildingRepository.findRegisteredPlacesByExternalApiIds(anyCollection())).thenReturn(List.of());
+        lenient().when(buildingRepository.findNearestRegisteredPlace(anyDouble(), anyDouble(), anyInt())).thenReturn(Optional.empty());
+    }
 
     @Test
     void search_blankQuery_throwsBadRequest() {
@@ -106,6 +125,26 @@ class PlaceSearchServiceTest {
     }
 
     @Test
+    void search_mergesRegisteredByExternalApiId_andUsesRegisteredName() {
+        when(buildingRepository.searchRegisteredPlaces("신세계"))
+                .thenReturn(List.of());
+        when(buildingRepository.findRegisteredPlacesByExternalApiIds(anyCollection()))
+                .thenReturn(List.of(
+                        projection("관리자 등록 건물명", "서울 중구 소공로 63", 37.5609, 126.9810, "7969138")
+                ));
+        when(kakaoPlaceSearchClient.searchByKeyword("신세계"))
+                .thenReturn(List.of(
+                        new PlaceSearchItemResponse("외부 건물명", "서울 중구 소공로 63", null, 37.5609, 126.9810, false, "7969138")
+                ));
+
+        List<PlaceSearchItemResponse> result = placeSearchService.search("신세계", null, null, null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo("관리자 등록 건물명");
+        assertThat(result.get(0).isRegistered()).isTrue();
+    }
+
+    @Test
     void search_withPartialCoordinates_throwsInvalidCoordinate() {
         assertThatThrownBy(() -> placeSearchService.search("스타벅스", 37.5, null, null))
                 .isInstanceOf(PlaceException.class)
@@ -158,10 +197,57 @@ class PlaceSearchServiceTest {
     }
 
     @Test
+    void findNearest_returnsRegisteredBuildingFirst_whenInsideRegisteredFootprint() {
+        when(buildingRepository.findNearestRegisteredPlace(37.5, 127.0, 30))
+                .thenReturn(Optional.of(projection("등록건물", "서울시", 37.5, 127.0, "111")));
+
+        Optional<PlaceNearestResponse> result = placeSearchService.findNearest(37.5, 127.0, 30);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().name()).isEqualTo("등록건물");
+        assertThat(result.get().isRegistered()).isTrue();
+        verify(kakaoPlaceSearchClient, never()).findNearestByCoordinate(37.5, 127.0, 30);
+    }
+
+    @Test
     void findNearest_invalidRadius_throwsPlaceException() {
         assertThatThrownBy(() -> placeSearchService.findNearest(37.5, 127.0, 0))
                 .isInstanceOf(PlaceException.class)
                 .extracting(ex -> ((PlaceException) ex).getErrorCode())
                 .isEqualTo(PlaceErrorCode.INVALID_RADIUS);
+    }
+
+    private BuildingSearchProjection projection(String name, String address, Double lat, Double lng, String externalApiId) {
+        return new BuildingSearchProjection() {
+            @Override
+            public UUID getId() {
+                return UUID.randomUUID();
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getAddress() {
+                return address;
+            }
+
+            @Override
+            public Double getLat() {
+                return lat;
+            }
+
+            @Override
+            public Double getLng() {
+                return lng;
+            }
+
+            @Override
+            public String getExternalApiId() {
+                return externalApiId;
+            }
+        };
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #32

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `/api/v1/places/search` 통합 검색(DB + 카카오) 로직 적용
- `externalApiId` 기준 등록 건물 매칭 및 `isRegistered` 실제 판별
- 중복 제거 적용 (`externalApiId` 우선, 보조 키 적용)
- 정렬 정책 변경: `lat/lng` 있을 때 거리 기준 정렬
- `radius`는 선택 필터로 적용 (미전달 시 전체 후보)
- 응답 필드에 `distanceMeters` 추가

### 스크린샷 (선택)
<img width="871" height="235" alt="image" src="https://github.com/user-attachments/assets/d53634cd-ad73-4032-b4dd-457fddcd116b" />

<img width="392" height="224" alt="image" src="https://github.com/user-attachments/assets/a2691ce4-789f-4c5b-8bb6-83ab018b1da4" />
<img width="873" height="689" alt="image" src="https://github.com/user-attachments/assets/cf3be846-ebe4-4b16-b30e-35c1eee5a454" />


## 💬리뷰 요구사항(선택)
 정확도 우선 랭킹 고도화는 ES 도입 후속 이슈로 분리 예정입니다~
 현재 isRegistered는 externalApiId 기반 매칭 기준이라, 등록 건물 내부 POI(예: 크롬하츠 신세계백화점 본점 더 리저브)는 false로 반환될 수 있습니다. 내부 POI까지 등록됨 처리하는 정책은 후속 이슈로 분리 예정입니다.
