### PR TITLE
[feat] 건물 등록 플로우 구현 (#54)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/ai/converter/AiDetectionConverter.java
+++ b/src/main/java/com/insideout/backend/domain/ai/converter/AiDetectionConverter.java
@@ -176,18 +176,22 @@ public class AiDetectionConverter {
         throw new AiException(AiErrorCode.AI_INVALID_DETECTION_GEOMETRY);
     }
 
-    private String toBox2d(List<Double> bboxPx) {
+    private String toBox2d(List<?> bboxPx) {
         if (bboxPx == null || bboxPx.size() < 4) {
             return null;
         }
 
-        double x = bboxPx.get(0);
-        double y = bboxPx.get(1);
-        double width = bboxPx.get(2);
-        double height = bboxPx.get(3);
-        double maxX = x + width;
-        double maxY = y + height;
+        try {
+            double x = ((Number) bboxPx.get(0)).doubleValue();
+            double y = ((Number) bboxPx.get(1)).doubleValue();
+            double width = ((Number) bboxPx.get(2)).doubleValue();
+            double height = ((Number) bboxPx.get(3)).doubleValue();
+            double maxX = x + width;
+            double maxY = y + height;
 
-        return String.format("BOX(%s %s,%s %s)", x, y, maxX, maxY);
+            return String.format("BOX(%s %s,%s %s)", x, y, maxX, maxY);
+        } catch (ClassCastException | NullPointerException e) {
+            throw new AiException(AiErrorCode.AI_INVALID_DETECTION_GEOMETRY);
+        }
     }
 }

--- a/src/main/java/com/insideout/backend/domain/ai/entity/CampusAiDetection.java
+++ b/src/main/java/com/insideout/backend/domain/ai/entity/CampusAiDetection.java
@@ -87,6 +87,7 @@ public class CampusAiDetection {
             }
         }
         if (job != null && campusMap != null && job.getCampusMap() != null
+                && campusMap.getId() != null && job.getCampusMap().getId() != null
                 && !campusMap.getId().equals(job.getCampusMap().getId())) {
             throw new IllegalArgumentException("campusMap must match job.campusMap");
         }

--- a/src/main/java/com/insideout/backend/domain/ai/entity/CampusAiDetection.java
+++ b/src/main/java/com/insideout/backend/domain/ai/entity/CampusAiDetection.java
@@ -87,7 +87,7 @@ public class CampusAiDetection {
             }
         }
         if (job != null && campusMap != null && job.getCampusMap() != null
-                && !campusMap.equals(job.getCampusMap())) {
+                && !campusMap.getId().equals(job.getCampusMap().getId())) {
             throw new IllegalArgumentException("campusMap must match job.campusMap");
         }
         this.tenantId = tenantId;

--- a/src/main/java/com/insideout/backend/domain/ai/exception/AiException.java
+++ b/src/main/java/com/insideout/backend/domain/ai/exception/AiException.java
@@ -7,4 +7,13 @@ public class AiException extends ProjectException {
     public AiException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public AiException(BaseErrorCode errorCode, String customMessage) {
+        super(errorCode, customMessage);
+    }
+
+    public AiException(BaseErrorCode errorCode, String customMessage, Throwable cause) {
+        super(errorCode, customMessage, cause);
+    }
 }
+

--- a/src/main/java/com/insideout/backend/domain/ai/repository/AiDetectionRepository.java
+++ b/src/main/java/com/insideout/backend/domain/ai/repository/AiDetectionRepository.java
@@ -3,6 +3,7 @@ package com.insideout.backend.domain.ai.repository;
 import com.insideout.backend.domain.ai.entity.AiDetection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,5 +24,8 @@ public interface AiDetectionRepository extends JpaRepository<AiDetection, UUID> 
             where d.tenantId = :tenantId
               and d.floorplan.id in :floorplanIds
             """)
-    List<UUID> findAnalyzedFloorplanIdsByTenantIdAndFloorplanIds(UUID tenantId, List<UUID> floorplanIds);
+    List<UUID> findAnalyzedFloorplanIdsByTenantIdAndFloorplanIds(
+            @Param("tenantId") UUID tenantId,
+            @Param("floorplanIds") List<UUID> floorplanIds
+    );
 }

--- a/src/main/java/com/insideout/backend/domain/ai/repository/AiDetectionRepository.java
+++ b/src/main/java/com/insideout/backend/domain/ai/repository/AiDetectionRepository.java
@@ -2,6 +2,7 @@ package com.insideout.backend.domain.ai.repository;
 
 import com.insideout.backend.domain.ai.entity.AiDetection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,4 +16,12 @@ public interface AiDetectionRepository extends JpaRepository<AiDetection, UUID> 
     List<AiDetection> findByJob_IdOrderByIdAsc(UUID jobId);
 
     void deleteByFloorplanId(UUID floorplanId);
+
+    @Query("""
+            select distinct d.floorplan.id
+            from AiDetection d
+            where d.tenantId = :tenantId
+              and d.floorplan.id in :floorplanIds
+            """)
+    List<UUID> findAnalyzedFloorplanIdsByTenantIdAndFloorplanIds(UUID tenantId, List<UUID> floorplanIds);
 }

--- a/src/main/java/com/insideout/backend/domain/ai/service/AiAnalyzeService.java
+++ b/src/main/java/com/insideout/backend/domain/ai/service/AiAnalyzeService.java
@@ -60,8 +60,13 @@ public class AiAnalyzeService {
         } catch (Exception e) {
             log.error("AI 분석 중 예상치 못한 오류 발생. Job ID: {}", savedJob.getId(), e);
             aiAnalyzePersistenceService.completeFailure(savedJob.getId(), AiErrorCode.AI_ANALYSIS_FAILED.getMessage());
-            throw new AiException(AiErrorCode.AI_ANALYSIS_FAILED);
+            throw new AiException(
+                    AiErrorCode.AI_ANALYSIS_FAILED,
+                    "AI 분석 중 예상치 못한 오류 발생: " + e.getMessage() + " (" + e.getClass().getSimpleName() + ")",
+                    e
+            );
         }
+
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/insideout/backend/domain/ai/service/CampusAiAnalyzePersistenceService.java
+++ b/src/main/java/com/insideout/backend/domain/ai/service/CampusAiAnalyzePersistenceService.java
@@ -46,6 +46,25 @@ public class CampusAiAnalyzePersistenceService {
         return campusAiJobRepository.save(job);
     }
 
+    private static final java.util.Set<String> ALLOWED_CAMPUS_TYPES = java.util.Set.of(
+            "campus_gate",
+            "campus_road",
+            "building_footprint",
+            "obstacle",
+            "wall",
+            "door",
+            "corridor",
+            "room",
+            "elevator",
+            "stair",
+            "escalator",
+            "restroom_sign",
+            "text",
+            "poi_candidate",
+            "node_candidate",
+            "edge_candidate"
+    );
+
     @Transactional(noRollbackFor = AiException.class)
     public CampusAnalyzeResultDTO completeSuccess(
             UUID jobId,
@@ -63,6 +82,15 @@ public class CampusAiAnalyzePersistenceService {
 
         List<CampusAiDetection> detections = (aiResponse.detections() == null ? List.<AiDetectionDTO>of() : aiResponse.detections())
                 .stream()
+                .map(dto -> {
+                    // AI 분석 서버가 'entrance'로 응답한 경우 캠퍼스 맵 사양인 'campus_gate'로 보정하여 매핑
+                    if ("entrance".equals(dto.detectType())) {
+                        return new AiDetectionDTO("campus_gate", dto.confidence(), dto.geomPx(), dto.bboxPx(), dto.label(), dto.ocrText());
+                    }
+                    return dto;
+                })
+                // 캠퍼스 AI 결과 테이블(campus_ai_detection)의 CHECK 제약조건 범위 내의 타입만 필터링해서 DB 적재
+                .filter(dto -> ALLOWED_CAMPUS_TYPES.contains(dto.detectType()))
                 .map(detectionDto -> aiDetectionConverter.toCampusEntity(tenantId, job, campusMap, detectionDto))
                 .toList();
         List<CampusAiDetection> savedDetections = campusAiDetectionRepository.saveAll(detections);

--- a/src/main/java/com/insideout/backend/domain/ai/service/CampusAiAnalyzeService.java
+++ b/src/main/java/com/insideout/backend/domain/ai/service/CampusAiAnalyzeService.java
@@ -60,8 +60,13 @@ public class CampusAiAnalyzeService {
         } catch (Exception e) {
             log.error("캠퍼스 AI 분석 중 예상치 못한 오류 발생. Job ID: {}", savedJob.getId(), e);
             markFailureSafely(savedJob.getId(), AiErrorCode.AI_ANALYSIS_FAILED.getMessage());
-            throw new AiException(AiErrorCode.AI_ANALYSIS_FAILED);
+            throw new AiException(
+                    AiErrorCode.AI_ANALYSIS_FAILED,
+                    "캠퍼스 AI 분석 중 예상치 못한 오류 발생: " + e.getMessage() + " (" + e.getClass().getSimpleName() + ")",
+                    e
+            );
         }
+
     }
 
     private void markFailureSafely(UUID jobId, String errorMessage) {

--- a/src/main/java/com/insideout/backend/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/insideout/backend/domain/building/controller/BuildingController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,6 +45,20 @@ public class BuildingController {
         return ApiResponse.success(
                 GeneralSuccessCode.OK,
                 buildingService.getBuildings(tenantId)
+        );
+    }
+
+    @Operation(summary = "테넌트 내 건물 단건 조회", description = "특정 테넌트 하위의 건물 상세 정보를 조회합니다.")
+    @GetMapping("/{buildingId}")
+    public ApiResponse<BuildingSummaryDTO> getBuilding(
+            @PathVariable UUID buildingId,
+            @RequestParam UUID tenantId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        return ApiResponse.success(
+                GeneralSuccessCode.OK,
+                buildingService.getBuilding(tenantId, buildingId)
         );
     }
 

--- a/src/main/java/com/insideout/backend/domain/building/controller/CampusController.java
+++ b/src/main/java/com/insideout/backend/domain/building/controller/CampusController.java
@@ -19,6 +19,7 @@ import org.springframework.security.authentication.AuthenticationCredentialsNotF
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,6 +51,21 @@ public class CampusController {
         return ApiResponse.success(
                 GeneralSuccessCode.CREATED,
                 campusService.createCampus(tenantId, request)
+        );
+    }
+
+    @Operation(summary = "캠퍼스 수정", description = "기존 캠퍼스/단지의 지리 정보를 수정합니다.")
+    @PutMapping("/{campusId}")
+    public ApiResponse<CampusResponseDTO> updateCampus(
+            @RequestParam UUID tenantId,
+            @PathVariable UUID campusId,
+            @Valid @RequestBody CampusCreateRequestDTO request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        return ApiResponse.success(
+                GeneralSuccessCode.OK,
+                campusService.updateCampus(tenantId, campusId, request)
         );
     }
 

--- a/src/main/java/com/insideout/backend/domain/building/dto/CampusGateDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/CampusGateDTO.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.building.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CampusGateDTO(
+        String id,
+        @NotBlank String name,
+        @NotNull @Valid CoordinateDTO location
+) {}

--- a/src/main/java/com/insideout/backend/domain/building/dto/request/BuildingCreateRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/request/BuildingCreateRequestDTO.java
@@ -13,6 +13,7 @@ public record BuildingCreateRequestDTO(
         String address,
         @Min(0) int entranceCount,
         UUID campusId,
+        Boolean requiresFloorplan,
         String externalApiId,
         String longitude,
         String latitude,

--- a/src/main/java/com/insideout/backend/domain/building/dto/request/CampusCreateRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/request/CampusCreateRequestDTO.java
@@ -1,6 +1,7 @@
 package com.insideout.backend.domain.building.dto.request;
 
 import com.insideout.backend.domain.building.dto.CoordinateDTO;
+import com.insideout.backend.domain.building.dto.CampusGateDTO;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -13,7 +14,9 @@ public record CampusCreateRequestDTO(
         String address,
         List<@NotNull @Valid CoordinateDTO> boundary,
         @Valid CoordinateDTO centroid,
-        @NotNull @Valid CoordinateDTO primaryEntrance,
+        @Valid CoordinateDTO primaryEntrance,
         String primaryEntranceName,
+        List<@NotNull @Valid CampusGateDTO> gates,
+        Boolean requiresFloorplan,
         Map<String, Object> meta
 ) {}

--- a/src/main/java/com/insideout/backend/domain/building/dto/response/BuildingSummaryDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/response/BuildingSummaryDTO.java
@@ -2,45 +2,103 @@ package com.insideout.backend.domain.building.dto.response;
 
 import com.insideout.backend.domain.building.entity.Building;
 import com.insideout.backend.domain.building.entity.Floor;
+import com.insideout.backend.domain.building.entity.Floorplan;
 
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
+
 public record BuildingSummaryDTO(
         UUID id,
+        UUID tenantId,
         String name,
         String address,
         UUID campusId,
         String campusName,
         int entranceCount,
+        boolean requiresFloorplan,
+        String activationStatus,
         OffsetDateTime createdAt,
         List<FloorDTO> floors
 ) {
     public record FloorDTO(
             UUID id,
             int level,
-            String name
+            String name,
+            UUID floorplanId,
+            String floorplanImageUrl
     ) {
+        public static FloorDTO from(Floor floor, Floorplan floorplan, String imageUrl) {
+            return new FloorDTO(
+                    floor.getId(),
+                    floor.getLevel(),
+                    floor.getName(),
+                    floorplan != null ? floorplan.getId() : null,
+                    imageUrl
+            );
+        }
+
+        public static FloorDTO from(Floor floor, Floorplan floorplan) {
+            return from(floor, floorplan, floorplan != null ? floorplan.getImageUrl() : null);
+        }
+
         public static FloorDTO from(Floor floor) {
-            return new FloorDTO(floor.getId(), floor.getLevel(), floor.getName());
+            return from(floor, null);
         }
     }
 
     public static BuildingSummaryDTO from(Building building) {
-        return from(building, List.of());
+        return from(building, List.of(), java.util.Map.of(), java.util.Map.of());
     }
 
     public static BuildingSummaryDTO from(Building building, List<Floor> floors) {
+        return from(building, floors, java.util.Map.of(), java.util.Map.of());
+    }
+
+    public static BuildingSummaryDTO from(Building building, List<Floor> floors, java.util.Map<UUID, Floorplan> floorplanByFloorId) {
+        return from(building, floors, floorplanByFloorId, java.util.Map.of());
+    }
+
+    public static BuildingSummaryDTO from(Building building, List<Floor> floors, java.util.Map<UUID, Floorplan> floorplanByFloorId, java.util.Map<UUID, String> presignedUrlByFloorplanId) {
         return new BuildingSummaryDTO(
                 building.getId(),
+                building.getTenant().getId(),
                 building.getName(),
                 building.getAddress(),
                 building.getCampus() != null ? building.getCampus().getId() : null,
                 building.getCampus() != null ? building.getCampus().getName() : null,
                 building.getEntranceCount(),
+                extractRequiresFloorplan(building),
+                extractActivationStatus(building),
                 building.getCreatedAt(),
-                floors != null ? floors.stream().map(FloorDTO::from).toList() : List.of()
+                floors != null ? floors.stream()
+                        .map(floor -> {
+                            Floorplan fp = floorplanByFloorId.get(floor.getId());
+                            String url = fp != null ? presignedUrlByFloorplanId.get(fp.getId()) : null;
+                            return FloorDTO.from(floor, fp, url);
+                        })
+                        .toList() : List.of()
         );
     }
+
+    private static boolean extractRequiresFloorplan(Building building) {
+        Object value = building.getMeta() != null ? building.getMeta().get("requiresFloorplan") : null;
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        if (value instanceof String stringValue) {
+            return Boolean.parseBoolean(stringValue);
+        }
+        return false;
+    }
+
+    private static String extractActivationStatus(Building building) {
+        Object value = building.getMeta() != null ? building.getMeta().get("activationStatus") : null;
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            return stringValue;
+        }
+        return "draft";
+    }
 }
+

--- a/src/main/java/com/insideout/backend/domain/building/dto/response/BuildingSummaryDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/response/BuildingSummaryDTO.java
@@ -27,24 +27,26 @@ public record BuildingSummaryDTO(
             int level,
             String name,
             UUID floorplanId,
-            String floorplanImageUrl
+            String floorplanImageUrl,
+            boolean analysisCompleted
     ) {
-        public static FloorDTO from(Floor floor, Floorplan floorplan, String imageUrl) {
+        public static FloorDTO from(Floor floor, Floorplan floorplan, String imageUrl, boolean analysisCompleted) {
             return new FloorDTO(
                     floor.getId(),
                     floor.getLevel(),
                     floor.getName(),
                     floorplan != null ? floorplan.getId() : null,
-                    imageUrl
+                    imageUrl,
+                    analysisCompleted
             );
         }
 
-        public static FloorDTO from(Floor floor, Floorplan floorplan) {
-            return from(floor, floorplan, floorplan != null ? floorplan.getImageUrl() : null);
+        public static FloorDTO from(Floor floor, Floorplan floorplan, boolean analysisCompleted) {
+            return from(floor, floorplan, floorplan != null ? floorplan.getImageUrl() : null, analysisCompleted);
         }
 
         public static FloorDTO from(Floor floor) {
-            return from(floor, null);
+            return from(floor, null, false);
         }
     }
 
@@ -57,10 +59,14 @@ public record BuildingSummaryDTO(
     }
 
     public static BuildingSummaryDTO from(Building building, List<Floor> floors, java.util.Map<UUID, Floorplan> floorplanByFloorId) {
-        return from(building, floors, floorplanByFloorId, java.util.Map.of());
+        return from(building, floors, floorplanByFloorId, java.util.Map.of(), java.util.Map.of());
     }
 
     public static BuildingSummaryDTO from(Building building, List<Floor> floors, java.util.Map<UUID, Floorplan> floorplanByFloorId, java.util.Map<UUID, String> presignedUrlByFloorplanId) {
+        return from(building, floors, floorplanByFloorId, presignedUrlByFloorplanId, java.util.Map.of());
+    }
+
+    public static BuildingSummaryDTO from(Building building, List<Floor> floors, java.util.Map<UUID, Floorplan> floorplanByFloorId, java.util.Map<UUID, String> presignedUrlByFloorplanId, java.util.Map<UUID, Boolean> analysisCompletedByFloorplanId) {
         return new BuildingSummaryDTO(
                 building.getId(),
                 building.getTenant().getId(),
@@ -76,7 +82,8 @@ public record BuildingSummaryDTO(
                         .map(floor -> {
                             Floorplan fp = floorplanByFloorId.get(floor.getId());
                             String url = fp != null ? presignedUrlByFloorplanId.get(fp.getId()) : null;
-                            return FloorDTO.from(floor, fp, url);
+                            boolean analysisCompleted = fp != null && Boolean.TRUE.equals(analysisCompletedByFloorplanId.get(fp.getId()));
+                            return FloorDTO.from(floor, fp, url, analysisCompleted);
                         })
                         .toList() : List.of()
         );
@@ -101,4 +108,3 @@ public record BuildingSummaryDTO(
         return "draft";
     }
 }
-

--- a/src/main/java/com/insideout/backend/domain/building/dto/response/CampusMapResponseDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/response/CampusMapResponseDTO.java
@@ -15,14 +15,19 @@ public record CampusMapResponseDTO(
         OffsetDateTime uploadedAt
 ) {
     public static CampusMapResponseDTO from(CampusMap map) {
+        return from(map, map.getImageUrl());
+    }
+
+    public static CampusMapResponseDTO from(CampusMap map, String imageUrl) {
         return new CampusMapResponseDTO(
                 map.getId(),
                 map.getCampus().getId(),
-                map.getImageUrl(),
+                imageUrl,
                 map.getWidthPx(),
                 map.getHeightPx(),
                 map.isCurrent(),
                 map.getUploadedAt()
         );
     }
+
 }

--- a/src/main/java/com/insideout/backend/domain/building/dto/response/CampusResponseDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/response/CampusResponseDTO.java
@@ -1,6 +1,7 @@
 package com.insideout.backend.domain.building.dto.response;
 
 import com.insideout.backend.domain.building.dto.CoordinateDTO;
+import com.insideout.backend.domain.building.dto.CampusGateDTO;
 import com.insideout.backend.domain.building.entity.Campus;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
@@ -11,6 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.insideout.backend.domain.building.entity.CampusMap;
+
 public record CampusResponseDTO(
         UUID id,
         UUID tenantId,
@@ -20,10 +23,22 @@ public record CampusResponseDTO(
         CoordinateDTO centroid,
         CoordinateDTO primaryEntrance,
         String primaryEntranceName,
+        List<CampusGateDTO> gates,
+        boolean requiresFloorplan,
         Map<String, Object> meta,
-        OffsetDateTime createdAt
+        OffsetDateTime createdAt,
+        UUID currentMapId,
+        String currentMapImageUrl
 ) {
     public static CampusResponseDTO from(Campus campus) {
+        return from(campus, null, null);
+    }
+
+    public static CampusResponseDTO from(Campus campus, CampusMap currentMap) {
+        return from(campus, currentMap, currentMap != null ? currentMap.getImageUrl() : null);
+    }
+
+    public static CampusResponseDTO from(Campus campus, CampusMap currentMap, String currentMapImageUrl) {
         return new CampusResponseDTO(
                 campus.getId(),
                 campus.getTenant().getId(),
@@ -33,10 +48,15 @@ public record CampusResponseDTO(
                 toCoordinateDTO(campus.getCentroid()),
                 toCoordinateDTO(campus.getPrimaryEntrance()),
                 campus.getPrimaryEntranceName(),
+                extractGates(campus.getMeta(), campus.getPrimaryEntrance(), campus.getPrimaryEntranceName()),
+                extractRequiresFloorplan(campus.getMeta()),
                 campus.getMeta(),
-                campus.getCreatedAt()
+                campus.getCreatedAt(),
+                currentMap != null ? currentMap.getId() : null,
+                currentMapImageUrl
         );
     }
+
 
     private static CoordinateDTO toCoordinateDTO(Point point) {
         if (point == null) {
@@ -54,5 +74,72 @@ public record CampusResponseDTO(
             coords.add(new CoordinateDTO(c.x, c.y));
         }
         return coords;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<CampusGateDTO> extractGates(Map<String, Object> meta, Point primaryEntrance, String primaryEntranceName) {
+        Object gatesValue = meta != null ? meta.get("gates") : null;
+        if (gatesValue instanceof List<?> gates && !gates.isEmpty()) {
+            return gates.stream()
+                    .filter(Map.class::isInstance)
+                    .map(Map.class::cast)
+                    .map(entry -> {
+                        Object id = entry.get("id");
+                        Object name = entry.get("name");
+                        Object location = entry.get("location");
+                        if (!(location instanceof Map<?, ?> locationMap)) {
+                            return null;
+                        }
+
+                        Double longitude = asDouble(locationMap.get("longitude"));
+                        Double latitude = asDouble(locationMap.get("latitude"));
+                        if (name == null || longitude == null || latitude == null) {
+                            return null;
+                        }
+
+                        return new CampusGateDTO(
+                                id != null ? String.valueOf(id) : null,
+                                String.valueOf(name),
+                                new CoordinateDTO(longitude, latitude)
+                        );
+                    })
+                    .filter(java.util.Objects::nonNull)
+                    .toList();
+        }
+
+        if (primaryEntrance != null) {
+            return List.of(new CampusGateDTO(
+                    "primary-gate",
+                    primaryEntranceName != null && !primaryEntranceName.isBlank() ? primaryEntranceName : "대표 출입구",
+                    new CoordinateDTO(primaryEntrance.getX(), primaryEntrance.getY())
+            ));
+        }
+
+        return List.of();
+    }
+
+    private static boolean extractRequiresFloorplan(Map<String, Object> meta) {
+        Object value = meta != null ? meta.get("requiresFloorplan") : null;
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        if (value instanceof String stringValue) {
+            return Boolean.parseBoolean(stringValue);
+        }
+        return false;
+    }
+
+    private static Double asDouble(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof String stringValue) {
+            try {
+                return Double.parseDouble(stringValue);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/insideout/backend/domain/building/dto/response/FloorplanResponseDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/response/FloorplanResponseDTO.java
@@ -17,11 +17,15 @@ public record FloorplanResponseDTO(
         OffsetDateTime uploadedAt
 ) {
     public static FloorplanResponseDTO from(Floorplan floorplan) {
+        return from(floorplan, floorplan.getImageUrl());
+    }
+
+    public static FloorplanResponseDTO from(Floorplan floorplan, String imageUrl) {
         return new FloorplanResponseDTO(
                 floorplan.getId(),
                 floorplan.getTenantId(),
                 floorplan.getFloor() != null ? floorplan.getFloor().getId() : null,
-                floorplan.getImageUrl(),
+                imageUrl,
                 floorplan.getImageSha256(),
                 floorplan.getWidthPx(),
                 floorplan.getHeightPx(),
@@ -31,3 +35,4 @@ public record FloorplanResponseDTO(
         );
     }
 }
+

--- a/src/main/java/com/insideout/backend/domain/building/entity/Building.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/Building.java
@@ -132,6 +132,13 @@ public class Building {
         return this.campus != null;
     }
 
+    public void updateEntranceCount(int entranceCount) {
+        if (entranceCount < 0) {
+            throw new BuildingException(BuildingErrorCode.NEGATIVE_ENTRANCE_COUNT);
+        }
+        this.entranceCount = entranceCount;
+    }
+
     private boolean hasDifferentTenant(Tenant tenant, Campus campus) {
         if (tenant == null || campus == null || campus.getTenant() == null) {
             return false;

--- a/src/main/java/com/insideout/backend/domain/building/entity/Campus.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/Campus.java
@@ -89,4 +89,22 @@ public class Campus {
         this.primaryEntranceName = primaryEntranceName;
         this.meta = meta != null ? meta : Map.of();
     }
+
+    public void updateGeography(
+            String name,
+            String address,
+            Polygon boundary,
+            Point centroid,
+            Point primaryEntrance,
+            String primaryEntranceName,
+            Map<String, Object> meta
+    ) {
+        this.name = name;
+        this.address = address;
+        this.boundary = boundary;
+        this.centroid = centroid;
+        this.primaryEntrance = primaryEntrance;
+        this.primaryEntranceName = primaryEntranceName;
+        this.meta = meta != null ? meta : Map.of();
+    }
 }

--- a/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
@@ -59,6 +59,11 @@ public enum BuildingErrorCode implements BaseErrorCode {
         "BUILDING404_4",
         "해당 층을 찾을 수 없습니다."
     ),
+    BUILDING_ENTRANCE_NOT_FOUND(
+        HttpStatus.NOT_FOUND,
+        "BUILDING404_5",
+        "해당 건물 출입구를 찾을 수 없습니다."
+    ),
     UNAUTHORIZED_ACCESS(
         HttpStatus.FORBIDDEN,
         "BUILDING403_1",
@@ -68,6 +73,31 @@ public enum BuildingErrorCode implements BaseErrorCode {
         HttpStatus.BAD_REQUEST,
         "BUILDING400_7",
         "캠퍼스 경계(boundary)는 최소 3개 이상의 유효한 좌표가 필요합니다."
+    ),
+    INVALID_CAMPUS_GATES(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_8",
+        "캠퍼스 출입구(gate)는 최소 1개 이상 필요합니다."
+    ),
+    INVALID_CAMPUS_GATE(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_9",
+        "유효하지 않은 Campus Gate입니다."
+    ),
+    BUILDING_FLOOR_MISMATCH(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_10",
+        "해당 층은 요청한 건물에 속하지 않습니다."
+    ),
+    ENTRANCE_MAPPING_REQUIRES_CAMPUS(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_11",
+        "Campus Gate 매핑은 캠퍼스에 속한 건물에서만 가능합니다."
+    ),
+    POI_CATEGORY_NOT_FOUND(
+        HttpStatus.NOT_FOUND,
+        "BUILDING404_6",
+        "필수 POI 카테고리를 찾을 수 없습니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
@@ -84,6 +84,11 @@ public enum BuildingErrorCode implements BaseErrorCode {
         "BUILDING400_9",
         "유효하지 않은 Campus Gate입니다."
     ),
+    DUPLICATE_CAMPUS_GATE_NAME(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_12",
+        "Campus Gate 이름은 중복될 수 없습니다."
+    ),
     BUILDING_FLOOR_MISMATCH(
         HttpStatus.BAD_REQUEST,
         "BUILDING400_10",

--- a/src/main/java/com/insideout/backend/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/BuildingRepository.java
@@ -13,5 +13,7 @@ public interface BuildingRepository extends JpaRepository<Building, UUID> {
 
     Optional<Building> findByIdAndCampusIsNotNull(UUID id);
 
+    Optional<Building> findByIdAndTenant_Id(UUID id, UUID tenantId);
+
     List<Building> findByTenant_IdOrderByCreatedAtDesc(UUID tenantId);
 }

--- a/src/main/java/com/insideout/backend/domain/building/repository/CampusMapRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/CampusMapRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,6 +16,8 @@ import java.util.UUID;
 public interface CampusMapRepository extends JpaRepository<CampusMap, UUID> {
 
     Optional<CampusMap> findByCampusIdAndIsCurrentTrue(UUID campusId);
+
+    List<CampusMap> findAllByCampusIdInAndIsCurrentTrue(Collection<UUID> campusIds);
 
     Optional<CampusMap> findByIdAndTenantId(UUID id, UUID tenantId);
 

--- a/src/main/java/com/insideout/backend/domain/building/repository/FloorplanRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/FloorplanRepository.java
@@ -7,15 +7,20 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
 
 @Repository
 public interface FloorplanRepository extends JpaRepository<Floorplan, UUID> {
 
     Optional<Floorplan> findByFloorIdAndIsCurrentTrue(UUID floorId);
 
+    List<Floorplan> findAllByFloorIdInAndIsCurrentTrue(java.util.List<UUID> floorIds);
+
     Optional<Floorplan> findByIdAndTenantId(UUID id, UUID tenantId);
+
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Floorplan f SET f.isCurrent = false WHERE f.floor.id = :floorId AND f.isCurrent = true")

--- a/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
@@ -12,13 +12,19 @@ import com.insideout.backend.domain.building.entity.Floor;
 import com.insideout.backend.domain.building.repository.FloorRepository;
 import com.insideout.backend.domain.tenant.entity.Tenant;
 import com.insideout.backend.domain.tenant.repository.TenantRepository;
+import com.insideout.backend.domain.building.repository.FloorplanRepository;
+import com.insideout.backend.domain.building.entity.Floorplan;
+import com.insideout.backend.global.infra.storage.service.S3StorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +35,8 @@ public class BuildingService {
     private final CampusRepository campusRepository;
     private final TenantRepository tenantRepository;
     private final FloorRepository floorRepository;
+    private final FloorplanRepository floorplanRepository;
+    private final S3StorageService s3StorageService;
 
     /**
      * 특정 테넌트에 속한 건물 목록을 최신순으로 조회합니다.
@@ -47,13 +55,28 @@ public class BuildingService {
         Map<UUID, List<Floor>> floorsByBuildingId = allFloors.stream()
                 .collect(java.util.stream.Collectors.groupingBy(floor -> floor.getBuilding().getId()));
 
+        List<UUID> floorIds = allFloors.stream().map(Floor::getId).toList();
+        List<Floorplan> currentFloorplans = floorplanRepository.findAllByFloorIdInAndIsCurrentTrue(floorIds);
+        Map<UUID, Floorplan> floorplanByFloorId = currentFloorplans.stream()
+                .collect(java.util.stream.Collectors.toMap(fp -> fp.getFloor().getId(), fp -> fp));
+
+        Map<UUID, String> presignedUrlByFloorplanId = currentFloorplans.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Floorplan::getId,
+                        fp -> s3StorageService.getPresignedUrlFromS3Url(fp.getImageUrl())
+                ));
+
         return buildings.stream()
                 .map(building -> BuildingSummaryDTO.from(
                         building,
-                        floorsByBuildingId.getOrDefault(building.getId(), List.of())
+                        floorsByBuildingId.getOrDefault(building.getId(), List.of()),
+                        floorplanByFloorId,
+                        presignedUrlByFloorplanId
                 ))
                 .toList();
     }
+
+
 
     /**
      * 특정 테넌트 하위에 새로운 건물을 생성합니다.
@@ -69,14 +92,16 @@ public class BuildingService {
                     .orElseThrow(() -> new BuildingException(BuildingErrorCode.CAMPUS_NOT_FOUND));
         }
 
-        // 위경도 좌표를 JSON meta 맵에 위치 정보로 매핑하여 저장
-        Map<String, Object> meta = Map.of();
+        // 위경도 좌표와 등록 플로우 관련 메타를 JSON에 함께 저장
+        Map<String, Object> meta = new LinkedHashMap<>();
         if (req.longitude() != null && req.latitude() != null) {
-            meta = Map.of("location", Map.of(
+            meta.put("location", Map.of(
                     "longitude", req.longitude(),
                     "latitude", req.latitude()
             ));
         }
+        meta.put("requiresFloorplan", Boolean.TRUE.equals(req.requiresFloorplan()));
+        meta.put("activationStatus", "draft");
 
         Building building = Building.builder()
                 .tenant(tenant)
@@ -91,7 +116,7 @@ public class BuildingService {
 
         Building savedBuilding = buildingRepository.save(building);
 
-        // 건물 등록 시 함께 전달된 층 정보 일괄 저장
+        // 건물 등록 시 함께 전달된 층 정보는 도면 업로드 여부와 관계없이 기본 구조로 먼저 저장합니다.
         List<Floor> savedFloors = List.of();
         if (req.floors() != null && !req.floors().isEmpty()) {
             List<Floor> floorsToSave = req.floors().stream()

--- a/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 
@@ -58,12 +59,19 @@ public class BuildingService {
         List<UUID> floorIds = allFloors.stream().map(Floor::getId).toList();
         List<Floorplan> currentFloorplans = floorplanRepository.findAllByFloorIdInAndIsCurrentTrue(floorIds);
         Map<UUID, Floorplan> floorplanByFloorId = currentFloorplans.stream()
-                .collect(java.util.stream.Collectors.toMap(fp -> fp.getFloor().getId(), fp -> fp));
+                .filter(fp -> fp.getFloor() != null && fp.getFloor().getId() != null)
+                .collect(java.util.stream.Collectors.toMap(
+                        fp -> Objects.requireNonNull(fp.getFloor()).getId(),
+                        fp -> fp,
+                        (existing, replacement) -> existing
+                ));
 
         Map<UUID, String> presignedUrlByFloorplanId = currentFloorplans.stream()
+                .filter(fp -> fp.getImageUrl() != null)
                 .collect(java.util.stream.Collectors.toMap(
                         Floorplan::getId,
-                        fp -> s3StorageService.getPresignedUrlFromS3Url(fp.getImageUrl())
+                        fp -> s3StorageService.getPresignedUrlFromS3Url(fp.getImageUrl()),
+                        (existing, replacement) -> existing
                 ));
 
         return buildings.stream()

--- a/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
@@ -1,5 +1,6 @@
 package com.insideout.backend.domain.building.service;
 
+import com.insideout.backend.domain.ai.repository.AiDetectionRepository;
 import com.insideout.backend.domain.building.dto.request.BuildingCreateRequestDTO;
 import com.insideout.backend.domain.building.dto.response.BuildingSummaryDTO;
 import com.insideout.backend.domain.building.entity.Building;
@@ -37,6 +38,7 @@ public class BuildingService {
     private final TenantRepository tenantRepository;
     private final FloorRepository floorRepository;
     private final FloorplanRepository floorplanRepository;
+    private final AiDetectionRepository aiDetectionRepository;
     private final S3StorageService s3StorageService;
 
     /**
@@ -48,6 +50,22 @@ public class BuildingService {
             return List.of();
         }
 
+        return buildBuildingSummaries(buildings);
+    }
+
+    /**
+     * 특정 테넌트에 속한 건물 단건을 조회합니다.
+     */
+    public BuildingSummaryDTO getBuilding(UUID tenantId, UUID buildingId) {
+        Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        return buildBuildingSummaries(List.of(building)).stream()
+                .findFirst()
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+    }
+
+    private List<BuildingSummaryDTO> buildBuildingSummaries(List<Building> buildings) {
         List<UUID> buildingIds = buildings.stream()
                 .map(Building::getId)
                 .toList();
@@ -74,17 +92,30 @@ public class BuildingService {
                         (existing, replacement) -> existing
                 ));
 
+        List<UUID> floorplanIds = currentFloorplans.stream()
+                .map(Floorplan::getId)
+                .toList();
+        Map<UUID, Boolean> analysisCompletedByFloorplanId = aiDetectionRepository
+                .findAnalyzedFloorplanIdsByTenantIdAndFloorplanIds(
+                        buildings.get(0).getTenant().getId(),
+                        floorplanIds
+                ).stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        java.util.function.Function.identity(),
+                        ignored -> true,
+                        (existing, replacement) -> existing
+                ));
+
         return buildings.stream()
                 .map(building -> BuildingSummaryDTO.from(
                         building,
                         floorsByBuildingId.getOrDefault(building.getId(), List.of()),
                         floorplanByFloorId,
-                        presignedUrlByFloorplanId
+                        presignedUrlByFloorplanId,
+                        analysisCompletedByFloorplanId
                 ))
                 .toList();
     }
-
-
 
     /**
      * 특정 테넌트 하위에 새로운 건물을 생성합니다.

--- a/src/main/java/com/insideout/backend/domain/building/service/CampusService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/CampusService.java
@@ -1,6 +1,7 @@
 package com.insideout.backend.domain.building.service;
 
 import com.insideout.backend.domain.building.dto.CoordinateDTO;
+import com.insideout.backend.domain.building.dto.CampusGateDTO;
 import com.insideout.backend.domain.building.dto.request.CampusCreateRequestDTO;
 import com.insideout.backend.domain.building.dto.response.CampusMapResponseDTO;
 import com.insideout.backend.domain.building.dto.response.CampusResponseDTO;
@@ -34,7 +35,9 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -62,7 +65,13 @@ public class CampusService {
 
         Polygon boundary = createPolygon(req.boundary());
         Point centroid = createPoint(req.centroid());
-        Point primaryEntrance = createPoint(req.primaryEntrance());
+        List<CampusGateDTO> normalizedGates = normalizeGates(req);
+        Point primaryEntrance = !normalizedGates.isEmpty()
+                ? createPoint(normalizedGates.get(0).location())
+                : createPoint(req.primaryEntrance());
+        String primaryEntranceName = !normalizedGates.isEmpty()
+                ? normalizedGates.get(0).name()
+                : req.primaryEntranceName();
 
         Campus campus = Campus.builder()
                 .tenant(tenant)
@@ -71,8 +80,8 @@ public class CampusService {
                 .boundary(boundary)
                 .centroid(centroid)
                 .primaryEntrance(primaryEntrance)
-                .primaryEntranceName(req.primaryEntranceName())
-                .meta(req.meta())
+                .primaryEntranceName(primaryEntranceName)
+                .meta(buildCampusMeta(req.meta(), normalizedGates, req.requiresFloorplan()))
                 .build();
 
         Campus savedCampus = campusRepository.save(campus);
@@ -84,7 +93,12 @@ public class CampusService {
      */
     public List<CampusResponseDTO> getCampuses(UUID tenantId) {
         return campusRepository.findAllByTenant_IdOrderByCreatedAtDesc(tenantId).stream()
-                .map(CampusResponseDTO::from)
+                .map(campus -> {
+                    CampusMap currentMap = campusMapRepository.findByCampusIdAndIsCurrentTrue(campus.getId())
+                            .orElse(null);
+                    String presignedUrl = currentMap != null ? s3StorageService.getPresignedUrlFromS3Url(currentMap.getImageUrl()) : null;
+                    return CampusResponseDTO.from(campus, currentMap, presignedUrl);
+                })
                 .toList();
     }
 
@@ -94,8 +108,12 @@ public class CampusService {
     public CampusResponseDTO getCampus(UUID tenantId, UUID campusId) {
         Campus campus = campusRepository.findByIdAndTenant_Id(campusId, tenantId)
                 .orElseThrow(() -> new BuildingException(BuildingErrorCode.CAMPUS_NOT_FOUND));
-        return CampusResponseDTO.from(campus);
+        CampusMap currentMap = campusMapRepository.findByCampusIdAndIsCurrentTrue(campusId)
+                .orElse(null);
+        String presignedUrl = currentMap != null ? s3StorageService.getPresignedUrlFromS3Url(currentMap.getImageUrl()) : null;
+        return CampusResponseDTO.from(campus, currentMap, presignedUrl);
     }
+
 
     /**
      * 캠퍼스 야외 도면 이미지를 검증 및 업로드하고 DB에 저장합니다.
@@ -155,7 +173,53 @@ public class CampusService {
                 .build();
 
         CampusMap savedMap = campusMapRepository.save(campusMap);
-        return CampusMapResponseDTO.from(savedMap);
+        return CampusMapResponseDTO.from(savedMap, s3StorageService.getPresignedUrlFromS3Url(savedMap.getImageUrl()));
+    }
+
+    private List<CampusGateDTO> normalizeGates(CampusCreateRequestDTO req) {
+        if (req.gates() != null && !req.gates().isEmpty()) {
+            return req.gates().stream()
+                    .map(gate -> new CampusGateDTO(
+                            gate.id() != null && !gate.id().isBlank() ? gate.id() : UUID.randomUUID().toString(),
+                            gate.name(),
+                            gate.location()
+                    ))
+                    .toList();
+        }
+
+        if (req.primaryEntrance() != null) {
+            return List.of(new CampusGateDTO(
+                    UUID.randomUUID().toString(),
+                    req.primaryEntranceName() != null && !req.primaryEntranceName().isBlank() ? req.primaryEntranceName() : "대표 출입구",
+                    req.primaryEntrance()
+            ));
+        }
+
+        throw new BuildingException(BuildingErrorCode.INVALID_CAMPUS_GATES);
+    }
+
+    private Map<String, Object> buildCampusMeta(
+            Map<String, Object> originalMeta,
+            List<CampusGateDTO> gates,
+            Boolean requiresFloorplan
+    ) {
+        Map<String, Object> meta = new LinkedHashMap<>();
+        if (originalMeta != null) {
+            meta.putAll(originalMeta);
+        }
+
+        meta.put("requiresFloorplan", Boolean.TRUE.equals(requiresFloorplan));
+        meta.put("gates", gates.stream()
+                .map(gate -> Map.of(
+                        "id", gate.id(),
+                        "name", gate.name(),
+                        "location", Map.of(
+                                "longitude", gate.location().longitude(),
+                                "latitude", gate.location().latitude()
+                        )
+                ))
+                .toList());
+        return meta;
     }
 
     private Polygon createPolygon(List<CoordinateDTO> boundary) {

--- a/src/main/java/com/insideout/backend/domain/building/service/CampusService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/CampusService.java
@@ -36,9 +36,13 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -88,14 +92,50 @@ public class CampusService {
         return CampusResponseDTO.from(savedCampus);
     }
 
+    @Transactional
+    public CampusResponseDTO updateCampus(UUID tenantId, UUID campusId, CampusCreateRequestDTO req) {
+        Campus campus = campusRepository.findByIdAndTenant_Id(campusId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.CAMPUS_NOT_FOUND));
+
+        Polygon boundary = createPolygon(req.boundary());
+        Point centroid = createPoint(req.centroid());
+        List<CampusGateDTO> normalizedGates = normalizeGates(req);
+        Point primaryEntrance = !normalizedGates.isEmpty()
+                ? createPoint(normalizedGates.get(0).location())
+                : createPoint(req.primaryEntrance());
+        String primaryEntranceName = !normalizedGates.isEmpty()
+                ? normalizedGates.get(0).name()
+                : req.primaryEntranceName();
+
+        campus.updateGeography(
+                req.name(),
+                req.address(),
+                boundary,
+                centroid,
+                primaryEntrance,
+                primaryEntranceName,
+                buildCampusMeta(req.meta(), normalizedGates, req.requiresFloorplan())
+        );
+
+        return CampusResponseDTO.from(campus);
+    }
+
     /**
      * 특정 테넌트의 모든 캠퍼스 목록을 최신순으로 조회합니다.
      */
     public List<CampusResponseDTO> getCampuses(UUID tenantId) {
-        return campusRepository.findAllByTenant_IdOrderByCreatedAtDesc(tenantId).stream()
+        List<Campus> campuses = campusRepository.findAllByTenant_IdOrderByCreatedAtDesc(tenantId);
+        List<UUID> campusIds = campuses.stream()
+                .map(Campus::getId)
+                .toList();
+        Map<UUID, CampusMap> currentMapsByCampusId = campusMapRepository
+                .findAllByCampusIdInAndIsCurrentTrue(campusIds)
+                .stream()
+                .collect(Collectors.toMap(campusMap -> campusMap.getCampus().getId(), Function.identity()));
+
+        return campuses.stream()
                 .map(campus -> {
-                    CampusMap currentMap = campusMapRepository.findByCampusIdAndIsCurrentTrue(campus.getId())
-                            .orElse(null);
+                    CampusMap currentMap = currentMapsByCampusId.get(campus.getId());
                     String presignedUrl = currentMap != null ? s3StorageService.getPresignedUrlFromS3Url(currentMap.getImageUrl()) : null;
                     return CampusResponseDTO.from(campus, currentMap, presignedUrl);
                 })
@@ -178,13 +218,16 @@ public class CampusService {
 
     private List<CampusGateDTO> normalizeGates(CampusCreateRequestDTO req) {
         if (req.gates() != null && !req.gates().isEmpty()) {
-            return req.gates().stream()
+            List<CampusGateDTO> gates = req.gates().stream()
                     .map(gate -> new CampusGateDTO(
                             gate.id() != null && !gate.id().isBlank() ? gate.id() : UUID.randomUUID().toString(),
                             gate.name(),
                             gate.location()
                     ))
                     .toList();
+
+            validateUniqueGateNames(gates);
+            return gates;
         }
 
         if (req.primaryEntrance() != null) {
@@ -196,6 +239,16 @@ public class CampusService {
         }
 
         throw new BuildingException(BuildingErrorCode.INVALID_CAMPUS_GATES);
+    }
+
+    private void validateUniqueGateNames(List<CampusGateDTO> gates) {
+        Set<String> names = new LinkedHashSet<>();
+        for (CampusGateDTO gate : gates) {
+            String normalizedName = gate.name() == null ? "" : gate.name().trim().toLowerCase();
+            if (!names.add(normalizedName)) {
+                throw new BuildingException(BuildingErrorCode.DUPLICATE_CAMPUS_GATE_NAME);
+            }
+        }
     }
 
     private Map<String, Object> buildCampusMeta(

--- a/src/main/java/com/insideout/backend/domain/building/service/FloorplanService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/FloorplanService.java
@@ -28,6 +28,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
+import com.insideout.backend.global.infra.storage.service.S3StorageService;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -38,7 +40,9 @@ public class FloorplanService {
     private final FloorplanRepository floorplanRepository;
     private final UserRepository userRepository;
     private final ImageStorageService imageStorageService;
+    private final S3StorageService s3StorageService;
     private final TenantQueryFacade tenantQueryFacade;
+
 
     /**
      * 도면 이미지를 검증 및 업로드하고 DB에 저장합니다.
@@ -108,8 +112,9 @@ public class FloorplanService {
 
         Floorplan savedFloorplan = floorplanRepository.save(floorplan);
 
-        return FloorplanResponseDTO.from(savedFloorplan);
+        return FloorplanResponseDTO.from(savedFloorplan, s3StorageService.getPresignedUrlFromS3Url(savedFloorplan.getImageUrl()));
     }
+
 
     private String calculateSha256(MultipartFile file) {
         try {

--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -94,7 +94,11 @@ public class MapQueryFacade {
 
     public Optional<RoutingGraph> findPublishedRoutingGraph(MapType mapType, UUID ownerId) {
         Optional<MapVersion> mapVersion = switch (mapType) {
-            case CAMPUS -> mapVersionRepository.findFirstByCampusIdAndMapTypeAndStatus(ownerId, MapType.CAMPUS, "published");
+            case CAMPUS -> mapVersionRepository.findFirstByCampusIdAndMapTypeAndStatusOrderByCreatedAtDesc(
+                    ownerId,
+                    MapType.CAMPUS,
+                    "published"
+            );
             case BUILDING -> mapVersionRepository.findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(
                     ownerId,
                     MapType.BUILDING,

--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -95,7 +95,11 @@ public class MapQueryFacade {
     public Optional<RoutingGraph> findPublishedRoutingGraph(MapType mapType, UUID ownerId) {
         Optional<MapVersion> mapVersion = switch (mapType) {
             case CAMPUS -> mapVersionRepository.findFirstByCampusIdAndMapTypeAndStatus(ownerId, MapType.CAMPUS, "published");
-            case BUILDING -> mapVersionRepository.findFirstByBuildingIdAndMapTypeAndStatus(ownerId, MapType.BUILDING, "published");
+            case BUILDING -> mapVersionRepository.findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(
+                    ownerId,
+                    MapType.BUILDING,
+                    "published"
+            );
         };
 
         return mapVersion.map(version -> toRoutingGraph(mapType, ownerId, version));

--- a/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
@@ -18,4 +18,6 @@ public interface MapVersionRepository extends JpaRepository<MapVersion, UUID> {
     Optional<MapVersion> findFirstByBuildingIdAndMapTypeOrderByCreatedAtDesc(UUID buildingId, MapType mapType);
 
     Optional<MapVersion> findFirstByCampusIdAndMapTypeAndStatus(UUID campusId, MapType mapType, String status);
+
+    Optional<MapVersion> findFirstByCampusIdAndMapTypeAndStatusOrderByCreatedAtDesc(UUID campusId, MapType mapType, String status);
 }

--- a/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
@@ -13,5 +13,9 @@ public interface MapVersionRepository extends JpaRepository<MapVersion, UUID> {
 
     Optional<MapVersion> findFirstByBuildingIdAndMapTypeAndStatus(UUID buildingId, MapType mapType, String status);
 
+    Optional<MapVersion> findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(UUID buildingId, MapType mapType, String status);
+
+    Optional<MapVersion> findFirstByBuildingIdAndMapTypeOrderByCreatedAtDesc(UUID buildingId, MapType mapType);
+
     Optional<MapVersion> findFirstByCampusIdAndMapTypeAndStatus(UUID campusId, MapType mapType, String status);
 }

--- a/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
@@ -34,6 +34,10 @@ public interface NodeRepository extends JpaRepository<Node, UUID> {
 
     List<Node> findByMapVersionId(UUID mapVersionId);
 
+    List<Node> findByMapVersion_Building_IdAndKindCodeOrderByCreatedAtAsc(UUID buildingId, String kindCode);
+
+    long countByMapVersion_Building_IdAndKindCode(UUID buildingId, String kindCode);
+
     @Query(value = """
             SELECT n.*
             FROM node n

--- a/src/main/java/com/insideout/backend/domain/map/repository/PoiRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/PoiRepository.java
@@ -6,9 +6,12 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.List;
 
 @Repository
 public interface PoiRepository extends JpaRepository<Poi, UUID> {
 
     Optional<Poi> findByPublicId(Long publicId);
+
+    List<Poi> findByAnchorNodeIdIn(List<UUID> anchorNodeIds);
 }

--- a/src/main/java/com/insideout/backend/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/ApiResponse.java
@@ -57,7 +57,15 @@ public class ApiResponse<T> {
                 .body(onFailureBody(code, result));
     }
 
+    // [실패] 에러 핸들러에서 사용 (커스텀 메시지 및 데이터 포함)
+    public static <T> ResponseEntity<ApiResponse<T>> onFailureEntity(BaseErrorCode code, String customMessage, T result) {
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(new ApiResponse<>(false, code.getCode(), customMessage, result));
+    }
+
     private static <T> ApiResponse<T> onFailureBody(BaseErrorCode code, T result) {
         return new ApiResponse<>(false, code.getCode(), code.getMessage(), result);
     }
 }
+

--- a/src/main/java/com/insideout/backend/global/apiPayload/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/exception/GlobalExceptionHandler.java
@@ -22,10 +22,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ProjectException.class)
     public ResponseEntity<ApiResponse<Void>> handleCustomException(ProjectException e) {
         BaseErrorCode errorCode = e.getErrorCode();
-        log.error("Custom Exception: {}", errorCode.getMessage());
+        String message = e.getCustomMessage() != null ? e.getCustomMessage() : errorCode.getMessage();
+        log.error("Custom Exception: {} - Details: {}", errorCode.getMessage(), message);
+        if (e.getCause() != null) {
+            log.error("Caused by: ", e.getCause());
+        }
 
-        return ApiResponse.onFailureEntity(errorCode);
+        return ApiResponse.onFailureEntity(errorCode, message, null);
     }
+
 
     // Validation 예외 처리 (MethodArgumentNotValidException)
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/insideout/backend/global/apiPayload/exception/ProjectException.java
+++ b/src/main/java/com/insideout/backend/global/apiPayload/exception/ProjectException.java
@@ -2,10 +2,28 @@ package com.insideout.backend.global.apiPayload.exception;
 
 import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class ProjectException extends RuntimeException {
     private final BaseErrorCode errorCode;
+    private final String customMessage;
+
+    public ProjectException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.customMessage = null;
+    }
+
+    public ProjectException(BaseErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+        this.customMessage = customMessage;
+    }
+
+    public ProjectException(BaseErrorCode errorCode, String customMessage, Throwable cause) {
+        super(customMessage, cause);
+        this.errorCode = errorCode;
+        this.customMessage = customMessage;
+    }
 }
+

--- a/src/main/java/com/insideout/backend/global/infra/storage/service/S3StorageService.java
+++ b/src/main/java/com/insideout/backend/global/infra/storage/service/S3StorageService.java
@@ -23,10 +23,10 @@ import java.util.UUID;
 /**
  * S3/MinIO 스토리지 서비스.
  *
- * 파일 업로드/다운로드/삭제 책임만 가진다.
+ * 파일 업로드/다운로드/삭제 책임을 가진다.
  * 어떤 키(경로)로 저장할지는 호출자가 결정 (예: FloorplanService).
- *
- * AI 서버는 boto3로 직접 인증 다운로드하므로, 여기서 presigned URL 생성은 불필요.
+ * 추가로 getPresignedUrlFromS3Url, generatePresignedDownloadUrl 메서드를 통해
+ * 클라이언트가 직접 다운로드할 수 있는 presigned URL을 생성할 수 있다.
  */
 @Slf4j
 @Service

--- a/src/main/java/com/insideout/backend/global/infra/storage/service/S3StorageService.java
+++ b/src/main/java/com/insideout/backend/global/infra/storage/service/S3StorageService.java
@@ -120,6 +120,32 @@ public class S3StorageService {
     }
 
     /**
+     * s3://bucket-name/key 형식의 URL을 클라이언트 다운로드 가능한 presigned URL로 변환.
+     * 유효기간은 60분으로 지정합니다.
+     */
+    public String getPresignedUrlFromS3Url(String s3Url) {
+        if (s3Url == null || !s3Url.startsWith("s3://")) {
+            return s3Url;
+        }
+
+        try {
+            String bucketPrefix = "s3://";
+            int bucketEnd = s3Url.indexOf("/", bucketPrefix.length());
+            if (bucketEnd == -1) {
+                return s3Url;
+            }
+            String bucket = s3Url.substring(bucketPrefix.length(), bucketEnd);
+            String key = s3Url.substring(bucketEnd + 1);
+
+            return generatePresignedDownloadUrl(bucket, key, Duration.ofMinutes(60));
+        } catch (Exception e) {
+            log.error("Failed to parse S3 URL to presigned URL: {}", s3Url, e);
+            return s3Url;
+        }
+    }
+
+
+    /**
      * 파일 삭제.
      */
     public void delete(String key) {

--- a/src/main/resources/db/migration/V17__expand_campus_ai_detect_types.sql
+++ b/src/main/resources/db/migration/V17__expand_campus_ai_detect_types.sql
@@ -1,7 +1,7 @@
 -- campus_ai_detection 테이블의 detect_type CHECK 제약 조건을 확장합니다.
 -- AI 서버가 실내/실외 공통으로 반환하는 모든 타입을 저장할 수 있도록 합니다.
 
-ALTER TABLE campus_ai_detection DROP CONSTRAINT campus_ai_detection_detect_type_check;
+ALTER TABLE campus_ai_detection DROP CONSTRAINT IF EXISTS campus_ai_detection_detect_type_check;
 
 ALTER TABLE campus_ai_detection
     ADD CONSTRAINT campus_ai_detection_detect_type_check

--- a/src/main/resources/db/migration/V17__expand_campus_ai_detect_types.sql
+++ b/src/main/resources/db/migration/V17__expand_campus_ai_detect_types.sql
@@ -1,0 +1,30 @@
+-- campus_ai_detection 테이블의 detect_type CHECK 제약 조건을 확장합니다.
+-- AI 서버가 실내/실외 공통으로 반환하는 모든 타입을 저장할 수 있도록 합니다.
+
+ALTER TABLE campus_ai_detection DROP CONSTRAINT campus_ai_detection_detect_type_check;
+
+ALTER TABLE campus_ai_detection
+    ADD CONSTRAINT campus_ai_detection_detect_type_check
+        CHECK (detect_type IN (
+            -- 캠퍼스(야외) 전용
+            'campus_gate',          -- 정문/게이트
+            'campus_road',          -- 캠퍼스 도로
+            'building_footprint',   -- 건물 영역
+            'obstacle',             -- 장애물
+
+            -- 실내 구조 (AI가 캠퍼스 도면에서도 감지)
+            'wall',                 -- 벽
+            'door',                 -- 문
+            'corridor',             -- 복도/통행 가능 구역
+            'room',                 -- 방/공간
+            'elevator',             -- 엘리베이터
+            'stair',                -- 계단
+            'escalator',            -- 에스컬레이터
+            'restroom_sign',        -- 화장실 표시
+
+            -- 공통
+            'text',                 -- 텍스트 (OCR)
+            'poi_candidate',        -- POI 후보
+            'node_candidate',       -- 노드 후보
+            'edge_candidate'        -- 엣지 후보
+        ));

--- a/src/main/resources/db/migration/V18__add_building_entrance_mapping.sql
+++ b/src/main/resources/db/migration/V18__add_building_entrance_mapping.sql
@@ -2,6 +2,10 @@ INSERT INTO poi_category (code, path, name_ko, is_system)
 VALUES ('facility.entrance', 'facility.entrance', '출입구', true)
 ON CONFLICT (code) DO NOTHING;
 
+ALTER TABLE building
+    ADD CONSTRAINT uq_building_tenant_id_id_campus_id
+        UNIQUE (tenant_id, id, campus_id);
+
 CREATE TABLE building_entrance_mapping (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     tenant_id uuid NOT NULL,
@@ -13,10 +17,9 @@ CREATE TABLE building_entrance_mapping (
     created_at timestamptz NOT NULL DEFAULT now(),
     UNIQUE (tenant_id, campus_id, campus_gate_id),
     UNIQUE (tenant_id, entrance_node_id),
-    FOREIGN KEY (tenant_id, campus_id) REFERENCES campus(tenant_id, id) ON DELETE CASCADE,
-    FOREIGN KEY (tenant_id, building_id) REFERENCES building(tenant_id, id) ON DELETE CASCADE
+    FOREIGN KEY (tenant_id, building_id, campus_id)
+        REFERENCES building(tenant_id, id, campus_id) ON DELETE CASCADE
 );
 
 CREATE INDEX building_entrance_mapping_building_idx
     ON building_entrance_mapping (tenant_id, building_id, created_at);
-

--- a/src/main/resources/db/migration/V18__add_building_entrance_mapping.sql
+++ b/src/main/resources/db/migration/V18__add_building_entrance_mapping.sql
@@ -1,0 +1,22 @@
+INSERT INTO poi_category (code, path, name_ko, is_system)
+VALUES ('facility.entrance', 'facility.entrance', '출입구', true)
+ON CONFLICT (code) DO NOTHING;
+
+CREATE TABLE building_entrance_mapping (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL,
+    campus_id uuid NOT NULL,
+    building_id uuid NOT NULL,
+    campus_gate_id text NOT NULL,
+    entrance_node_id uuid NOT NULL REFERENCES node(id) ON DELETE CASCADE,
+    entrance_poi_id uuid REFERENCES poi(id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, campus_id, campus_gate_id),
+    UNIQUE (tenant_id, entrance_node_id),
+    FOREIGN KEY (tenant_id, campus_id) REFERENCES campus(tenant_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (tenant_id, building_id) REFERENCES building(tenant_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX building_entrance_mapping_building_idx
+    ON building_entrance_mapping (tenant_id, building_id, created_at);
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #54 

## 📝작업 내용

건물 및 단지 등록 이후, 층별 도면 업로드와 AI 분석 흐름을 지원하기 위해 백엔드 API와 DTO를 정리했습니다.

- Campus 등록 요청/응답 구조를 확장해 다중 Gate 및 메타데이터를 저장할 수 있도록 수정
- Building 등록 시 층(Floor) 정보를 함께 저장하도록 구현
- Building / Campus 응답 DTO를 보강해 프론트에서 층, 도면, 상태 정보를 함께 사용할 수 있도록 정리
- 층별 도면(Floorplan) 업로드 응답을 정리하고, current floorplan 기준 조회 흐름을 보강
- 캠퍼스 및 도면 AI 분석 저장/조회 로직을 보강
- 캠퍼스 AI detect type을 확장해 `wall`, `room`, `corridor`, `door`, `elevator`, `stair`, `escalator`, `restroom_sign` 등을 저장할 수 있도록 수정
- AI detection geometry 변환 및 예외 처리 로직을 보강
- 관련 validation / exception / API response 처리를 정리

추가로 반영된 DB 변경:
- `V17__expand_campus_ai_detect_types.sql`
- `V18__add_building_entrance_mapping.sql`

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - 캠퍼스 게이트 관리 및 출입구 매핑 추가, 캠퍼스 수정 PUT 및 단건 건물 조회 API 추가
  - 캠퍼스/건물 응답에 gates, requiresFloorplan, currentMapId/currentMapImageUrl, 플로어플랜 이미지 URL 및 상태 포함

* **Bug Fixes**
  - AI 감지 기하학 입력 검증/예외 처리 강화 및 분석 실패 시 상세 메시지·원인 보존
  - 캠퍼스맵/빌딩 매핑·조회 시 최신 항목 우선 선택 로직 개선

* **Chores**
  - DB 마이그레이션으로 탐지 타입 확장 및 출입구 매핑 테이블 추가
  - S3 presigned URL 지원 및 여러 리포지토리/DTO 개선사항 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->