### PR TITLE
[feat] /api/v1/users/me 응답에 displayName 추가 및 조회 로직 분리 (#63)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/place/service/search/PlaceSearchBootstrapRunner.java
+++ b/src/main/java/com/insideout/backend/domain/place/service/search/PlaceSearchBootstrapRunner.java
@@ -3,6 +3,7 @@ package com.insideout.backend.domain.place.service.search;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@ConditionalOnBean(JdbcTemplate.class)
 @RequiredArgsConstructor
 public class PlaceSearchBootstrapRunner implements ApplicationRunner {
 

--- a/src/main/java/com/insideout/backend/domain/user/controller/UserQueryController.java
+++ b/src/main/java/com/insideout/backend/domain/user/controller/UserQueryController.java
@@ -1,9 +1,11 @@
 package com.insideout.backend.domain.user.controller;
 
 import com.insideout.backend.domain.user.dto.response.CurrentUserResponse;
+import com.insideout.backend.domain.user.service.UserQueryService;
 import com.insideout.backend.global.apiPayload.ApiResponse;
 import com.insideout.backend.global.apiPayload.code.GeneralSuccessCode;
 import com.insideout.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,16 +13,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
 public class UserQueryController {
+
+	private final UserQueryService userQueryService;
 
 	@GetMapping("/me")
 	public ApiResponse<CurrentUserResponse> me(@AuthenticationPrincipal CustomUserDetails userDetails) {
-		return ApiResponse.success(GeneralSuccessCode.OK,
-			new CurrentUserResponse(
-				userDetails.getUserId(),
-				userDetails.getEmail(),
-				userDetails.getGlobalRole()
-			)
-		);
+		return ApiResponse.success(GeneralSuccessCode.OK, userQueryService.getCurrentUser(userDetails));
 	}
 }

--- a/src/main/java/com/insideout/backend/domain/user/dto/response/CurrentUserResponse.java
+++ b/src/main/java/com/insideout/backend/domain/user/dto/response/CurrentUserResponse.java
@@ -1,11 +1,21 @@
 package com.insideout.backend.domain.user.dto.response;
 
 import com.insideout.backend.domain.user.enums.GlobalRole;
+import com.insideout.backend.global.security.CustomUserDetails;
 import java.util.UUID;
 
 public record CurrentUserResponse(
 	UUID userId,
 	String email,
+	String displayName,
 	GlobalRole globalRole
 ) {
+	public static CurrentUserResponse from(CustomUserDetails userDetails) {
+		return new CurrentUserResponse(
+			userDetails.getUserId(),
+			userDetails.getEmail(),
+			userDetails.getDisplayName(),
+			userDetails.getGlobalRole()
+		);
+	}
 }

--- a/src/main/java/com/insideout/backend/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/insideout/backend/domain/user/service/UserQueryService.java
@@ -1,0 +1,18 @@
+package com.insideout.backend.domain.user.service;
+
+import com.insideout.backend.domain.user.dto.response.CurrentUserResponse;
+import com.insideout.backend.global.security.CustomUserDetails;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserQueryService {
+
+	public CurrentUserResponse getCurrentUser(CustomUserDetails userDetails) {
+		if (userDetails == null) {
+			throw new AuthenticationCredentialsNotFoundException("인증 정보가 없습니다.");
+		}
+		return CurrentUserResponse.from(userDetails);
+	}
+}
+

--- a/src/main/java/com/insideout/backend/global/security/CustomUserDetails.java
+++ b/src/main/java/com/insideout/backend/global/security/CustomUserDetails.java
@@ -17,6 +17,7 @@ public class CustomUserDetails implements UserDetails {
 	private final UUID userId;
 	private final String email;
 	private final String passwordHash;
+	private final String displayName;
 	private final GlobalRole globalRole;
 
 	@Override

--- a/src/main/java/com/insideout/backend/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/insideout/backend/global/security/CustomUserDetailsService.java
@@ -25,6 +25,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 			user.getId(),
 			user.getEmail(),
 			user.getPasswordHash(),
+			user.getDisplayName(),
 			user.getGlobalRole()
 		);
 	}

--- a/src/test/java/com/insideout/backend/domain/building/service/CampusServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/building/service/CampusServiceTest.java
@@ -113,6 +113,8 @@ class CampusServiceTest {
                 new CoordinateDTO(127.05, 37.05),
                 new CoordinateDTO(127.0, 37.0),
                 "Gate 1",
+                null,
+                null,
                 Map.of("key", "value")
         );
 
@@ -146,7 +148,7 @@ class CampusServiceTest {
     @Test
     void createCampus_throwsTenantNotFound() {
         CampusCreateRequestDTO request = new CampusCreateRequestDTO(
-                "Test Campus", "Address", List.of(), null, new CoordinateDTO(127.0, 37.0), "Gate", null
+                "Test Campus", "Address", List.of(), null, new CoordinateDTO(127.0, 37.0), "Gate", null, null, null
         );
         when(tenantRepository.findById(tenantId)).thenReturn(Optional.empty());
 
@@ -160,7 +162,13 @@ class CampusServiceTest {
     void uploadCampusMap_succeeds() throws Exception {
         UUID campusId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        CustomUserDetails userDetails = new CustomUserDetails(userId, "test@example.com", "passwordHash", GlobalRole.TENANT_USER);
+        CustomUserDetails userDetails = new CustomUserDetails(
+                userId,
+                "test@example.com",
+                "passwordHash",
+                "tester",
+                GlobalRole.TENANT_USER
+        );
 
         Campus campus = Campus.builder()
                 .tenant(tenant)
@@ -181,6 +189,7 @@ class CampusServiceTest {
         when(imageStorageService.uploadCampusMapImage(tenantId, campusId, file))
                 .thenReturn("s3://my-bucket/tenants/" + tenantId + "/campuses/" + campusId + "/maps/file.png");
         when(s3StorageService.defaultBucket()).thenReturn("my-bucket");
+        when(s3StorageService.getPresignedUrlFromS3Url(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         when(campusMapRepository.save(any(CampusMap.class))).thenAnswer(invocation -> {
             CampusMap saved = invocation.getArgument(0);
@@ -207,7 +216,7 @@ class CampusServiceTest {
     @Test
     void createCampus_throwsInvalidCampusBoundary_whenBoundaryIsEmpty() {
         CampusCreateRequestDTO request = new CampusCreateRequestDTO(
-                "Test Campus", "Address", List.of(), null, new CoordinateDTO(127.0, 37.0), "Gate", null
+                "Test Campus", "Address", List.of(), null, new CoordinateDTO(127.0, 37.0), "Gate", null, null, null
         );
         when(tenantRepository.findById(tenantId)).thenReturn(Optional.of(tenant));
 
@@ -220,7 +229,7 @@ class CampusServiceTest {
     @Test
     void createCampus_throwsInvalidCampusBoundary_whenBoundaryIsNull() {
         CampusCreateRequestDTO request = new CampusCreateRequestDTO(
-                "Test Campus", "Address", null, null, new CoordinateDTO(127.0, 37.0), "Gate", null
+                "Test Campus", "Address", null, null, new CoordinateDTO(127.0, 37.0), "Gate", null, null, null
         );
         when(tenantRepository.findById(tenantId)).thenReturn(Optional.of(tenant));
 

--- a/src/test/java/com/insideout/backend/domain/user/service/UserQueryServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/user/service/UserQueryServiceTest.java
@@ -1,0 +1,43 @@
+package com.insideout.backend.domain.user.service;
+
+import com.insideout.backend.domain.user.dto.response.CurrentUserResponse;
+import com.insideout.backend.domain.user.enums.GlobalRole;
+import com.insideout.backend.global.security.CustomUserDetails;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserQueryServiceTest {
+
+	private final UserQueryService userQueryService = new UserQueryService();
+
+	@Test
+	void getCurrentUser_returnsDisplayNameInResponse() {
+		UUID userId = UUID.randomUUID();
+		CustomUserDetails userDetails = new CustomUserDetails(
+			userId,
+			"test@example.com",
+			"passwordHash",
+			"tester",
+			GlobalRole.END_USER
+		);
+
+		CurrentUserResponse response = userQueryService.getCurrentUser(userDetails);
+
+		assertThat(response.userId()).isEqualTo(userId);
+		assertThat(response.email()).isEqualTo("test@example.com");
+		assertThat(response.displayName()).isEqualTo("tester");
+		assertThat(response.globalRole()).isEqualTo(GlobalRole.END_USER);
+	}
+
+	@Test
+	void getCurrentUser_throwsWhenPrincipalIsNull() {
+		assertThatThrownBy(() -> userQueryService.getCurrentUser(null))
+			.isInstanceOf(AuthenticationCredentialsNotFoundException.class);
+	}
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #63 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
displayname 필드 추가했어요
실패되는 테스트코드도 잘 돌아가게 수정햇습니다
### 스크린샷 (선택)
<img width="616" height="522" alt="image" src="https://github.com/user-attachments/assets/eb02259d-544b-4940-8f02-8fb5eb0c0dde" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
