### PR TITLE
[fix] 라우팅 페이지 관련 코드 수정(#66)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/place/service/search/PlaceSearchBootstrapRunner.java
+++ b/src/main/java/com/insideout/backend/domain/place/service/search/PlaceSearchBootstrapRunner.java
@@ -5,11 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@ConditionalOnProperty(name = "place.search.bootstrap.enabled", havingValue = "true")
 @RequiredArgsConstructor
 public class PlaceSearchBootstrapRunner implements ApplicationRunner {
 

--- a/src/main/java/com/insideout/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/insideout/backend/global/security/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/places/**").permitAll()
+                        .requestMatchers("/api/v1/navigation/**").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasRole("SYS_ADMIN")
                         .requestMatchers("/api/v1/tenant/**").hasRole("TENANT_USER")
                         .requestMatchers("/api/v1/user/**").hasRole("END_USER")

--- a/src/test/java/com/insideout/backend/domain/building/service/CampusServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/building/service/CampusServiceTest.java
@@ -113,7 +113,9 @@ class CampusServiceTest {
                 new CoordinateDTO(127.05, 37.05),
                 new CoordinateDTO(127.0, 37.0),
                 "Gate 1",
-                Map.of("key", "value")
+                null,
+                null,
+                Map.<String, Object>of("key", "value")
         );
 
         when(tenantRepository.findById(tenantId)).thenReturn(Optional.of(tenant));
@@ -146,7 +148,7 @@ class CampusServiceTest {
     @Test
     void createCampus_throwsTenantNotFound() {
         CampusCreateRequestDTO request = new CampusCreateRequestDTO(
-                "Test Campus", "Address", List.of(), null, new CoordinateDTO(127.0, 37.0), "Gate", null
+                "Test Campus", "Address", List.of(), null, new CoordinateDTO(127.0, 37.0), "Gate", null, null, null
         );
         when(tenantRepository.findById(tenantId)).thenReturn(Optional.empty());
 
@@ -174,13 +176,15 @@ class CampusServiceTest {
         User uploader = User.builder().email("test@example.com").build();
         byte[] pngBytes = createTinyPngBytes();
         MockMultipartFile file = new MockMultipartFile("file", "map.png", "image/png", pngBytes);
+        String imageUrl = "s3://my-bucket/tenants/" + tenantId + "/campuses/" + campusId + "/maps/file.png";
+        String presignedUrl = "http://localhost:9000/my-bucket/tenants/" + tenantId + "/campuses/" + campusId + "/maps/file.png";
 
         when(tenantQueryFacade.isUserMemberOfTenant(userId, tenantId)).thenReturn(true);
         when(campusRepository.findByIdAndTenant_IdForUpdate(campusId, tenantId)).thenReturn(Optional.of(campus));
         when(userRepository.findById(userId)).thenReturn(Optional.of(uploader));
         when(imageStorageService.uploadCampusMapImage(tenantId, campusId, file))
-                .thenReturn("s3://my-bucket/tenants/" + tenantId + "/campuses/" + campusId + "/maps/file.png");
-        when(s3StorageService.defaultBucket()).thenReturn("my-bucket");
+                .thenReturn(imageUrl);
+        when(s3StorageService.getPresignedUrlFromS3Url(imageUrl)).thenReturn(presignedUrl);
 
         when(campusMapRepository.save(any(CampusMap.class))).thenAnswer(invocation -> {
             CampusMap saved = invocation.getArgument(0);
@@ -196,7 +200,7 @@ class CampusServiceTest {
         CampusMapResponseDTO response = campusService.uploadCampusMap(tenantId, campusId, file, userDetails);
 
         assertThat(response.campusId()).isEqualTo(campusId);
-        assertThat(response.imageUrl()).contains("s3://my-bucket/");
+        assertThat(response.imageUrl()).isEqualTo(presignedUrl);
         assertThat(response.widthPx()).isEqualTo(10);
         assertThat(response.heightPx()).isEqualTo(10);
         assertThat(response.isCurrent()).isTrue();
@@ -207,7 +211,7 @@ class CampusServiceTest {
     @Test
     void createCampus_throwsInvalidCampusBoundary_whenBoundaryIsEmpty() {
         CampusCreateRequestDTO request = new CampusCreateRequestDTO(
-                "Test Campus", "Address", List.of(), null, new CoordinateDTO(127.0, 37.0), "Gate", null
+                "Test Campus", "Address", List.of(), null, new CoordinateDTO(127.0, 37.0), "Gate", null, null, null
         );
         when(tenantRepository.findById(tenantId)).thenReturn(Optional.of(tenant));
 
@@ -220,7 +224,7 @@ class CampusServiceTest {
     @Test
     void createCampus_throwsInvalidCampusBoundary_whenBoundaryIsNull() {
         CampusCreateRequestDTO request = new CampusCreateRequestDTO(
-                "Test Campus", "Address", null, null, new CoordinateDTO(127.0, 37.0), "Gate", null
+                "Test Campus", "Address", null, null, new CoordinateDTO(127.0, 37.0), "Gate", null, null, null
         );
         when(tenantRepository.findById(tenantId)).thenReturn(Optional.of(tenant));
 

--- a/src/test/java/com/insideout/backend/domain/navigation/controller/NavigationControllerSecurityTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/controller/NavigationControllerSecurityTest.java
@@ -1,0 +1,80 @@
+package com.insideout.backend.domain.navigation.controller;
+
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto;
+import com.insideout.backend.domain.navigation.service.NavigationService;
+import com.insideout.backend.global.security.CustomUserDetailsService;
+import com.insideout.backend.global.security.SecurityConfig;
+import com.insideout.backend.global.security.jwt.JwtAccessDeniedHandler;
+import com.insideout.backend.global.security.jwt.JwtAuthenticationEntryPoint;
+import com.insideout.backend.global.security.jwt.JwtAuthenticationFilter;
+import com.insideout.backend.global.security.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NavigationController.class)
+@Import({
+        SecurityConfig.class,
+        JwtAuthenticationFilter.class,
+        JwtAuthenticationEntryPoint.class,
+        JwtAccessDeniedHandler.class
+})
+class NavigationControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NavigationService navigationService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    void findRoutes_allowsAnonymousRequest() throws Exception {
+        when(navigationService.findRoutes(any()))
+                .thenReturn(new NavigationResponseDto(
+                        new NavigationResponseDto.CoordinateDto(126.95, 37.47, "도착"),
+                        new NavigationResponseDto.CoordinateDto(126.95, 37.47, "도착"),
+                        null,
+                        List.of(),
+                        List.of(),
+                        null
+                ));
+
+        mockMvc.perform(post("/api/v1/navigation/routes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "startX": 126.951744,
+                                  "startY": 37.478095,
+                                  "endX": 126.95,
+                                  "endY": 37.47,
+                                  "includeIndoor": true,
+                                  "routeTypes": ["WALK"]
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        verify(navigationService).findRoutes(any());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #66 
## 📝작업 내용
>프론트엔드 라우팅 페이지 개발 및 API 연동 과정에서 발견된 백엔드 인증/인가 문제와 관련 테스트 코드의 컴파일 및 컨텍스트 에러를 해결했습니다.

### 1. 비로그인 길찾기 API 허용 (`SecurityConfig`)
* **문제:** `/api/v1/navigation/routes` 주소가 비로그인 허용 목록에서 누락되어 인증 필터(401/403)에 걸리던 현상
* **해결:** `SecurityConfig` 내 `permitAll()` 대상에 `/api/v1/navigation/**` 추가하여 로그인 없이도 길찾기 기능을 이용할 수 있도록 수정

### 2. 컴파일 및 컨텍스트 테스트 오류 해결 (`CampusServiceTest`)
* **생성자 인자 매칭:** `CampusCreateRequestDTO` (Record)의 정의와 테스트 코드 내 생성자 인자 개수가 불일치하여 발생하던 컴파일 오류 해결
* **기대값 수정:** 캠퍼스 맵 업로드 테스트 시 서비스가 원본 S3 URL 대신 **Presigned URL**을 반환하도록 로직이 변경됨에 따라, 테스트 코드의 기대값을 현행화

### 3. 부트스트랩 러너 빈 등록 조건화 (`PlaceSearchBootstrapRunner`)
* **문제:** DB 자동설정을 꺼둔 Context Test 환경에서 `PlaceSearchBootstrapRunner`가 빈 생성 시점에 `JdbcTemplate`을 무조건 요구하여 테스트가 깨지는 현상 (`bootstrapEnabled=false` 임에도 발생)
* **해결:** `@ConditionalOnProperty` 등을 활용하여 `place.search.bootstrap.enabled=true` 일 때만 해당 러너가 빈으로 등록되도록 개선 (DB/JdbcTemplate이 없는 테스트 환경에서도 Context가 안정적으로 로드됨)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 경로 검색 API(`/api/v1/navigation/**`)가 인증 없이 접근 가능해졌습니다.

* **Tests**
  * 경로 검색 기능에 대한 보안 테스트를 추가했습니다.
  * 캠퍼스 관련 테스트의 명확성을 개선했습니다.

* **Chores**
  * 장소 검색 부트스트랩 기능을 설정을 통해 선택적으로 활성화할 수 있도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->