### PR TITLE
[feat] 맵 에디터 기능 (#69)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/building/controller/BuildingEntranceController.java
+++ b/src/main/java/com/insideout/backend/domain/building/controller/BuildingEntranceController.java
@@ -2,10 +2,10 @@ package com.insideout.backend.domain.building.controller;
 
 import com.insideout.backend.domain.ai.exception.AiErrorCode;
 import com.insideout.backend.domain.ai.exception.AiException;
-import com.insideout.backend.domain.building.dto.request.BuildingCreateRequestDTO;
-import com.insideout.backend.domain.building.dto.request.FloorRequestDTO;
-import com.insideout.backend.domain.building.dto.response.BuildingSummaryDTO;
-import com.insideout.backend.domain.building.service.BuildingService;
+import com.insideout.backend.domain.building.dto.request.BuildingEntranceCreateRequestDTO;
+import com.insideout.backend.domain.building.dto.request.BuildingEntranceMappingCreateRequestDTO;
+import com.insideout.backend.domain.building.dto.response.BuildingEntranceResponseDTO;
+import com.insideout.backend.domain.building.service.BuildingEntranceService;
 import com.insideout.backend.domain.tenant.facade.TenantQueryFacade;
 import com.insideout.backend.global.apiPayload.ApiResponse;
 import com.insideout.backend.global.apiPayload.code.GeneralSuccessCode;
@@ -27,81 +27,65 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.UUID;
 
-@Tag(name = "Building", description = "건물 관리 API")
+@Tag(name = "Building Entrance", description = "건물 출입구 및 Campus Gate 매핑 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/buildings")
-public class BuildingController {
+public class BuildingEntranceController {
 
-    private final BuildingService buildingService;
+    private final BuildingEntranceService buildingEntranceService;
     private final TenantQueryFacade tenantQueryFacade;
 
-    @Operation(summary = "테넌트 내 건물 목록 조회", description = "특정 테넌트 하위에 등록된 건물 목록을 조회합니다.")
-    @GetMapping
-    public ApiResponse<List<BuildingSummaryDTO>> getBuildings(
+    @Operation(summary = "건물 출입구 목록 조회", description = "특정 건물에 등록된 출입구 Node/POI 목록과 Gate 매핑 상태를 조회합니다.")
+    @GetMapping("/{buildingId}/entrances")
+    public ApiResponse<List<BuildingEntranceResponseDTO>> getEntrances(
             @RequestParam UUID tenantId,
+            @PathVariable UUID buildingId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         validateTenantAccess(userDetails, tenantId);
         return ApiResponse.success(
                 GeneralSuccessCode.OK,
-                buildingService.getBuildings(tenantId)
+                buildingEntranceService.getEntrances(tenantId, buildingId)
         );
     }
 
-    @Operation(summary = "테넌트 내 건물 단건 조회", description = "특정 테넌트 하위의 건물 상세 정보를 조회합니다.")
-    @GetMapping("/{buildingId}")
-    public ApiResponse<BuildingSummaryDTO> getBuilding(
+    @Operation(summary = "건물 출입구 생성", description = "건물 1층 등 특정 층에 수동 출입구 Node와 Entrance POI를 함께 생성합니다.")
+    @PostMapping("/{buildingId}/entrances")
+    public ApiResponse<BuildingEntranceResponseDTO> createEntrance(
+            @RequestParam UUID tenantId,
             @PathVariable UUID buildingId,
-            @RequestParam UUID tenantId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        validateTenantAccess(userDetails, tenantId);
-        return ApiResponse.success(
-                GeneralSuccessCode.OK,
-                buildingService.getBuilding(tenantId, buildingId)
-        );
-    }
-
-    @Operation(summary = "건물 등록", description = "선택한 테넌트 하위에 새로운 건물을 등록합니다.")
-    @PostMapping
-    public ApiResponse<BuildingSummaryDTO> createBuilding(
-            @RequestParam UUID tenantId,
-            @Valid @RequestBody BuildingCreateRequestDTO request,
+            @Valid @RequestBody BuildingEntranceCreateRequestDTO request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         validateTenantAccess(userDetails, tenantId);
         return ApiResponse.success(
                 GeneralSuccessCode.CREATED,
-                buildingService.createBuilding(tenantId, request)
+                buildingEntranceService.createEntrance(tenantId, buildingId, request)
         );
     }
 
-    @Operation(summary = "건물에 층 추가", description = "특정 건물 하위에 새로운 개별 층을 등록합니다.")
-    @PostMapping("/{buildingId}/floors")
-    public ApiResponse<BuildingSummaryDTO> addFloor(
-            @PathVariable UUID buildingId,
+    @Operation(summary = "Campus Gate와 출입구 매핑", description = "Campus Gate와 건물 출입구 Node를 1:1로 연결합니다.")
+    @PostMapping("/{buildingId}/entrance-mappings")
+    public ApiResponse<BuildingEntranceResponseDTO> mapCampusGate(
             @RequestParam UUID tenantId,
-            @Valid @RequestBody FloorRequestDTO request,
+            @PathVariable UUID buildingId,
+            @Valid @RequestBody BuildingEntranceMappingCreateRequestDTO request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         validateTenantAccess(userDetails, tenantId);
         return ApiResponse.success(
                 GeneralSuccessCode.CREATED,
-                buildingService.addFloor(tenantId, buildingId, request)
+                buildingEntranceService.mapCampusGate(tenantId, buildingId, request)
         );
     }
 
-    /**
-     * 로그인한 유저가 요청한 tenantId에 소속되어 있는지 검증합니다.
-     */
     private void validateTenantAccess(CustomUserDetails userDetails, UUID tenantId) {
         if (userDetails == null) {
             throw new AuthenticationCredentialsNotFoundException("인증 정보가 없습니다.");
         }
 
         if (!tenantQueryFacade.isUserMemberOfTenant(userDetails.getUserId(), tenantId)) {
-            // TODO: 추후 Tenant 도메인으로 예외를 통합하는 것이 좋습니다. 현재는 AiException을 재사용합니다.
             throw new AiException(AiErrorCode.AI_TENANT_NOT_FOUND);
         }
     }

--- a/src/main/java/com/insideout/backend/domain/building/dto/PixelCoordinateDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/PixelCoordinateDTO.java
@@ -1,0 +1,9 @@
+package com.insideout.backend.domain.building.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PixelCoordinateDTO(
+        @NotNull Double x,
+        @NotNull Double y
+) {
+}

--- a/src/main/java/com/insideout/backend/domain/building/dto/request/BuildingEntranceCreateRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/request/BuildingEntranceCreateRequestDTO.java
@@ -1,0 +1,17 @@
+package com.insideout.backend.domain.building.dto.request;
+
+import com.insideout.backend.domain.building.dto.CoordinateDTO;
+import com.insideout.backend.domain.building.dto.PixelCoordinateDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record BuildingEntranceCreateRequestDTO(
+        @NotNull UUID floorId,
+        @NotBlank String name,
+        @Valid PixelCoordinateDTO pixelCoordinate,
+        @Valid CoordinateDTO worldCoordinate
+) {
+}

--- a/src/main/java/com/insideout/backend/domain/building/dto/request/BuildingEntranceMappingCreateRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/request/BuildingEntranceMappingCreateRequestDTO.java
@@ -1,0 +1,12 @@
+package com.insideout.backend.domain.building.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record BuildingEntranceMappingCreateRequestDTO(
+        @NotBlank String campusGateId,
+        @NotNull UUID entranceNodeId
+) {
+}

--- a/src/main/java/com/insideout/backend/domain/building/dto/request/FloorRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/request/FloorRequestDTO.java
@@ -1,0 +1,8 @@
+package com.insideout.backend.domain.building.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FloorRequestDTO(
+        int level,
+        @NotBlank String name
+) {}

--- a/src/main/java/com/insideout/backend/domain/building/dto/response/BuildingEntranceResponseDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/response/BuildingEntranceResponseDTO.java
@@ -1,0 +1,54 @@
+package com.insideout.backend.domain.building.dto.response;
+
+import com.insideout.backend.domain.building.dto.CoordinateDTO;
+import com.insideout.backend.domain.building.dto.PixelCoordinateDTO;
+import com.insideout.backend.domain.map.entity.Node;
+import com.insideout.backend.domain.map.entity.Poi;
+import org.locationtech.jts.geom.Point;
+
+import java.util.UUID;
+
+public record BuildingEntranceResponseDTO(
+        UUID nodeId,
+        UUID poiId,
+        UUID floorId,
+        UUID mapVersionId,
+        String name,
+        PixelCoordinateDTO pixelCoordinate,
+        CoordinateDTO worldCoordinate,
+        String campusGateId,
+        String campusGateName
+) {
+    public static BuildingEntranceResponseDTO from(
+            Node node,
+            Poi poi,
+            String campusGateId,
+            String campusGateName
+    ) {
+        return new BuildingEntranceResponseDTO(
+                node.getId(),
+                poi != null ? poi.getId() : null,
+                node.getFloor() != null ? node.getFloor().getId() : null,
+                node.getMapVersion() != null ? node.getMapVersion().getId() : null,
+                node.getNameKo(),
+                toPixelCoordinate(node.getGeomPx()),
+                toWorldCoordinate(node.getGeomWgs84()),
+                campusGateId,
+                campusGateName
+        );
+    }
+
+    private static PixelCoordinateDTO toPixelCoordinate(Point point) {
+        if (point == null) {
+            return null;
+        }
+        return new PixelCoordinateDTO(point.getX(), point.getY());
+    }
+
+    private static CoordinateDTO toWorldCoordinate(Point point) {
+        if (point == null) {
+            return null;
+        }
+        return new CoordinateDTO(point.getX(), point.getY());
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/building/dto/response/BuildingSummaryDTO.java
+++ b/src/main/java/com/insideout/backend/domain/building/dto/response/BuildingSummaryDTO.java
@@ -51,22 +51,33 @@ public record BuildingSummaryDTO(
     }
 
     public static BuildingSummaryDTO from(Building building) {
-        return from(building, List.of(), java.util.Map.of(), java.util.Map.of());
+        return from(building, List.of(), java.util.Map.of(), java.util.Map.of(), java.util.Map.of(), false);
     }
 
     public static BuildingSummaryDTO from(Building building, List<Floor> floors) {
-        return from(building, floors, java.util.Map.of(), java.util.Map.of());
+        return from(building, floors, java.util.Map.of(), java.util.Map.of(), java.util.Map.of(), false);
     }
 
     public static BuildingSummaryDTO from(Building building, List<Floor> floors, java.util.Map<UUID, Floorplan> floorplanByFloorId) {
-        return from(building, floors, floorplanByFloorId, java.util.Map.of(), java.util.Map.of());
+        return from(building, floors, floorplanByFloorId, java.util.Map.of(), java.util.Map.of(), false);
     }
 
     public static BuildingSummaryDTO from(Building building, List<Floor> floors, java.util.Map<UUID, Floorplan> floorplanByFloorId, java.util.Map<UUID, String> presignedUrlByFloorplanId) {
-        return from(building, floors, floorplanByFloorId, presignedUrlByFloorplanId, java.util.Map.of());
+        return from(building, floors, floorplanByFloorId, presignedUrlByFloorplanId, java.util.Map.of(), false);
     }
 
     public static BuildingSummaryDTO from(Building building, List<Floor> floors, java.util.Map<UUID, Floorplan> floorplanByFloorId, java.util.Map<UUID, String> presignedUrlByFloorplanId, java.util.Map<UUID, Boolean> analysisCompletedByFloorplanId) {
+        return from(building, floors, floorplanByFloorId, presignedUrlByFloorplanId, analysisCompletedByFloorplanId, false);
+    }
+
+    public static BuildingSummaryDTO from(
+            Building building,
+            List<Floor> floors,
+            java.util.Map<UUID, Floorplan> floorplanByFloorId,
+            java.util.Map<UUID, String> presignedUrlByFloorplanId,
+            java.util.Map<UUID, Boolean> analysisCompletedByFloorplanId,
+            boolean published
+    ) {
         return new BuildingSummaryDTO(
                 building.getId(),
                 building.getTenant().getId(),
@@ -76,7 +87,7 @@ public record BuildingSummaryDTO(
                 building.getCampus() != null ? building.getCampus().getName() : null,
                 building.getEntranceCount(),
                 extractRequiresFloorplan(building),
-                extractActivationStatus(building),
+                extractActivationStatus(building, published),
                 building.getCreatedAt(),
                 floors != null ? floors.stream()
                         .map(floor -> {
@@ -100,7 +111,10 @@ public record BuildingSummaryDTO(
         return false;
     }
 
-    private static String extractActivationStatus(Building building) {
+    private static String extractActivationStatus(Building building, boolean published) {
+        if (published) {
+            return "active";
+        }
         Object value = building.getMeta() != null ? building.getMeta().get("activationStatus") : null;
         if (value instanceof String stringValue && !stringValue.isBlank()) {
             return stringValue;

--- a/src/main/java/com/insideout/backend/domain/building/entity/Building.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/Building.java
@@ -14,6 +14,7 @@ import com.insideout.backend.domain.building.exception.BuildingErrorCode;
 import com.insideout.backend.domain.building.exception.BuildingException;
 
 import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -137,6 +138,16 @@ public class Building {
             throw new BuildingException(BuildingErrorCode.NEGATIVE_ENTRANCE_COUNT);
         }
         this.entranceCount = entranceCount;
+    }
+
+    public void updateActivationStatus(String activationStatus) {
+        Map<String, Object> nextMeta = new LinkedHashMap<>(this.meta != null ? this.meta : Map.of());
+        if (activationStatus == null || activationStatus.isBlank()) {
+            nextMeta.remove("activationStatus");
+        } else {
+            nextMeta.put("activationStatus", activationStatus);
+        }
+        this.meta = nextMeta;
     }
 
     private boolean hasDifferentTenant(Tenant tenant, Campus campus) {

--- a/src/main/java/com/insideout/backend/domain/building/entity/BuildingEntranceMapping.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/BuildingEntranceMapping.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,7 +17,19 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "building_entrance_mapping")
+@Table(
+        name = "building_entrance_mapping",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_building_entrance_mapping_gate",
+                        columnNames = {"tenant_id", "campus_id", "campus_gate_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_building_entrance_mapping_node",
+                        columnNames = {"tenant_id", "building_id", "entrance_node_id"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BuildingEntranceMapping {

--- a/src/main/java/com/insideout/backend/domain/building/entity/BuildingEntranceMapping.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/BuildingEntranceMapping.java
@@ -1,0 +1,77 @@
+package com.insideout.backend.domain.building.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "building_entrance_mapping")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BuildingEntranceMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private UUID tenantId;
+
+    @Column(name = "campus_id", nullable = false)
+    private UUID campusId;
+
+    @Column(name = "building_id", nullable = false)
+    private UUID buildingId;
+
+    @Column(name = "campus_gate_id", nullable = false)
+    private String campusGateId;
+
+    @Column(name = "entrance_node_id", nullable = false)
+    private UUID entranceNodeId;
+
+    @Column(name = "entrance_poi_id")
+    private UUID entrancePoiId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now();
+        }
+    }
+
+    @Builder
+    public BuildingEntranceMapping(
+            UUID tenantId,
+            UUID campusId,
+            UUID buildingId,
+            String campusGateId,
+            UUID entranceNodeId,
+            UUID entrancePoiId
+    ) {
+        this.tenantId = tenantId;
+        this.campusId = campusId;
+        this.buildingId = buildingId;
+        this.campusGateId = campusGateId;
+        this.entranceNodeId = entranceNodeId;
+        this.entrancePoiId = entrancePoiId;
+    }
+
+    public void updateEntrance(UUID entranceNodeId, UUID entrancePoiId) {
+        this.entranceNodeId = entranceNodeId;
+        this.entrancePoiId = entrancePoiId;
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/building/entity/FloorplanCalibration.java
+++ b/src/main/java/com/insideout/backend/domain/building/entity/FloorplanCalibration.java
@@ -85,4 +85,8 @@ public class FloorplanCalibration {
         this.rotationDeg = rotationDeg;
         this.rmseM = rmseM;
     }
+
+    public void updateAffine(List<Double> affine) {
+        this.affine = affine;
+    }
 }

--- a/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
@@ -108,6 +108,11 @@ public enum BuildingErrorCode implements BaseErrorCode {
         HttpStatus.BAD_REQUEST,
         "BUILDING400_13",
         "이미 존재하는 층 레벨 또는 이름입니다."
+    ),
+    BUILDING_ENTRANCE_NOT_EDITABLE(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_14",
+        "수정 가능한 초안 상태의 출입구 노드만 매핑할 수 있습니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/building/exception/BuildingErrorCode.java
@@ -103,6 +103,11 @@ public enum BuildingErrorCode implements BaseErrorCode {
         HttpStatus.NOT_FOUND,
         "BUILDING404_6",
         "필수 POI 카테고리를 찾을 수 없습니다."
+    ),
+    DUPLICATE_FLOOR(
+        HttpStatus.BAD_REQUEST,
+        "BUILDING400_13",
+        "이미 존재하는 층 레벨 또는 이름입니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/com/insideout/backend/domain/building/repository/BuildingEntranceMappingRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/BuildingEntranceMappingRepository.java
@@ -1,0 +1,19 @@
+package com.insideout.backend.domain.building.repository;
+
+import com.insideout.backend.domain.building.entity.BuildingEntranceMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface BuildingEntranceMappingRepository extends JpaRepository<BuildingEntranceMapping, UUID> {
+
+    List<BuildingEntranceMapping> findAllByTenantIdAndBuildingIdOrderByCreatedAtAsc(UUID tenantId, UUID buildingId);
+
+    Optional<BuildingEntranceMapping> findByTenantIdAndBuildingIdAndEntranceNodeId(UUID tenantId, UUID buildingId, UUID entranceNodeId);
+
+    Optional<BuildingEntranceMapping> findByTenantIdAndCampusIdAndCampusGateId(UUID tenantId, UUID campusId, String campusGateId);
+}

--- a/src/main/java/com/insideout/backend/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/BuildingRepository.java
@@ -22,6 +22,8 @@ public interface BuildingRepository extends JpaRepository<Building, UUID> {
 
     List<Building> findByTenant_IdOrderByCreatedAtDesc(UUID tenantId);
 
+    List<Building> findByTenant_IdIn(Collection<UUID> tenantIds);
+
     @Query(value = """
             SELECT
                 b.id AS id,

--- a/src/main/java/com/insideout/backend/domain/building/repository/FloorplanCalibrationRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/FloorplanCalibrationRepository.java
@@ -8,5 +8,5 @@ import java.util.UUID;
 
 @Repository
 public interface FloorplanCalibrationRepository extends JpaRepository<FloorplanCalibration, UUID> {
-    java.util.Optional<FloorplanCalibration> findByFloorplanId(UUID floorplanId);
+    java.util.Optional<FloorplanCalibration> findTopByFloorplanIdOrderByCreatedAtDesc(UUID floorplanId);
 }

--- a/src/main/java/com/insideout/backend/domain/building/repository/FloorplanCalibrationRepository.java
+++ b/src/main/java/com/insideout/backend/domain/building/repository/FloorplanCalibrationRepository.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 
 @Repository
 public interface FloorplanCalibrationRepository extends JpaRepository<FloorplanCalibration, UUID> {
+    java.util.Optional<FloorplanCalibration> findByFloorplanId(UUID floorplanId);
 }

--- a/src/main/java/com/insideout/backend/domain/building/service/BuildingEntranceService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/BuildingEntranceService.java
@@ -111,8 +111,21 @@ public class BuildingEntranceService {
     public List<BuildingEntranceResponseDTO> getEntrances(UUID tenantId, UUID buildingId) {
         Building building = getBuilding(tenantId, buildingId);
 
-        List<Node> entranceNodes = nodeRepository.findByMapVersion_Building_IdAndKindCodeOrderByCreatedAtAsc(
-                buildingId,
+        UUID currentMapVersionId = mapVersionRepository
+                .findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(buildingId, MapType.BUILDING, "draft")
+                .map(MapVersion::getId)
+                .orElseGet(() -> mapVersionRepository
+                        .findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(buildingId, MapType.BUILDING, "published")
+                        .map(MapVersion::getId)
+                        .orElse(null)
+                );
+
+        if (currentMapVersionId == null) {
+            return List.of();
+        }
+
+        List<Node> entranceNodes = nodeRepository.findByMapVersionIdAndKindCodeOrderByCreatedAtAsc(
+                currentMapVersionId,
                 ENTRANCE_KIND
         );
         if (entranceNodes.isEmpty()) {
@@ -173,13 +186,25 @@ public class BuildingEntranceService {
             throw new BuildingException(BuildingErrorCode.BUILDING_ENTRANCE_NOT_FOUND);
         }
 
+        boolean isDraft = entranceNode.getMapVersion() != null
+                && "draft".equals(entranceNode.getMapVersion().getStatus());
+        if (!isDraft) {
+            throw new BuildingException(BuildingErrorCode.BUILDING_ENTRANCE_NOT_EDITABLE);
+        }
+
         Optional<BuildingEntranceMapping> existingByGate = buildingEntranceMappingRepository
                 .findByTenantIdAndCampusIdAndCampusGateId(tenantId, campus.getId(), request.campusGateId());
         existingByGate.ifPresent(buildingEntranceMappingRepository::delete);
 
         Optional<BuildingEntranceMapping> existingByNode = buildingEntranceMappingRepository
                 .findByTenantIdAndBuildingIdAndEntranceNodeId(tenantId, buildingId, request.entranceNodeId());
-        existingByNode.ifPresent(buildingEntranceMappingRepository::delete);
+        existingByNode.ifPresent(mapping -> {
+            if (existingByGate.isEmpty() || !existingByGate.get().getId().equals(mapping.getId())) {
+                buildingEntranceMappingRepository.delete(mapping);
+            }
+        });
+        
+        buildingEntranceMappingRepository.flush();
 
         Poi entrancePoi = poiRepository.findByAnchorNodeIdIn(List.of(entranceNode.getId()))
                 .stream()
@@ -237,8 +262,8 @@ public class BuildingEntranceService {
                 });
     }
 
-    private void syncEntranceCount(Building building) {
-        long count = nodeRepository.countByMapVersion_Building_IdAndKindCode(building.getId(), ENTRANCE_KIND);
+    public void syncEntranceCount(Building building) {
+        long count = nodeRepository.countByMapVersion_Building_IdAndKindCodeAndMapVersion_Status(building.getId(), ENTRANCE_KIND, "published");
         building.updateEntranceCount((int) count);
     }
 

--- a/src/main/java/com/insideout/backend/domain/building/service/BuildingEntranceService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/BuildingEntranceService.java
@@ -1,0 +1,296 @@
+package com.insideout.backend.domain.building.service;
+
+import com.insideout.backend.domain.building.dto.CoordinateDTO;
+import com.insideout.backend.domain.building.dto.CampusGateDTO;
+import com.insideout.backend.domain.building.dto.PixelCoordinateDTO;
+import com.insideout.backend.domain.building.dto.request.BuildingEntranceCreateRequestDTO;
+import com.insideout.backend.domain.building.dto.request.BuildingEntranceMappingCreateRequestDTO;
+import com.insideout.backend.domain.building.dto.response.BuildingEntranceResponseDTO;
+import com.insideout.backend.domain.building.entity.Building;
+import com.insideout.backend.domain.building.entity.BuildingEntranceMapping;
+import com.insideout.backend.domain.building.entity.Campus;
+import com.insideout.backend.domain.building.entity.Floor;
+import com.insideout.backend.domain.building.exception.BuildingErrorCode;
+import com.insideout.backend.domain.building.exception.BuildingException;
+import com.insideout.backend.domain.building.repository.BuildingEntranceMappingRepository;
+import com.insideout.backend.domain.building.repository.BuildingRepository;
+import com.insideout.backend.domain.building.repository.FloorRepository;
+import com.insideout.backend.domain.map.entity.MapVersion;
+import com.insideout.backend.domain.map.entity.Node;
+import com.insideout.backend.domain.map.entity.Poi;
+import com.insideout.backend.domain.map.entity.PoiCategory;
+import com.insideout.backend.domain.map.enums.MapType;
+import com.insideout.backend.domain.map.repository.MapVersionRepository;
+import com.insideout.backend.domain.map.repository.NodeRepository;
+import com.insideout.backend.domain.map.repository.PoiCategoryRepository;
+import com.insideout.backend.domain.map.repository.PoiRepository;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BuildingEntranceService {
+
+    private static final GeometryFactory PX_GEOMETRY_FACTORY = new GeometryFactory();
+    private static final GeometryFactory WGS84_GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+    private static final String ENTRANCE_KIND = "entrance";
+    private static final String ENTRANCE_POI_CATEGORY_CODE = "facility.entrance";
+
+    private final BuildingRepository buildingRepository;
+    private final FloorRepository floorRepository;
+    private final MapVersionRepository mapVersionRepository;
+    private final NodeRepository nodeRepository;
+    private final PoiRepository poiRepository;
+    private final PoiCategoryRepository poiCategoryRepository;
+    private final BuildingEntranceMappingRepository buildingEntranceMappingRepository;
+
+    @Transactional
+    public BuildingEntranceResponseDTO createEntrance(
+            UUID tenantId,
+            UUID buildingId,
+            BuildingEntranceCreateRequestDTO request
+    ) {
+        Building building = getBuilding(tenantId, buildingId);
+        Floor floor = floorRepository.findByIdAndBuilding_Id(request.floorId(), buildingId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.FLOOR_NOT_FOUND));
+
+        MapVersion mapVersion = getOrCreateDraftMapVersion(building);
+        PoiCategory entranceCategory = poiCategoryRepository.findByCode(ENTRANCE_POI_CATEGORY_CODE)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.POI_CATEGORY_NOT_FOUND));
+
+        Point geomPx = createPixelPoint(request.pixelCoordinate());
+        Point geomWgs84 = createWorldPoint(request.worldCoordinate());
+        Map<String, Object> nodeProperties = new HashMap<>();
+        if (request.pixelCoordinate() == null) {
+            nodeProperties.put("usesSyntheticPx", true);
+        }
+
+        Node savedNode = nodeRepository.save(Node.builder()
+                .tenantId(tenantId)
+                .mapVersion(mapVersion)
+                .floor(floor)
+                .kindCode(ENTRANCE_KIND)
+                .geomPx(geomPx)
+                .geomWgs84(geomWgs84)
+                .nameKo(request.name())
+                .properties(nodeProperties)
+                .source("manual")
+                .build());
+
+        Poi savedPoi = poiRepository.save(Poi.builder()
+                .tenantId(tenantId)
+                .mapVersion(mapVersion)
+                .floor(floor)
+                .categoryId(entranceCategory.getId())
+                .name(request.name())
+                .geomPx(geomPx)
+                .geomWgs84(geomWgs84 != null ? cloneAsPoint2D(geomWgs84) : null)
+                .anchorNodeId(savedNode.getId())
+                .attrs(Map.of("poiType", "entrance"))
+                .source("manual")
+                .build());
+
+        syncEntranceCount(building);
+        return BuildingEntranceResponseDTO.from(savedNode, savedPoi, null, null);
+    }
+
+    public List<BuildingEntranceResponseDTO> getEntrances(UUID tenantId, UUID buildingId) {
+        Building building = getBuilding(tenantId, buildingId);
+
+        List<Node> entranceNodes = nodeRepository.findByMapVersion_Building_IdAndKindCodeOrderByCreatedAtAsc(
+                buildingId,
+                ENTRANCE_KIND
+        );
+        if (entranceNodes.isEmpty()) {
+            return List.of();
+        }
+
+        Map<UUID, Poi> poiByAnchorNodeId = poiRepository.findByAnchorNodeIdIn(
+                        entranceNodes.stream().map(Node::getId).toList()
+                ).stream()
+                .collect(Collectors.toMap(Poi::getAnchorNodeId, Function.identity()));
+
+        Map<UUID, BuildingEntranceMapping> mappingByNodeId = buildingEntranceMappingRepository
+                .findAllByTenantIdAndBuildingIdOrderByCreatedAtAsc(tenantId, buildingId)
+                .stream()
+                .collect(Collectors.toMap(BuildingEntranceMapping::getEntranceNodeId, Function.identity()));
+
+        Map<String, String> gateNamesById = extractCampusGateNames(building.getCampus());
+
+        return entranceNodes.stream()
+                .map(node -> {
+                    BuildingEntranceMapping mapping = mappingByNodeId.get(node.getId());
+                    String gateId = mapping != null ? mapping.getCampusGateId() : null;
+                    return BuildingEntranceResponseDTO.from(
+                            node,
+                            poiByAnchorNodeId.get(node.getId()),
+                            gateId,
+                            gateId != null ? gateNamesById.get(gateId) : null
+                    );
+                })
+                .toList();
+    }
+
+    @Transactional
+    public BuildingEntranceResponseDTO mapCampusGate(
+            UUID tenantId,
+            UUID buildingId,
+            BuildingEntranceMappingCreateRequestDTO request
+    ) {
+        Building building = getBuilding(tenantId, buildingId);
+        Campus campus = building.getCampus();
+        if (campus == null) {
+            throw new BuildingException(BuildingErrorCode.ENTRANCE_MAPPING_REQUIRES_CAMPUS);
+        }
+
+        Map<String, String> gateNamesById = extractCampusGateNames(campus);
+        String campusGateName = gateNamesById.get(request.campusGateId());
+        if (campusGateName == null) {
+            throw new BuildingException(BuildingErrorCode.INVALID_CAMPUS_GATE);
+        }
+
+        Node entranceNode = nodeRepository.findById(request.entranceNodeId())
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_ENTRANCE_NOT_FOUND));
+
+        boolean belongsToBuilding = entranceNode.getMapVersion() != null
+                && entranceNode.getMapVersion().getBuilding() != null
+                && buildingId.equals(entranceNode.getMapVersion().getBuilding().getId());
+        if (!belongsToBuilding) {
+            throw new BuildingException(BuildingErrorCode.BUILDING_ENTRANCE_NOT_FOUND);
+        }
+
+        Optional<BuildingEntranceMapping> existingByGate = buildingEntranceMappingRepository
+                .findByTenantIdAndCampusIdAndCampusGateId(tenantId, campus.getId(), request.campusGateId());
+        existingByGate.ifPresent(buildingEntranceMappingRepository::delete);
+
+        Optional<BuildingEntranceMapping> existingByNode = buildingEntranceMappingRepository
+                .findByTenantIdAndBuildingIdAndEntranceNodeId(tenantId, buildingId, request.entranceNodeId());
+        existingByNode.ifPresent(buildingEntranceMappingRepository::delete);
+
+        Poi entrancePoi = poiRepository.findByAnchorNodeIdIn(List.of(entranceNode.getId()))
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        // 캠퍼스 게이트와 매핑 시, 해당 노드의 유형(kind)도 "entrance"로 데이터베이스에 자동 갱신되도록 처리합니다.
+        if (!"entrance".equals(entranceNode.getKindCode())) {
+            entranceNode.updateKindCode("entrance");
+        }
+
+        buildingEntranceMappingRepository.save(BuildingEntranceMapping.builder()
+                .tenantId(tenantId)
+                .campusId(campus.getId())
+                .buildingId(buildingId)
+                .campusGateId(request.campusGateId())
+                .entranceNodeId(entranceNode.getId())
+                .entrancePoiId(entrancePoi != null ? entrancePoi.getId() : null)
+                .build());
+
+        return BuildingEntranceResponseDTO.from(
+                entranceNode,
+                entrancePoi,
+                request.campusGateId(),
+                campusGateName
+        );
+    }
+
+    private Building getBuilding(UUID tenantId, UUID buildingId) {
+        return buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+    }
+
+    private MapVersion getOrCreateDraftMapVersion(Building building) {
+        return mapVersionRepository
+                .findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(building.getId(), MapType.BUILDING, "draft")
+                .orElseGet(() -> {
+                    UUID parentVersionId = mapVersionRepository
+                            .findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(
+                                    building.getId(),
+                                    MapType.BUILDING,
+                                    "published"
+                            )
+                            .map(MapVersion::getId)
+                            .orElse(null);
+
+                    return mapVersionRepository.save(MapVersion.builder()
+                            .tenantId(building.getTenant().getId())
+                            .building(building)
+                            .mapType(MapType.BUILDING)
+                            .label(building.getName() + " 출입구 설정 초안")
+                            .status("draft")
+                            .parentVersionId(parentVersionId)
+                            .build());
+                });
+    }
+
+    private void syncEntranceCount(Building building) {
+        long count = nodeRepository.countByMapVersion_Building_IdAndKindCode(building.getId(), ENTRANCE_KIND);
+        building.updateEntranceCount((int) count);
+    }
+
+    private Point createPixelPoint(PixelCoordinateDTO pixelCoordinate) {
+        if (pixelCoordinate == null) {
+            Point fallback = PX_GEOMETRY_FACTORY.createPoint(new Coordinate(0, 0));
+            fallback.setSRID(0);
+            return fallback;
+        }
+        Point point = PX_GEOMETRY_FACTORY.createPoint(new Coordinate(pixelCoordinate.x(), pixelCoordinate.y()));
+        point.setSRID(0);
+        return point;
+    }
+
+    private Point createWorldPoint(CoordinateDTO worldCoordinate) {
+        if (worldCoordinate == null) {
+            return null;
+        }
+        Point point = WGS84_GEOMETRY_FACTORY.createPoint(new Coordinate(worldCoordinate.longitude(), worldCoordinate.latitude()));
+        point.setSRID(4326);
+        return point;
+    }
+
+    private Point cloneAsPoint2D(Point point) {
+        Point cloned = WGS84_GEOMETRY_FACTORY.createPoint(new Coordinate(point.getX(), point.getY()));
+        cloned.setSRID(4326);
+        return cloned;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> extractCampusGateNames(Campus campus) {
+        if (campus == null || campus.getMeta() == null) {
+            return Map.of();
+        }
+
+        Object gatesValue = campus.getMeta().get("gates");
+        if (!(gatesValue instanceof List<?> gates)) {
+            return Map.of();
+        }
+
+        return gates.stream()
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .map(entry -> {
+                    Object id = entry.get("id");
+                    Object name = entry.get("name");
+                    if (id == null || name == null) {
+                        return null;
+                    }
+                    return new CampusGateDTO(String.valueOf(id), String.valueOf(name), null);
+                })
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toMap(CampusGateDTO::id, CampusGateDTO::name, (left, right) -> left));
+    }
+}

--- a/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
@@ -11,6 +11,8 @@ import com.insideout.backend.domain.building.repository.BuildingRepository;
 import com.insideout.backend.domain.building.repository.CampusRepository;
 import com.insideout.backend.domain.building.entity.Floor;
 import com.insideout.backend.domain.building.repository.FloorRepository;
+import com.insideout.backend.domain.map.enums.MapType;
+import com.insideout.backend.domain.map.repository.MapVersionRepository;
 import com.insideout.backend.domain.tenant.entity.Tenant;
 import com.insideout.backend.domain.tenant.repository.TenantRepository;
 import com.insideout.backend.domain.building.repository.FloorplanRepository;
@@ -40,6 +42,7 @@ public class BuildingService {
     private final FloorplanRepository floorplanRepository;
     private final AiDetectionRepository aiDetectionRepository;
     private final S3StorageService s3StorageService;
+    private final MapVersionRepository mapVersionRepository;
 
     /**
      * 특정 테넌트에 속한 건물 목록을 최신순으로 조회합니다.
@@ -69,6 +72,14 @@ public class BuildingService {
         List<UUID> buildingIds = buildings.stream()
                 .map(Building::getId)
                 .toList();
+        Map<UUID, Boolean> publishedByBuildingId = mapVersionRepository
+                .findBuildingIdsByMapTypeAndStatus(buildingIds, MapType.BUILDING, "published")
+                .stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        java.util.function.Function.identity(),
+                        ignored -> true,
+                        (existing, replacement) -> existing
+                ));
 
         List<Floor> allFloors = floorRepository.findAllByBuilding_IdInOrderByLevelDesc(buildingIds);
         Map<UUID, List<Floor>> floorsByBuildingId = allFloors.stream()
@@ -112,7 +123,8 @@ public class BuildingService {
                         floorsByBuildingId.getOrDefault(building.getId(), List.of()),
                         floorplanByFloorId,
                         presignedUrlByFloorplanId,
-                        analysisCompletedByFloorplanId
+                        analysisCompletedByFloorplanId,
+                        Boolean.TRUE.equals(publishedByBuildingId.get(building.getId()))
                 ))
                 .toList();
     }
@@ -170,5 +182,32 @@ public class BuildingService {
         }
 
         return BuildingSummaryDTO.from(savedBuilding, savedFloors);
+    }
+
+    /**
+     * 건물에 층을 추가합니다.
+     */
+    @Transactional
+    public BuildingSummaryDTO addFloor(UUID tenantId, UUID buildingId, com.insideout.backend.domain.building.dto.request.FloorRequestDTO req) {
+        Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        // 해당 건물에 동일한 level 또는 name이 있는지 확인
+        boolean exists = floorRepository.findAllByBuilding_IdInOrderByLevelDesc(List.of(buildingId)).stream()
+                .anyMatch(f -> f.getLevel() == req.level() || f.getName().equalsIgnoreCase(req.name()));
+        if (exists) {
+            throw new BuildingException(BuildingErrorCode.DUPLICATE_FLOOR);
+        }
+
+        Floor floor = Floor.builder()
+                .tenantId(tenantId)
+                .building(building)
+                .level(req.level())
+                .name(req.name())
+                .build();
+
+        floorRepository.save(floor);
+
+        return getBuilding(tenantId, buildingId);
     }
 }

--- a/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
+++ b/src/main/java/com/insideout/backend/domain/building/service/BuildingService.java
@@ -170,6 +170,11 @@ public class BuildingService {
         // 건물 등록 시 함께 전달된 층 정보는 도면 업로드 여부와 관계없이 기본 구조로 먼저 저장합니다.
         List<Floor> savedFloors = List.of();
         if (req.floors() != null && !req.floors().isEmpty()) {
+            List<LevelNamePair> newFloors = req.floors().stream()
+                    .map(f -> new LevelNamePair(f.level(), f.name()))
+                    .toList();
+            validateNoDuplicateFloors(savedBuilding.getId(), newFloors);
+
             List<Floor> floorsToSave = req.floors().stream()
                     .map(f -> Floor.builder()
                             .tenantId(tenantId)
@@ -192,12 +197,7 @@ public class BuildingService {
         Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
                 .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
 
-        // 해당 건물에 동일한 level 또는 name이 있는지 확인
-        boolean exists = floorRepository.findAllByBuilding_IdInOrderByLevelDesc(List.of(buildingId)).stream()
-                .anyMatch(f -> f.getLevel() == req.level() || f.getName().equalsIgnoreCase(req.name()));
-        if (exists) {
-            throw new BuildingException(BuildingErrorCode.DUPLICATE_FLOOR);
-        }
+        validateNoDuplicateFloors(buildingId, List.of(new LevelNamePair(req.level(), req.name())));
 
         Floor floor = Floor.builder()
                 .tenantId(tenantId)
@@ -210,4 +210,35 @@ public class BuildingService {
 
         return getBuilding(tenantId, buildingId);
     }
+
+    private void validateNoDuplicateFloors(UUID buildingId, List<LevelNamePair> newFloors) {
+        if (newFloors == null || newFloors.isEmpty()) {
+            return;
+        }
+
+        // 1. 요청으로 들어온 새로운 층 목록 자체에 중복이 있는지 검사
+        long uniqueLevelCount = newFloors.stream().map(LevelNamePair::level).distinct().count();
+        if (uniqueLevelCount < newFloors.size()) {
+            throw new BuildingException(BuildingErrorCode.DUPLICATE_FLOOR);
+        }
+
+        long uniqueNameCount = newFloors.stream().map(f -> f.name().trim().toLowerCase()).distinct().count();
+        if (uniqueNameCount < newFloors.size()) {
+            throw new BuildingException(BuildingErrorCode.DUPLICATE_FLOOR);
+        }
+
+        // 2. 기존 DB에 저장되어 있는 층들과 중복이 있는지 검사
+        if (buildingId != null) {
+            List<Floor> existingFloors = floorRepository.findAllByBuilding_IdInOrderByLevelDesc(List.of(buildingId));
+            for (LevelNamePair newFloor : newFloors) {
+                boolean conflict = existingFloors.stream()
+                        .anyMatch(f -> f.getLevel() == newFloor.level() || f.getName().trim().equalsIgnoreCase(newFloor.name().trim()));
+                if (conflict) {
+                    throw new BuildingException(BuildingErrorCode.DUPLICATE_FLOOR);
+                }
+            }
+        }
+    }
+
+    private record LevelNamePair(int level, String name) {}
 }

--- a/src/main/java/com/insideout/backend/domain/map/controller/MapEditorController.java
+++ b/src/main/java/com/insideout/backend/domain/map/controller/MapEditorController.java
@@ -2,6 +2,7 @@ package com.insideout.backend.domain.map.controller;
 
 import com.insideout.backend.domain.ai.exception.AiErrorCode;
 import com.insideout.backend.domain.ai.exception.AiException;
+import com.insideout.backend.domain.map.dto.request.MapEditorDraftSaveRequestDTO;
 import com.insideout.backend.domain.map.dto.response.MapEditorInitBuildingDraftResponseDTO;
 import com.insideout.backend.domain.map.dto.response.MapEditorInitResponseDTO;
 import com.insideout.backend.domain.map.service.MapEditorService;
@@ -16,10 +17,19 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestBody;
 
+import com.insideout.backend.domain.map.dto.request.MapEditorVerticalConnectorCreateRequestDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorVerticalConnectorMapRequestDTO;
+import com.insideout.backend.domain.map.dto.response.MapEditorVerticalConnectorDTO;
+import com.insideout.backend.domain.map.dto.response.MapEditorDraftPoiResponseDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorPoiMappingsSaveRequestDTO;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Map Editor", description = "맵 에디터 초기 조회 및 draft 부트스트랩 API")
@@ -69,9 +79,176 @@ public class MapEditorController {
         );
     }
 
+    @Operation(summary = "맵 에디터 층 draft 저장", description = "현재 층의 node, edge, poi, zone 편집 결과를 draft에 저장하고 최신 floor 데이터를 반환합니다.")
+    @PutMapping("/buildings/{buildingId}/floors/{floorId}/draft")
+    public ApiResponse<MapEditorInitResponseDTO> saveFloorDraft(
+            @PathVariable UUID buildingId,
+            @PathVariable UUID floorId,
+            @RequestParam UUID tenantId,
+            @RequestBody MapEditorDraftSaveRequestDTO request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        return ApiResponse.success(
+                GeneralSuccessCode.OK,
+                mapEditorService.saveFloorDraft(
+                        tenantId,
+                        buildingId,
+                        floorId,
+                        userDetails != null ? userDetails.getUserId() : null,
+                        request
+                )
+        );
+    }
+
     private void validateTenantAccess(CustomUserDetails userDetails, UUID tenantId) {
         if (userDetails == null || !tenantQueryFacade.isUserMemberOfTenant(userDetails.getUserId(), tenantId)) {
             throw new AiException(AiErrorCode.AI_TENANT_NOT_FOUND);
         }
+    }
+
+    @Operation(summary = "수직 이동수단 목록 조회", description = "건물의 draft 맵 버전에 등록된 모든 수직 이동수단(엘리베이터, 계단 등)과 연결 노드를 조회합니다.")
+    @GetMapping("/buildings/{buildingId}/vertical-connectors")
+    public ApiResponse<List<MapEditorVerticalConnectorDTO>> getVerticalConnectors(
+            @PathVariable UUID buildingId,
+            @RequestParam UUID tenantId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        return ApiResponse.success(
+                GeneralSuccessCode.OK,
+                mapEditorService.getVerticalConnectors(
+                        tenantId,
+                        buildingId,
+                        userDetails != null ? userDetails.getUserId() : null
+                )
+        );
+    }
+
+    @Operation(summary = "수직 이동수단 생성", description = "신규 수직 이동수단(엘리베이터, 계단 등)을 생성합니다.")
+    @PostMapping("/buildings/{buildingId}/vertical-connectors")
+    public ApiResponse<MapEditorVerticalConnectorDTO> createVerticalConnector(
+            @PathVariable UUID buildingId,
+            @RequestParam UUID tenantId,
+            @RequestBody MapEditorVerticalConnectorCreateRequestDTO request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        return ApiResponse.success(
+                GeneralSuccessCode.OK,
+                mapEditorService.createVerticalConnector(
+                        tenantId,
+                        buildingId,
+                        userDetails != null ? userDetails.getUserId() : null,
+                        request
+                )
+        );
+    }
+
+    @Operation(summary = "수직 이동수단 삭제", description = "지정한 수직 이동수단을 삭제하고 연관된 노드 매핑 관계를 모두 해제합니다.")
+    @DeleteMapping("/buildings/{buildingId}/vertical-connectors/{connectorId}")
+    public ApiResponse<Void> deleteVerticalConnector(
+            @PathVariable UUID buildingId,
+            @PathVariable UUID connectorId,
+            @RequestParam UUID tenantId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        mapEditorService.deleteVerticalConnector(
+                tenantId,
+                buildingId,
+                connectorId,
+                userDetails != null ? userDetails.getUserId() : null
+        );
+        return ApiResponse.success(GeneralSuccessCode.OK, null);
+    }
+
+    @Operation(summary = "수직 이동수단 노드 연결", description = "특정 층의 노드를 지정한 수직 이동수단에 연결(매핑)합니다.")
+    @PostMapping("/buildings/{buildingId}/vertical-connectors/{connectorId}/nodes")
+    public ApiResponse<MapEditorVerticalConnectorDTO> mapVerticalConnectorNode(
+            @PathVariable UUID buildingId,
+            @PathVariable UUID connectorId,
+            @RequestParam UUID tenantId,
+            @RequestBody MapEditorVerticalConnectorMapRequestDTO request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        return ApiResponse.success(
+                GeneralSuccessCode.OK,
+                mapEditorService.mapVerticalConnectorNode(
+                        tenantId,
+                        buildingId,
+                        connectorId,
+                        userDetails != null ? userDetails.getUserId() : null,
+                        request
+                )
+        );
+    }
+
+    @Operation(summary = "수직 이동수단 노드 해제", description = "특정 층의 노드와 수직 이동수단 간의 연결(매핑)을 해제합니다.")
+    @DeleteMapping("/buildings/{buildingId}/vertical-connectors/{connectorId}/floors/{floorId}")
+    public ApiResponse<MapEditorVerticalConnectorDTO> unmapVerticalConnectorNode(
+            @PathVariable UUID buildingId,
+            @PathVariable UUID connectorId,
+            @PathVariable UUID floorId,
+            @RequestParam UUID tenantId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        return ApiResponse.success(
+                GeneralSuccessCode.OK,
+                mapEditorService.unmapVerticalConnectorNode(
+                        tenantId,
+                        buildingId,
+                        connectorId,
+                        floorId,
+                        userDetails != null ? userDetails.getUserId() : null
+                )
+        );
+    }
+
+    @Operation(summary = "맵 드래프트 최종 배포", description = "건물의 현재 draft 버전을 published 상태로 변환하여 최종 배포합니다.")
+    @PostMapping("/buildings/{buildingId}/publish")
+    public ApiResponse<MapEditorInitBuildingDraftResponseDTO> publishBuildingDraft(
+            @PathVariable UUID buildingId,
+            @RequestParam UUID tenantId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        return ApiResponse.success(
+                GeneralSuccessCode.OK,
+                mapEditorService.publishBuildingDraft(
+                        tenantId,
+                        buildingId,
+                        userDetails != null ? userDetails.getUserId() : null
+                )
+        );
+    }
+
+    @Operation(summary = "건물 내 draft POI 전체 조회", description = "최종 배포 전 카카오맵 매핑 및 검증을 위해 건물의 모든 draft POI 목록을 가져옵니다.")
+    @GetMapping("/buildings/{buildingId}/draft-pois")
+    public ApiResponse<List<MapEditorDraftPoiResponseDTO>> getBuildingDraftPois(
+            @PathVariable UUID buildingId,
+            @RequestParam UUID tenantId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        return ApiResponse.success(
+                GeneralSuccessCode.OK,
+                mapEditorService.getBuildingDraftPois(tenantId, buildingId)
+        );
+    }
+
+    @Operation(summary = "POI 외부 API ID 및 위경도 매핑 저장", description = "관리자가 승인/매핑한 POI들의 externalApiId 및 위경도 정보를 draft 상태의 POI에 업데이트합니다.")
+    @PutMapping("/buildings/{buildingId}/poi-mappings")
+    public ApiResponse<Void> saveBuildingPoiMappings(
+            @PathVariable UUID buildingId,
+            @RequestParam UUID tenantId,
+            @RequestBody MapEditorPoiMappingsSaveRequestDTO request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        validateTenantAccess(userDetails, tenantId);
+        mapEditorService.saveBuildingPoiMappings(tenantId, buildingId, request);
+        return ApiResponse.success(GeneralSuccessCode.OK, null);
     }
 }

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftEdgeSaveDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftEdgeSaveDTO.java
@@ -1,0 +1,17 @@
+package com.insideout.backend.domain.map.dto.request;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+
+public record MapEditorDraftEdgeSaveDTO(
+        UUID id,
+        UUID fromNodeId,
+        UUID toNodeId,
+        String kind,
+        Map<String, Object> geomPx,
+        Boolean isDirected,
+        BigDecimal baseWeight,
+        Map<String, Object> properties
+) {
+}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftNodeSaveDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftNodeSaveDTO.java
@@ -1,0 +1,13 @@
+package com.insideout.backend.domain.map.dto.request;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record MapEditorDraftNodeSaveDTO(
+        UUID id,
+        String kind,
+        String name,
+        Map<String, Object> geomPx,
+        Map<String, Object> properties
+) {
+}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftPoiSaveDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftPoiSaveDTO.java
@@ -1,0 +1,16 @@
+package com.insideout.backend.domain.map.dto.request;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record MapEditorDraftPoiSaveDTO(
+        UUID id,
+        String name,
+        String code,
+        Map<String, Object> geomPx,
+        Map<String, Object> footprintPx,
+        UUID anchorNodeId,
+        Map<String, Object> attrs,
+        String externalApiId
+) {
+}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftSaveRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftSaveRequestDTO.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.map.dto.request;
+
+import java.util.List;
+
+public record MapEditorDraftSaveRequestDTO(
+        List<MapEditorDraftNodeSaveDTO> nodes,
+        List<MapEditorDraftEdgeSaveDTO> edges,
+        List<MapEditorDraftPoiSaveDTO> pois,
+        List<MapEditorDraftZoneSaveDTO> zones
+) {
+}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftZoneSaveDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorDraftZoneSaveDTO.java
@@ -1,0 +1,13 @@
+package com.insideout.backend.domain.map.dto.request;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record MapEditorDraftZoneSaveDTO(
+        UUID id,
+        String kind,
+        String name,
+        Map<String, Object> geomPx,
+        Map<String, Object> properties
+) {
+}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorPoiMappingRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorPoiMappingRequestDTO.java
@@ -1,0 +1,13 @@
+package com.insideout.backend.domain.map.dto.request;
+
+import java.util.UUID;
+
+public record MapEditorPoiMappingRequestDTO(
+        UUID poiId,
+        String externalApiId,
+        Double latitude,
+        Double longitude,
+        String placeName,
+        String address,
+        Boolean excluded
+) {}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorPoiMappingRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorPoiMappingRequestDTO.java
@@ -9,5 +9,5 @@ public record MapEditorPoiMappingRequestDTO(
         Double longitude,
         String placeName,
         String address,
-        Boolean excluded
+        boolean excluded
 ) {}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorPoiMappingsSaveRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorPoiMappingsSaveRequestDTO.java
@@ -1,0 +1,7 @@
+package com.insideout.backend.domain.map.dto.request;
+
+import java.util.List;
+
+public record MapEditorPoiMappingsSaveRequestDTO(
+        List<MapEditorPoiMappingRequestDTO> mappings
+) {}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorVerticalConnectorCreateRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorVerticalConnectorCreateRequestDTO.java
@@ -1,0 +1,6 @@
+package com.insideout.backend.domain.map.dto.request;
+
+public record MapEditorVerticalConnectorCreateRequestDTO(
+        String kind,
+        String name
+) {}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorVerticalConnectorMapRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorVerticalConnectorMapRequestDTO.java
@@ -1,0 +1,8 @@
+package com.insideout.backend.domain.map.dto.request;
+
+import java.util.UUID;
+
+public record MapEditorVerticalConnectorMapRequestDTO(
+        UUID floorId,
+        UUID nodeId
+) {}

--- a/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorVerticalConnectorMapRequestDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/request/MapEditorVerticalConnectorMapRequestDTO.java
@@ -1,8 +1,10 @@
 package com.insideout.backend.domain.map.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 import java.util.UUID;
 
 public record MapEditorVerticalConnectorMapRequestDTO(
-        UUID floorId,
-        UUID nodeId
+        @NotNull UUID floorId,
+        @NotNull UUID nodeId
 ) {}

--- a/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorDraftPoiResponseDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorDraftPoiResponseDTO.java
@@ -1,0 +1,18 @@
+package com.insideout.backend.domain.map.dto.response;
+
+import java.util.UUID;
+
+public record MapEditorDraftPoiResponseDTO(
+        UUID id,
+        String name,
+        String code,
+        String floorName,
+        Double pxX,
+        Double pxY,
+        String externalApiId,
+        Double latitude,
+        Double longitude,
+        String mappedPlaceName,
+        String mappedAddress,
+        String reviewStatus
+) {}

--- a/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorEdgeDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorEdgeDTO.java
@@ -4,6 +4,7 @@ import com.insideout.backend.domain.map.entity.Edge;
 
 import java.util.Map;
 import java.util.UUID;
+import java.math.BigDecimal;
 
 public record MapEditorEdgeDTO(
         UUID id,
@@ -12,6 +13,7 @@ public record MapEditorEdgeDTO(
         String kind,
         Map<String, Object> geomPx,
         boolean isDirected,
+        BigDecimal baseWeight,
         Map<String, Object> properties,
         String source,
         UUID aiDetectionId
@@ -24,6 +26,7 @@ public record MapEditorEdgeDTO(
                 edge.getKindCode(),
                 MapGeometryView.toGeoJson(edge.getGeomPx()),
                 edge.isDirected(),
+                edge.getBaseWeight(),
                 edge.getProperties(),
                 edge.getSource(),
                 edge.getAiDetectionId()

--- a/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorInitResponseDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorInitResponseDTO.java
@@ -12,6 +12,10 @@ import java.util.UUID;
 public record MapEditorInitResponseDTO(
         UUID buildingId,
         String buildingName,
+        String buildingAddress,
+        String buildingExternalApiId,
+        Double buildingLatitude,
+        Double buildingLongitude,
         UUID floorId,
         String floorName,
         UUID floorplanId,
@@ -47,6 +51,10 @@ public record MapEditorInitResponseDTO(
         return new MapEditorInitResponseDTO(
                 building.getId(),
                 building.getName(),
+                building.getAddress(),
+                building.getExternalApiId(),
+                resolveBuildingLatitude(building),
+                resolveBuildingLongitude(building),
                 floor.getId(),
                 floor.getName(),
                 floorplan != null ? floorplan.getId() : null,
@@ -64,5 +72,53 @@ public record MapEditorInitResponseDTO(
                 zones,
                 floorplanObjects
         );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Double resolveBuildingLatitude(Building building) {
+        Object location = building.getMeta() != null ? building.getMeta().get("location") : null;
+        if (location instanceof java.util.Map<?, ?> map) {
+            Object latitude = map.get("latitude");
+            if (latitude instanceof Number number) {
+                return number.doubleValue();
+            }
+            if (latitude instanceof String value) {
+                try {
+                    return Double.parseDouble(value);
+                } catch (NumberFormatException ignored) {
+                    // noop
+                }
+            }
+        }
+
+        if (building.getFootprint() != null) {
+            org.locationtech.jts.geom.Point centroid = building.getFootprint().getCentroid();
+            return centroid != null ? centroid.getY() : null;
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Double resolveBuildingLongitude(Building building) {
+        Object location = building.getMeta() != null ? building.getMeta().get("location") : null;
+        if (location instanceof java.util.Map<?, ?> map) {
+            Object longitude = map.get("longitude");
+            if (longitude instanceof Number number) {
+                return number.doubleValue();
+            }
+            if (longitude instanceof String value) {
+                try {
+                    return Double.parseDouble(value);
+                } catch (NumberFormatException ignored) {
+                    // noop
+                }
+            }
+        }
+
+        if (building.getFootprint() != null) {
+            org.locationtech.jts.geom.Point centroid = building.getFootprint().getCentroid();
+            return centroid != null ? centroid.getX() : null;
+        }
+        return null;
     }
 }

--- a/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorVerticalConnectorDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorVerticalConnectorDTO.java
@@ -1,0 +1,11 @@
+package com.insideout.backend.domain.map.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+public record MapEditorVerticalConnectorDTO(
+        UUID id,
+        String kind,
+        String name,
+        List<MapEditorVerticalConnectorNodeDTO> nodes
+) {}

--- a/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorVerticalConnectorNodeDTO.java
+++ b/src/main/java/com/insideout/backend/domain/map/dto/response/MapEditorVerticalConnectorNodeDTO.java
@@ -1,0 +1,10 @@
+package com.insideout.backend.domain.map.dto.response;
+
+import java.util.UUID;
+
+public record MapEditorVerticalConnectorNodeDTO(
+        UUID floorId,
+        String floorName,
+        UUID nodeId,
+        String nodeName
+) {}

--- a/src/main/java/com/insideout/backend/domain/map/entity/MapVersion.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/MapVersion.java
@@ -134,4 +134,13 @@ public class MapVersion {
     private MapType inferMapType(Campus campus) {
         return campus != null ? MapType.CAMPUS : MapType.BUILDING;
     }
+
+    public void publish() {
+        this.status = "published";
+        this.publishedAt = OffsetDateTime.now();
+    }
+
+    public void archive() {
+        this.status = "archived";
+    }
 }

--- a/src/main/java/com/insideout/backend/domain/map/entity/Node.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Node.java
@@ -129,6 +129,9 @@ public class Node {
     }
 
     public void updateKindCode(String kindCode) {
+        if (kindCode == null || kindCode.trim().isEmpty()) {
+            throw new IllegalArgumentException("kindCode cannot be null or empty");
+        }
         this.kindCode = kindCode;
     }
 }

--- a/src/main/java/com/insideout/backend/domain/map/entity/Node.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Node.java
@@ -127,4 +127,8 @@ public class Node {
         this.source = source != null ? source : "manual";
         this.aiDetectionId = aiDetectionId;
     }
+
+    public void updateKindCode(String kindCode) {
+        this.kindCode = kindCode;
+    }
 }

--- a/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
@@ -12,6 +12,7 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 
 import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -27,6 +28,10 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Poi {
+
+    private static final String EXTERNAL_MAPPING_STATUS_ATTR = "externalMappingStatus";
+    private static final String EXTERNAL_MAPPING_NAME_ATTR = "externalMappingPlaceName";
+    private static final String EXTERNAL_MAPPING_ADDRESS_ATTR = "externalMappingAddress";
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -155,5 +160,86 @@ public class Poi {
         this.externalApiId = externalApiId;
         this.source = source != null ? source : "manual";
         this.aiDetectionId = aiDetectionId;
+    }
+
+    public void updateAnchorNodeId(UUID anchorNodeId) {
+        this.anchorNodeId = anchorNodeId;
+    }
+
+    public void updateExternalMapping(String externalApiId, Point geomWgs84) {
+        updateExternalMapping(externalApiId, geomWgs84, null, null);
+    }
+
+    public void updateExternalMapping(String externalApiId, Point geomWgs84, String placeName, String address) {
+        this.externalApiId = externalApiId;
+        this.geomWgs84 = geomWgs84;
+        updateExternalMappingMetadata(placeName, address);
+        updateExternalMappingStatus(externalApiId != null ? "confirmed" : "pending");
+    }
+
+    public void markExternalMappingExcluded() {
+        this.externalApiId = null;
+        this.geomWgs84 = null;
+        clearExternalMappingMetadata();
+        updateExternalMappingStatus("excluded");
+    }
+
+    public String getExternalMappingStatus() {
+        if (externalApiId != null && !externalApiId.isBlank()) {
+            return "confirmed";
+        }
+
+        Object rawStatus = attrs != null ? attrs.get(EXTERNAL_MAPPING_STATUS_ATTR) : null;
+        if (rawStatus instanceof String status && !status.isBlank()) {
+            return status;
+        }
+        return "pending";
+    }
+
+    public String getExternalMappingPlaceName() {
+        return getStringAttr(EXTERNAL_MAPPING_NAME_ATTR);
+    }
+
+    public String getExternalMappingAddress() {
+        return getStringAttr(EXTERNAL_MAPPING_ADDRESS_ATTR);
+    }
+
+    private String getStringAttr(String key) {
+        Object rawValue = attrs != null ? attrs.get(key) : null;
+        if (rawValue instanceof String value && !value.isBlank()) {
+            return value;
+        }
+        return null;
+    }
+
+    private void clearExternalMappingMetadata() {
+        updateExternalMappingMetadata(null, null);
+    }
+
+    private void updateExternalMappingMetadata(String placeName, String address) {
+        Map<String, Object> nextAttrs = new LinkedHashMap<>(attrs != null ? attrs : Map.of());
+        if (placeName == null || placeName.isBlank()) {
+            nextAttrs.remove(EXTERNAL_MAPPING_NAME_ATTR);
+        } else {
+            nextAttrs.put(EXTERNAL_MAPPING_NAME_ATTR, placeName);
+        }
+
+        if (address == null || address.isBlank()) {
+            nextAttrs.remove(EXTERNAL_MAPPING_ADDRESS_ATTR);
+        } else {
+            nextAttrs.put(EXTERNAL_MAPPING_ADDRESS_ATTR, address);
+        }
+
+        this.attrs = nextAttrs;
+    }
+
+    private void updateExternalMappingStatus(String status) {
+        Map<String, Object> nextAttrs = new LinkedHashMap<>(attrs != null ? attrs : Map.of());
+        if (status == null || status.isBlank() || "pending".equals(status)) {
+            nextAttrs.remove(EXTERNAL_MAPPING_STATUS_ATTR);
+        } else {
+            nextAttrs.put(EXTERNAL_MAPPING_STATUS_ATTR, status);
+        }
+        this.attrs = nextAttrs;
     }
 }

--- a/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
+++ b/src/main/java/com/insideout/backend/domain/map/entity/Poi.java
@@ -171,10 +171,11 @@ public class Poi {
     }
 
     public void updateExternalMapping(String externalApiId, Point geomWgs84, String placeName, String address) {
-        this.externalApiId = externalApiId;
+        String normalizedExternalApiId = (externalApiId == null || externalApiId.isBlank()) ? null: externalApiId;
+        this.externalApiId = normalizedExternalApiId;
         this.geomWgs84 = geomWgs84;
         updateExternalMappingMetadata(placeName, address);
-        updateExternalMappingStatus(externalApiId != null ? "confirmed" : "pending");
+        updateExternalMappingStatus(normalizedExternalApiId != null ? "confirmed" : "pending");
     }
 
     public void markExternalMappingExcluded() {

--- a/src/main/java/com/insideout/backend/domain/map/exception/MapErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/map/exception/MapErrorCode.java
@@ -73,6 +73,11 @@ public enum MapErrorCode implements BaseErrorCode {
         HttpStatus.NOT_FOUND,
         "MAP404_1",
         "해당 건물의 맵 버전을 찾을 수 없습니다."
+    ),
+    MAP_VERSION_NOT_EDITABLE(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_13",
+        "수정 가능한 초안 상태의 맵 버전만 변경할 수 있습니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/com/insideout/backend/domain/map/exception/MapErrorCode.java
+++ b/src/main/java/com/insideout/backend/domain/map/exception/MapErrorCode.java
@@ -58,6 +58,21 @@ public enum MapErrorCode implements BaseErrorCode {
         HttpStatus.BAD_REQUEST,
         "MAP400_10",
         "장애물의 floor가 해당 building에 속하지 않습니다."
+    ),
+    PUBLISH_REQUIRES_ENTRANCE_CALIBRATION(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_11",
+        "출입구 캘리브레이션이 완료되지 않아 최종 배포할 수 없습니다."
+    ),
+    PUBLISH_REQUIRES_POI_EXTERNAL_MAPPING(
+        HttpStatus.BAD_REQUEST,
+        "MAP400_12",
+        "외부 장소 매핑 검토가 끝나지 않은 POI가 있어 최종 배포할 수 없습니다."
+    ),
+    MAP_VERSION_NOT_FOUND(
+        HttpStatus.NOT_FOUND,
+        "MAP404_1",
+        "해당 건물의 맵 버전을 찾을 수 없습니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/com/insideout/backend/domain/map/repository/EdgeRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/EdgeRepository.java
@@ -2,6 +2,7 @@ package com.insideout.backend.domain.map.repository;
 
 import com.insideout.backend.domain.map.entity.Edge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -22,6 +23,17 @@ public interface EdgeRepository extends JpaRepository<Edge, UUID> {
               and e.toNode.floor.id = :floorId
             """)
     List<Edge> findByMapVersionIdAndFloorId(
+            @Param("mapVersionId") UUID mapVersionId,
+            @Param("floorId") UUID floorId
+    );
+
+    @Modifying
+    @Query("""
+            delete from Edge e
+            where e.mapVersion.id = :mapVersionId
+              and (e.fromNode.floor.id = :floorId or e.toNode.floor.id = :floorId)
+            """)
+    void deleteByMapVersionIdAndFloorId(
             @Param("mapVersionId") UUID mapVersionId,
             @Param("floorId") UUID floorId
     );

--- a/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/MapVersionRepository.java
@@ -3,15 +3,21 @@ package com.insideout.backend.domain.map.repository;
 import com.insideout.backend.domain.map.entity.MapVersion;
 import com.insideout.backend.domain.map.enums.MapType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Repository
 public interface MapVersionRepository extends JpaRepository<MapVersion, UUID> {
 
     Optional<MapVersion> findFirstByBuildingIdAndMapTypeAndStatus(UUID buildingId, MapType mapType, String status);
+
+    java.util.List<MapVersion> findAllByBuildingIdAndMapTypeAndStatus(UUID buildingId, MapType mapType, String status);
 
     Optional<MapVersion> findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(UUID buildingId, MapType mapType, String status);
 
@@ -20,4 +26,17 @@ public interface MapVersionRepository extends JpaRepository<MapVersion, UUID> {
     Optional<MapVersion> findFirstByCampusIdAndMapTypeAndStatus(UUID campusId, MapType mapType, String status);
 
     Optional<MapVersion> findFirstByCampusIdAndMapTypeAndStatusOrderByCreatedAtDesc(UUID campusId, MapType mapType, String status);
+
+    @Query("""
+            select distinct mv.building.id
+            from MapVersion mv
+            where mv.building.id in :buildingIds
+              and mv.mapType = :mapType
+              and mv.status = :status
+            """)
+    Set<UUID> findBuildingIdsByMapTypeAndStatus(
+            @Param("buildingIds") Collection<UUID> buildingIds,
+            @Param("mapType") MapType mapType,
+            @Param("status") String status
+    );
 }

--- a/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
@@ -37,7 +37,9 @@ public interface NodeRepository extends JpaRepository<Node, UUID> {
 
     List<Node> findByMapVersion_Building_IdAndKindCodeOrderByCreatedAtAsc(UUID buildingId, String kindCode);
 
-    long countByMapVersion_Building_IdAndKindCode(UUID buildingId, String kindCode);
+    List<Node> findByMapVersionIdAndKindCodeOrderByCreatedAtAsc(UUID mapVersionId, String kindCode);
+
+    long countByMapVersion_Building_IdAndKindCodeAndMapVersion_Status(UUID buildingId, String kindCode, String status);
 
     @Query(value = """
             SELECT n.*

--- a/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/NodeRepository.java
@@ -2,6 +2,7 @@ package com.insideout.backend.domain.map.repository;
 
 import com.insideout.backend.domain.map.entity.Node;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -59,4 +60,11 @@ public interface NodeRepository extends JpaRepository<Node, UUID> {
     );
 
     List<Node> findByMapVersionIdAndFloorId(UUID mapVersionId, UUID floorId);
+
+    @Modifying
+    @Query("delete from Node n where n.mapVersion.id = :mapVersionId and n.floor.id = :floorId")
+    void deleteByMapVersionIdAndFloorId(
+            @Param("mapVersionId") UUID mapVersionId,
+            @Param("floorId") UUID floorId
+    );
 }

--- a/src/main/java/com/insideout/backend/domain/map/repository/PoiRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/PoiRepository.java
@@ -2,6 +2,9 @@ package com.insideout.backend.domain.map.repository;
 
 import com.insideout.backend.domain.map.entity.Poi;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -16,4 +19,13 @@ public interface PoiRepository extends JpaRepository<Poi, UUID> {
     List<Poi> findByAnchorNodeIdIn(List<UUID> anchorNodeIds);
 
     List<Poi> findByMapVersionIdAndFloorId(UUID mapVersionId, UUID floorId);
+
+    List<Poi> findByMapVersionId(UUID mapVersionId);
+
+    @Modifying
+    @Query("delete from Poi p where p.mapVersion.id = :mapVersionId and p.floor.id = :floorId")
+    void deleteByMapVersionIdAndFloorId(
+            @Param("mapVersionId") UUID mapVersionId,
+            @Param("floorId") UUID floorId
+    );
 }

--- a/src/main/java/com/insideout/backend/domain/map/repository/VerticalConnectorNodeRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/VerticalConnectorNodeRepository.java
@@ -12,4 +12,10 @@ import java.util.UUID;
 public interface VerticalConnectorNodeRepository extends JpaRepository<VerticalConnectorNode, VerticalConnectorNodeId> {
 
     List<VerticalConnectorNode> findByConnectorMapVersionId(UUID mapVersionId);
+
+    List<VerticalConnectorNode> findByNodeIdIn(List<UUID> nodeIds);
+
+    void deleteByConnectorIdAndFloorId(UUID connectorId, UUID floorId);
+
+    void deleteByConnectorId(UUID connectorId);
 }

--- a/src/main/java/com/insideout/backend/domain/map/repository/VerticalConnectorRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/VerticalConnectorRepository.java
@@ -4,8 +4,10 @@ import com.insideout.backend.domain.map.entity.VerticalConnector;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface VerticalConnectorRepository extends JpaRepository<VerticalConnector, UUID> {
+    List<VerticalConnector> findByMapVersionId(UUID mapVersionId);
 }

--- a/src/main/java/com/insideout/backend/domain/map/repository/ZoneRepository.java
+++ b/src/main/java/com/insideout/backend/domain/map/repository/ZoneRepository.java
@@ -2,6 +2,9 @@ package com.insideout.backend.domain.map.repository;
 
 import com.insideout.backend.domain.map.entity.Zone;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +14,11 @@ import java.util.UUID;
 public interface ZoneRepository extends JpaRepository<Zone, UUID> {
 
     List<Zone> findByMapVersionIdAndFloorId(UUID mapVersionId, UUID floorId);
+
+    @Modifying
+    @Query("delete from Zone z where z.mapVersion.id = :mapVersionId and z.floor.id = :floorId")
+    void deleteByMapVersionIdAndFloorId(
+            @Param("mapVersionId") UUID mapVersionId,
+            @Param("floorId") UUID floorId
+    );
 }

--- a/src/main/java/com/insideout/backend/domain/map/service/MapEditorService.java
+++ b/src/main/java/com/insideout/backend/domain/map/service/MapEditorService.java
@@ -6,13 +6,26 @@ import com.insideout.backend.domain.ai.exception.AiErrorCode;
 import com.insideout.backend.domain.ai.exception.AiException;
 import com.insideout.backend.domain.ai.repository.AiDetectionRepository;
 import com.insideout.backend.domain.building.entity.Building;
+import com.insideout.backend.domain.building.entity.BuildingEntranceMapping;
 import com.insideout.backend.domain.building.entity.Floor;
 import com.insideout.backend.domain.building.entity.Floorplan;
 import com.insideout.backend.domain.building.exception.BuildingErrorCode;
 import com.insideout.backend.domain.building.exception.BuildingException;
+import com.insideout.backend.domain.building.repository.BuildingEntranceMappingRepository;
 import com.insideout.backend.domain.building.repository.BuildingRepository;
 import com.insideout.backend.domain.building.repository.FloorRepository;
 import com.insideout.backend.domain.building.repository.FloorplanRepository;
+import com.insideout.backend.domain.building.entity.Campus;
+import com.insideout.backend.domain.building.entity.FloorplanCalibration;
+import com.insideout.backend.domain.building.repository.FloorplanCalibrationRepository;
+import com.insideout.backend.domain.map.entity.VerticalConnector;
+import com.insideout.backend.domain.map.entity.VerticalConnectorNode;
+import com.insideout.backend.domain.map.repository.VerticalConnectorRepository;
+import com.insideout.backend.domain.map.repository.VerticalConnectorNodeRepository;
+import com.insideout.backend.domain.map.dto.request.MapEditorVerticalConnectorCreateRequestDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorVerticalConnectorMapRequestDTO;
+import com.insideout.backend.domain.map.dto.response.MapEditorVerticalConnectorDTO;
+import com.insideout.backend.domain.map.dto.response.MapEditorVerticalConnectorNodeDTO;
 import com.insideout.backend.domain.map.dto.response.MapEditorEdgeDTO;
 import com.insideout.backend.domain.map.dto.response.MapEditorFloorplanObjectDTO;
 import com.insideout.backend.domain.map.dto.response.MapEditorInitBuildingDraftFloorDTO;
@@ -21,6 +34,14 @@ import com.insideout.backend.domain.map.dto.response.MapEditorInitResponseDTO;
 import com.insideout.backend.domain.map.dto.response.MapEditorNodeDTO;
 import com.insideout.backend.domain.map.dto.response.MapEditorPoiDTO;
 import com.insideout.backend.domain.map.dto.response.MapEditorZoneDTO;
+import com.insideout.backend.domain.map.dto.response.MapEditorDraftPoiResponseDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorPoiMappingsSaveRequestDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorPoiMappingRequestDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorDraftEdgeSaveDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorDraftNodeSaveDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorDraftPoiSaveDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorDraftSaveRequestDTO;
+import com.insideout.backend.domain.map.dto.request.MapEditorDraftZoneSaveDTO;
 import com.insideout.backend.domain.map.entity.Edge;
 import com.insideout.backend.domain.map.entity.FloorplanObject;
 import com.insideout.backend.domain.map.entity.MapVersion;
@@ -40,20 +61,27 @@ import com.insideout.backend.domain.map.repository.ZoneRepository;
 import com.insideout.backend.domain.user.entity.User;
 import com.insideout.backend.domain.user.repository.UserRepository;
 import com.insideout.backend.global.infra.storage.service.S3StorageService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.math.RoundingMode;
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -70,6 +98,7 @@ public class MapEditorService {
     private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new org.locationtech.jts.geom.PrecisionModel(), 0);
 
     private final BuildingRepository buildingRepository;
+    private final BuildingEntranceMappingRepository buildingEntranceMappingRepository;
     private final FloorRepository floorRepository;
     private final FloorplanRepository floorplanRepository;
     private final MapVersionRepository mapVersionRepository;
@@ -82,6 +111,11 @@ public class MapEditorService {
     private final PoiCategoryRepository poiCategoryRepository;
     private final UserRepository userRepository;
     private final S3StorageService s3StorageService;
+    private final VerticalConnectorRepository verticalConnectorRepository;
+    private final VerticalConnectorNodeRepository verticalConnectorNodeRepository;
+    private final FloorplanCalibrationRepository floorplanCalibrationRepository;
+    @PersistenceContext
+    private final EntityManager entityManager;
 
     @Transactional
     public MapEditorInitResponseDTO getOrInitializeFloorDraft(
@@ -116,30 +150,88 @@ public class MapEditorService {
                 ? s3StorageService.getPresignedUrlFromS3Url(currentFloorplan.getImageUrl())
                 : null;
 
-        return MapEditorInitResponseDTO.of(
+        return buildFloorDraftResponse(
                 building,
                 floor,
                 currentFloorplan,
                 floorplanImageUrl,
                 draftMapVersion,
                 draftCreated,
-                initializedFromAi,
-                aiDetections.stream().map(DetectionViewDTO::from).toList(),
-                nodeRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId).stream()
-                        .map(MapEditorNodeDTO::from)
-                        .toList(),
-                edgeRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId).stream()
-                        .map(MapEditorEdgeDTO::from)
-                        .toList(),
-                poiRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId).stream()
-                        .map(MapEditorPoiDTO::from)
-                        .toList(),
-                zoneRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId).stream()
-                        .map(MapEditorZoneDTO::from)
-                        .toList(),
-                floorplanObjectRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId).stream()
-                        .map(MapEditorFloorplanObjectDTO::from)
-                        .toList()
+                initializedFromAi
+        );
+    }
+
+    @Transactional
+    public MapEditorInitResponseDTO saveFloorDraft(
+            UUID tenantId,
+            UUID buildingId,
+            UUID floorId,
+            UUID userId,
+            MapEditorDraftSaveRequestDTO request
+    ) {
+        Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+        Floor floor = floorRepository.findByIdAndBuilding_Id(floorId, buildingId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.FLOOR_NOT_FOUND));
+
+        DraftMapVersionResult draftResult = getOrCreateBuildingDraftMapVersion(building, userId);
+        MapVersion draftMapVersion = draftResult.mapVersion();
+        List<UUID> existingFloorNodeIds = nodeRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId).stream()
+                .map(Node::getId)
+                .toList();
+        Map<UUID, Poi> existingPoisById = poiRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId).stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Poi::getId,
+                        java.util.function.Function.identity(),
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new
+                ));
+
+        List<BuildingEntranceMapping> floorMappings = buildingEntranceMappingRepository
+                .findAllByTenantIdAndBuildingIdOrderByCreatedAtAsc(tenantId, buildingId).stream()
+                .filter(m -> existingFloorNodeIds.contains(m.getEntranceNodeId()))
+                .toList();
+
+        List<VerticalConnectorNode> floorConnectorNodes = existingFloorNodeIds.isEmpty()
+                ? List.of()
+                : verticalConnectorNodeRepository.findByNodeIdIn(existingFloorNodeIds);
+
+        if (!floorMappings.isEmpty()) {
+            buildingEntranceMappingRepository.deleteAll(floorMappings);
+            buildingEntranceMappingRepository.flush();
+        }
+
+        if (!floorConnectorNodes.isEmpty()) {
+            verticalConnectorNodeRepository.deleteAll(floorConnectorNodes);
+            verticalConnectorNodeRepository.flush();
+        }
+
+        edgeRepository.deleteByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId);
+        poiRepository.deleteByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId);
+        zoneRepository.deleteByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId);
+        nodeRepository.deleteByMapVersionIdAndFloorId(draftMapVersion.getId(), floorId);
+
+        Map<UUID, Node> savedNodesByRequestId = saveDraftNodes(draftMapVersion, floor, request.nodes());
+        saveDraftZones(draftMapVersion, floor, request.zones());
+        saveDraftPois(draftMapVersion, floor, request.pois(), savedNodesByRequestId, existingPoisById);
+        saveDraftEdges(draftMapVersion, request.edges(), savedNodesByRequestId);
+        syncEntranceMappingsAfterFloorDraftSave(savedNodesByRequestId, floorMappings);
+        syncVerticalConnectorNodesAfterFloorDraftSave(savedNodesByRequestId, floorConnectorNodes);
+
+        Floorplan currentFloorplan = floorplanRepository.findByFloorIdAndIsCurrentTrue(floorId)
+                .orElse(null);
+        String floorplanImageUrl = currentFloorplan != null && currentFloorplan.getImageUrl() != null
+                ? s3StorageService.getPresignedUrlFromS3Url(currentFloorplan.getImageUrl())
+                : null;
+
+        return buildFloorDraftResponse(
+                building,
+                floor,
+                currentFloorplan,
+                floorplanImageUrl,
+                draftMapVersion,
+                false,
+                false
         );
     }
 
@@ -223,6 +315,46 @@ public class MapEditorService {
         );
     }
 
+    private MapEditorInitResponseDTO buildFloorDraftResponse(
+            Building building,
+            Floor floor,
+            Floorplan currentFloorplan,
+            String floorplanImageUrl,
+            MapVersion draftMapVersion,
+            boolean draftCreated,
+            boolean initializedFromAi
+    ) {
+        List<AiDetection> aiDetections = currentFloorplan != null
+                ? aiDetectionRepository.findByFloorplanIdAndTenantId(currentFloorplan.getId(), building.getTenant().getId())
+                : List.of();
+
+        return MapEditorInitResponseDTO.of(
+                building,
+                floor,
+                currentFloorplan,
+                floorplanImageUrl,
+                draftMapVersion,
+                draftCreated,
+                initializedFromAi,
+                aiDetections.stream().map(DetectionViewDTO::from).toList(),
+                nodeRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floor.getId()).stream()
+                        .map(MapEditorNodeDTO::from)
+                        .toList(),
+                edgeRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floor.getId()).stream()
+                        .map(MapEditorEdgeDTO::from)
+                        .toList(),
+                poiRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floor.getId()).stream()
+                        .map(MapEditorPoiDTO::from)
+                        .toList(),
+                zoneRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floor.getId()).stream()
+                        .map(MapEditorZoneDTO::from)
+                        .toList(),
+                floorplanObjectRepository.findByMapVersionIdAndFloorId(draftMapVersion.getId(), floor.getId()).stream()
+                        .map(MapEditorFloorplanObjectDTO::from)
+                        .toList()
+        );
+    }
+
     private FloorDraftContentState getFloorDraftContentState(UUID mapVersionId, UUID floorId) {
         return new FloorDraftContentState(
                 !zoneRepository.findByMapVersionIdAndFloorId(mapVersionId, floorId).isEmpty(),
@@ -253,16 +385,17 @@ public class MapEditorService {
 
     private MapVersion createDraftMapVersion(Building building, UUID userId) {
         User createdBy = userId != null ? userRepository.findById(userId).orElse(null) : null;
-        UUID parentVersionId = mapVersionRepository
+        Optional<MapVersion> latestPublishedVersion = mapVersionRepository
                 .findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(
                         building.getId(),
                         MapType.BUILDING,
                         "published"
-                )
+                );
+        UUID parentVersionId = latestPublishedVersion
                 .map(MapVersion::getId)
                 .orElse(null);
 
-        return mapVersionRepository.save(
+        MapVersion draftMapVersion = mapVersionRepository.save(
                 MapVersion.builder()
                         .tenantId(building.getTenant().getId())
                         .building(building)
@@ -273,6 +406,155 @@ public class MapEditorService {
                         .createdBy(createdBy)
                         .build()
         );
+
+        latestPublishedVersion.ifPresent(published -> clonePublishedMapVersionIntoDraft(building, published, draftMapVersion));
+        return draftMapVersion;
+    }
+
+    private void clonePublishedMapVersionIntoDraft(
+            Building building,
+            MapVersion publishedMapVersion,
+            MapVersion draftMapVersion
+    ) {
+        List<Floor> floors = floorRepository.findAllByBuilding_IdOrderByLevelDesc(building.getId());
+
+        Map<UUID, Node> clonedNodesBySourceId = new LinkedHashMap<>();
+        List<Node> sourceNodes = nodeRepository.findByMapVersionId(publishedMapVersion.getId());
+        if (!sourceNodes.isEmpty()) {
+            List<Node> savedNodes = nodeRepository.saveAll(sourceNodes.stream()
+                    .map(node -> Node.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .floor(node.getFloor())
+                            .kindCode(node.getKindCode())
+                            .geomPx(node.getGeomPx())
+                            .geomWgs84(node.getGeomWgs84())
+                            .nameKo(node.getNameKo())
+                            .properties(node.getProperties())
+                            .source(node.getSource())
+                            .aiDetectionId(node.getAiDetectionId())
+                            .build())
+                    .toList());
+
+            for (int index = 0; index < sourceNodes.size(); index++) {
+                clonedNodesBySourceId.put(sourceNodes.get(index).getId(), savedNodes.get(index));
+            }
+        }
+
+        List<Zone> zonesToClone = new ArrayList<>();
+        List<FloorplanObject> floorplanObjectsToClone = new ArrayList<>();
+        for (Floor floor : floors) {
+            zonesToClone.addAll(zoneRepository.findByMapVersionIdAndFloorId(publishedMapVersion.getId(), floor.getId()));
+            floorplanObjectsToClone.addAll(floorplanObjectRepository.findByMapVersionIdAndFloorId(publishedMapVersion.getId(), floor.getId()));
+        }
+
+        if (!zonesToClone.isEmpty()) {
+            zoneRepository.saveAll(zonesToClone.stream()
+                    .map(zone -> Zone.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .floor(zone.getFloor())
+                            .kind(zone.getKind())
+                            .name(zone.getName())
+                            .geomPx(zone.getGeomPx())
+                            .properties(zone.getProperties())
+                            .build())
+                    .toList());
+        }
+
+        if (!floorplanObjectsToClone.isEmpty()) {
+            floorplanObjectRepository.saveAll(floorplanObjectsToClone.stream()
+                    .map(object -> FloorplanObject.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .floor(object.getFloor())
+                            .kind(object.getKind())
+                            .geomPx(object.getGeomPx())
+                            .properties(object.getProperties())
+                            .source(object.getSource())
+                            .aiDetectionId(object.getAiDetectionId())
+                            .build())
+                    .toList());
+        }
+
+        List<Poi> sourcePois = poiRepository.findByMapVersionId(publishedMapVersion.getId());
+        if (!sourcePois.isEmpty()) {
+            poiRepository.saveAll(sourcePois.stream()
+                    .map(poi -> Poi.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .floor(poi.getFloor())
+                            .categoryId(poi.getCategoryId())
+                            .name(poi.getName())
+                            .code(poi.getCode())
+                            .geomPx(poi.getGeomPx())
+                            .footprintPx(poi.getFootprintPx())
+                            .geomWgs84(poi.getGeomWgs84())
+                            .anchorNodeId(Optional.ofNullable(poi.getAnchorNodeId()).map(clonedNodesBySourceId::get).map(Node::getId).orElse(null))
+                            .tags(poi.getTags())
+                            .attrs(poi.getAttrs())
+                            .externalApiId(poi.getExternalApiId())
+                            .source(poi.getSource())
+                            .aiDetectionId(poi.getAiDetectionId())
+                            .build())
+                    .toList());
+        }
+
+        List<Edge> sourceEdges = edgeRepository.findByMapVersionId(publishedMapVersion.getId());
+        if (!sourceEdges.isEmpty()) {
+            edgeRepository.saveAll(sourceEdges.stream()
+                    .map(edge -> Edge.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .fromNode(clonedNodesBySourceId.get(edge.getFromNode().getId()))
+                            .toNode(clonedNodesBySourceId.get(edge.getToNode().getId()))
+                            .kindCode(edge.getKindCode())
+                            .geomPx(edge.getGeomPx())
+                            .geomWgs84(edge.getGeomWgs84())
+                            .lengthM(edge.getLengthM())
+                            .isDirected(edge.isDirected())
+                            .baseWeight(edge.getBaseWeight())
+                            .properties(edge.getProperties())
+                            .source(edge.getSource())
+                            .aiDetectionId(edge.getAiDetectionId())
+                            .build())
+                    .toList());
+        }
+
+        Map<UUID, VerticalConnector> clonedConnectorsBySourceId = new LinkedHashMap<>();
+        List<VerticalConnector> sourceConnectors = verticalConnectorRepository.findByMapVersionId(publishedMapVersion.getId());
+        if (!sourceConnectors.isEmpty()) {
+            List<VerticalConnector> savedConnectors = verticalConnectorRepository.saveAll(sourceConnectors.stream()
+                    .map(connector -> VerticalConnector.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .building(building)
+                            .kind(connector.getKind())
+                            .name(connector.getName())
+                            .capacity(connector.getCapacity())
+                            .avgWaitSeconds(connector.getAvgWaitSeconds())
+                            .direction(connector.getDirection())
+                            .accessibility(connector.getAccessibility())
+                            .build())
+                    .toList());
+
+            for (int index = 0; index < sourceConnectors.size(); index++) {
+                clonedConnectorsBySourceId.put(sourceConnectors.get(index).getId(), savedConnectors.get(index));
+            }
+        }
+
+        List<VerticalConnectorNode> sourceConnectorNodes = verticalConnectorNodeRepository.findByConnectorMapVersionId(publishedMapVersion.getId());
+        if (!sourceConnectorNodes.isEmpty()) {
+            verticalConnectorNodeRepository.saveAll(sourceConnectorNodes.stream()
+                    .map(node -> VerticalConnectorNode.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .connector(clonedConnectorsBySourceId.get(node.getConnector().getId()))
+                            .node(clonedNodesBySourceId.get(node.getNode().getId()))
+                            .floor(node.getFloor())
+                            .build())
+                    .filter(connectorNode -> connectorNode.getConnector() != null && connectorNode.getNode() != null)
+                    .toList());
+        }
     }
 
     private record DraftMapVersionResult(MapVersion mapVersion, boolean created) {
@@ -418,6 +700,15 @@ public class MapEditorService {
                         .findFirst()
                         .ifPresent(detection -> detection.markCommitted("node", savedNode.getId()));
             }
+
+            for (Poi poi : poisToSave) {
+                if (poi.getAiDetectionId() != null) {
+                    savedNodes.stream()
+                            .filter(n -> Objects.equals(n.getAiDetectionId(), poi.getAiDetectionId()))
+                            .findFirst()
+                            .ifPresent(n -> poi.updateAnchorNodeId(n.getId()));
+                }
+            }
         }
 
         if (!poisToSave.isEmpty()) {
@@ -429,6 +720,258 @@ public class MapEditorService {
         }
 
         saveEdges(draftMapVersion, floor, edgeDetections, nodeCache);
+    }
+
+    private Map<UUID, Node> saveDraftNodes(
+            MapVersion draftMapVersion,
+            Floor floor,
+            List<MapEditorDraftNodeSaveDTO> nodes
+    ) {
+        if (nodes == null || nodes.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Node> nodesToSave = new ArrayList<>();
+        List<UUID> requestIds = new ArrayList<>();
+
+        for (MapEditorDraftNodeSaveDTO node : nodes) {
+            Point point = toPoint(node.geomPx());
+            if (point == null) {
+                continue;
+            }
+
+            nodesToSave.add(
+                    Node.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .floor(floor)
+                            .kindCode(normalizeNodeKindCode(node.kind()))
+                            .geomPx(point)
+                            .nameKo(node.name())
+                            .properties(node.properties() != null ? node.properties() : Map.of())
+                            .source("manual")
+                            .build()
+            );
+            requestIds.add(node.id());
+        }
+
+        List<Node> savedNodes = nodeRepository.saveAll(nodesToSave);
+        Map<UUID, Node> savedNodesByRequestId = new HashMap<>();
+        for (int i = 0; i < savedNodes.size(); i++) {
+            UUID requestId = requestIds.get(i);
+            if (requestId != null) {
+                savedNodesByRequestId.put(requestId, savedNodes.get(i));
+            }
+        }
+        return savedNodesByRequestId;
+    }
+
+    private void syncEntranceMappingsAfterFloorDraftSave(
+            Map<UUID, Node> savedNodesByRequestId,
+            List<BuildingEntranceMapping> cachedFloorMappings
+    ) {
+        if (cachedFloorMappings == null || cachedFloorMappings.isEmpty()) {
+            return;
+        }
+
+        Map<UUID, UUID> newPoiIdByAnchorNodeId = poiRepository.findByAnchorNodeIdIn(
+                        savedNodesByRequestId.values().stream().map(Node::getId).toList()
+                ).stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Poi::getAnchorNodeId,
+                        Poi::getId,
+                        (existing, replacement) -> existing
+                ));
+
+        List<BuildingEntranceMapping> newMappings = new ArrayList<>();
+        for (BuildingEntranceMapping cachedMapping : cachedFloorMappings) {
+            UUID previousNodeId = cachedMapping.getEntranceNodeId();
+            Node replacementNode = savedNodesByRequestId.get(previousNodeId);
+            if (replacementNode == null) {
+                continue;
+            }
+
+            UUID newPoiId = newPoiIdByAnchorNodeId.get(replacementNode.getId());
+            newMappings.add(
+                    BuildingEntranceMapping.builder()
+                            .tenantId(cachedMapping.getTenantId())
+                            .campusId(cachedMapping.getCampusId())
+                            .buildingId(cachedMapping.getBuildingId())
+                            .campusGateId(cachedMapping.getCampusGateId())
+                            .entranceNodeId(replacementNode.getId())
+                            .entrancePoiId(newPoiId)
+                            .build()
+            );
+        }
+
+        if (!newMappings.isEmpty()) {
+            buildingEntranceMappingRepository.saveAll(newMappings);
+        }
+    }
+
+    private void syncVerticalConnectorNodesAfterFloorDraftSave(
+            Map<UUID, Node> savedNodesByRequestId,
+            List<VerticalConnectorNode> cachedFloorConnectorNodes
+    ) {
+        if (cachedFloorConnectorNodes == null || cachedFloorConnectorNodes.isEmpty()) {
+            return;
+        }
+
+        List<VerticalConnectorNode> newConnectorNodes = new ArrayList<>();
+        for (VerticalConnectorNode cached : cachedFloorConnectorNodes) {
+            UUID previousNodeId = cached.getNode().getId();
+            Node replacementNode = savedNodesByRequestId.get(previousNodeId);
+            if (replacementNode == null) {
+                continue;
+            }
+
+            newConnectorNodes.add(
+                    VerticalConnectorNode.builder()
+                            .tenantId(cached.getTenantId())
+                            .connector(cached.getConnector())
+                            .node(replacementNode)
+                            .floor(cached.getFloor())
+                            .build()
+            );
+        }
+
+        if (!newConnectorNodes.isEmpty()) {
+            verticalConnectorNodeRepository.saveAll(newConnectorNodes);
+        }
+    }
+
+    private void saveDraftZones(
+            MapVersion draftMapVersion,
+            Floor floor,
+            List<MapEditorDraftZoneSaveDTO> zones
+    ) {
+        if (zones == null || zones.isEmpty()) {
+            return;
+        }
+
+        List<Zone> zonesToSave = new ArrayList<>();
+        for (MapEditorDraftZoneSaveDTO zone : zones) {
+            Polygon polygon = toPolygon(zone.geomPx());
+            if (polygon == null) {
+                continue;
+            }
+
+            ZoneKind zoneKind = parseZoneKind(zone.kind());
+            zonesToSave.add(
+                    Zone.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .floor(floor)
+                            .kind(zoneKind)
+                            .name(zone.name())
+                            .geomPx(polygon)
+                            .properties(zone.properties() != null ? zone.properties() : Map.of())
+                            .build()
+            );
+        }
+
+        if (!zonesToSave.isEmpty()) {
+            zoneRepository.saveAll(suppressDuplicateRoomZones(zonesToSave));
+        }
+    }
+
+    private void saveDraftPois(
+            MapVersion draftMapVersion,
+            Floor floor,
+            List<MapEditorDraftPoiSaveDTO> pois,
+            Map<UUID, Node> savedNodesByRequestId,
+            Map<UUID, Poi> existingPoisById
+    ) {
+        if (pois == null || pois.isEmpty()) {
+            return;
+        }
+
+        Map<String, Long> categoryIdsByCode = loadPoiCategoryIdsFromCodes(
+                pois.stream()
+                        .map(MapEditorDraftPoiSaveDTO::code)
+                        .filter(Objects::nonNull)
+                        .toList()
+        );
+
+        List<Poi> poisToSave = new ArrayList<>();
+        for (MapEditorDraftPoiSaveDTO poi : pois) {
+            Point point = toPoint(poi.geomPx());
+            if (point == null) {
+                continue;
+            }
+
+            String categoryCode = normalizePoiCategoryCodeForDraft(poi.code(), poi.attrs());
+            UUID anchorNodeId = resolveSavedNodeId(poi.anchorNodeId(), savedNodesByRequestId);
+            Poi existingPoi = poi.id() != null ? existingPoisById.get(poi.id()) : null;
+            poisToSave.add(
+                    Poi.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .floor(floor)
+                            .categoryId(categoryCode != null ? categoryIdsByCode.get(categoryCode) : null)
+                            .name(firstNonBlank(poi.name(), "새 POI"))
+                            .code(categoryCode)
+                            .geomPx(point)
+                            .footprintPx(toPolygon(poi.footprintPx()))
+                            .geomWgs84(existingPoi != null ? existingPoi.getGeomWgs84() : null)
+                            .anchorNodeId(anchorNodeId)
+                            .attrs(mergePoiAttrs(existingPoi != null ? existingPoi.getAttrs() : null, poi.attrs(), categoryCode))
+                            .externalApiId(firstNonBlank(blankToNull(poi.externalApiId()), existingPoi != null ? existingPoi.getExternalApiId() : null))
+                            .source(existingPoi != null ? existingPoi.getSource() : "manual")
+                            .aiDetectionId(existingPoi != null ? existingPoi.getAiDetectionId() : null)
+                            .build()
+            );
+        }
+
+        if (!poisToSave.isEmpty()) {
+            poiRepository.saveAll(poisToSave);
+        }
+    }
+
+    private void saveDraftEdges(
+            MapVersion draftMapVersion,
+            List<MapEditorDraftEdgeSaveDTO> edges,
+            Map<UUID, Node> savedNodesByRequestId
+    ) {
+        if (edges == null || edges.isEmpty()) {
+            return;
+        }
+
+        List<Edge> edgesToSave = new ArrayList<>();
+        for (MapEditorDraftEdgeSaveDTO edge : edges) {
+            Node fromNode = resolveSavedNode(edge.fromNodeId(), savedNodesByRequestId);
+            Node toNode = resolveSavedNode(edge.toNodeId(), savedNodesByRequestId);
+            if (fromNode == null || toNode == null) {
+                continue;
+            }
+
+            LineString lineString = toLineString(edge.geomPx());
+            if (lineString == null) {
+                lineString = GEOMETRY_FACTORY.createLineString(new Coordinate[]{
+                        fromNode.getGeomPx().getCoordinate(),
+                        toNode.getGeomPx().getCoordinate(),
+                });
+            }
+
+            edgesToSave.add(
+                    Edge.builder()
+                            .tenantId(draftMapVersion.getTenantId())
+                            .mapVersion(draftMapVersion)
+                            .fromNode(fromNode)
+                            .toNode(toNode)
+                            .kindCode(firstNonBlank(edge.kind(), "walkway"))
+                            .geomPx(lineString)
+                            .isDirected(Boolean.TRUE.equals(edge.isDirected()))
+                            .baseWeight(edge.baseWeight() != null ? edge.baseWeight() : BigDecimal.ONE)
+                            .properties(edge.properties() != null ? edge.properties() : Map.of())
+                            .source("manual")
+                            .build()
+            );
+        }
+
+        if (!edgesToSave.isEmpty()) {
+            edgeRepository.saveAll(edgesToSave);
+        }
     }
 
     private void saveEdges(
@@ -600,6 +1143,10 @@ public class MapEditorService {
         Polygon footprint = geometry instanceof Polygon polygon ? polygon : null;
         String categoryCode = resolvePoiCategoryCode(detection.getDetectType());
         Long categoryId = categoryCode != null ? poiCategoryIdsByCode.get(categoryCode) : null;
+        Map<String, Object> properties = new LinkedHashMap<>(buildDetectionProperties(detection));
+        if (categoryCode != null) {
+            properties.put("label", categoryCode);
+        }
 
         return Optional.of(
                 Poi.builder()
@@ -608,9 +1155,10 @@ public class MapEditorService {
                         .floor(floor)
                         .categoryId(categoryId)
                         .name(resolvePoiName(detection))
+                        .code(categoryCode)
                         .geomPx(point)
                         .footprintPx(footprint)
-                        .attrs(buildDetectionProperties(detection))
+                        .attrs(properties)
                         .source("ai")
                         .aiDetectionId(detection.getId())
                         .build()
@@ -787,6 +1335,52 @@ public class MapEditorService {
             case "water_fountain" -> "facility.water_fountain";
             default -> null;
         };
+    }
+
+    private String normalizePoiCategoryCodeForDraft(String code, Map<String, Object> attrs) {
+        String normalizedCode = blankToNull(code);
+        if (normalizedCode != null) {
+            return normalizedCode;
+        }
+
+        Object label = attrs != null ? attrs.get("label") : null;
+        if (label instanceof String labelValue && !labelValue.isBlank()) {
+            return labelValue;
+        }
+        return null;
+    }
+
+    private Map<String, Long> loadPoiCategoryIdsFromCodes(Collection<String> categoryCodes) {
+        Set<String> normalizedCodes = categoryCodes.stream()
+                .filter(Objects::nonNull)
+                .filter(code -> !code.isBlank())
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+
+        if (normalizedCodes.isEmpty()) {
+            return Map.of();
+        }
+
+        return poiCategoryRepository.findByCodeIn(normalizedCodes).stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        PoiCategory::getCode,
+                        PoiCategory::getId,
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new
+                ));
+    }
+
+    private Map<String, Object> mergePoiAttrs(Map<String, Object> existingAttrs, Map<String, Object> attrs, String categoryCode) {
+        Map<String, Object> merged = new LinkedHashMap<>();
+        if (existingAttrs != null && !existingAttrs.isEmpty()) {
+            merged.putAll(existingAttrs);
+        }
+        if (attrs != null && !attrs.isEmpty()) {
+            merged.putAll(attrs);
+        }
+        if (categoryCode != null) {
+            merged.put("label", categoryCode);
+        }
+        return merged;
     }
 
     private String resolvePoiName(AiDetection detection) {
@@ -1049,12 +1643,48 @@ public class MapEditorService {
         return null;
     }
 
+    private String blankToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private ZoneKind parseZoneKind(String value) {
+        if (value == null || value.isBlank()) {
+            return ZoneKind.room;
+        }
+        try {
+            return ZoneKind.valueOf(value);
+        } catch (IllegalArgumentException ignored) {
+            return ZoneKind.room;
+        }
+    }
+
     private String resolveNodeKindCode(String detectType) {
         return switch (normalizeDetectType(detectType)) {
             case "entrance" -> "entrance";
             case "stair" -> "stair";
             case "elevator" -> "elevator";
             case "escalator" -> "escalator";
+            default -> "corridor";
+        };
+    }
+
+    private String normalizeNodeKindCode(String value) {
+        if (value == null || value.isBlank()) {
+            return "corridor";
+        }
+        return switch (value.trim().toLowerCase()) {
+            case "entrance" -> "entrance";
+            case "stair" -> "stair";
+            case "elevator" -> "elevator";
+            case "escalator" -> "escalator";
+            case "door" -> "door";
+            case "poi_anchor" -> "poi_anchor";
+            case "portal" -> "portal";
+            case "corridor", "node" -> "corridor";
             default -> "corridor";
         };
     }
@@ -1090,11 +1720,118 @@ public class MapEditorService {
         return centroid != null ? GEOMETRY_FACTORY.createPoint(centroid.getCoordinate()) : null;
     }
 
+    private Point toPoint(Map<String, Object> geometry) {
+        Geometry parsedGeometry = toGeometry(geometry);
+        return toPoint(parsedGeometry);
+    }
+
     private LineString toLineString(Geometry geometry) {
         if (geometry instanceof LineString lineString) {
             return lineString;
         }
         return null;
+    }
+
+    private LineString toLineString(Map<String, Object> geometry) {
+        Geometry parsedGeometry = toGeometry(geometry);
+        return parsedGeometry instanceof LineString lineString ? lineString : null;
+    }
+
+    private Polygon toPolygon(Map<String, Object> geometry) {
+        Geometry parsedGeometry = toGeometry(geometry);
+        return parsedGeometry instanceof Polygon polygon ? polygon : null;
+    }
+
+    private Geometry toGeometry(Map<String, Object> geometry) {
+        if (geometry == null || geometry.isEmpty()) {
+            return null;
+        }
+
+        Object typeValue = geometry.get("type");
+        Object coordinatesValue = geometry.get("coordinates");
+
+        if (!(typeValue instanceof String type) || coordinatesValue == null) {
+            return null;
+        }
+
+        return switch (type) {
+            case "Point" -> GEOMETRY_FACTORY.createPoint(toCoordinate(coordinatesValue));
+            case "LineString" -> GEOMETRY_FACTORY.createLineString(asCoordinateArray(coordinatesValue, 2));
+            case "Polygon" -> {
+                List<?> rings = asList(coordinatesValue);
+                if (rings.isEmpty()) {
+                    yield null;
+                }
+                Coordinate[] shellCoordinates = requireValidRing(asCoordinateArray(rings.get(0), 4));
+                LinearRing shell = GEOMETRY_FACTORY.createLinearRing(closeRing(shellCoordinates));
+                LinearRing[] holes = rings.stream()
+                        .skip(1)
+                        .map(this::asCoordinateArrayFromRing)
+                        .map(this::requireValidRing)
+                        .map(this::closeRing)
+                        .map(GEOMETRY_FACTORY::createLinearRing)
+                        .toArray(LinearRing[]::new);
+                yield GEOMETRY_FACTORY.createPolygon(shell, holes);
+            }
+            default -> null;
+        };
+    }
+
+    private Coordinate[] asCoordinateArrayFromRing(Object value) {
+        return asCoordinateArray(value, 4);
+    }
+
+    private Coordinate[] asCoordinateArray(Object value, int minSize) {
+        List<?> coordinateList = asList(value);
+        if (coordinateList.size() < minSize) {
+            throw new AiException(AiErrorCode.AI_INVALID_DETECTION_GEOMETRY);
+        }
+        return coordinateList.stream()
+                .map(this::toCoordinate)
+                .toArray(Coordinate[]::new);
+    }
+
+    private Coordinate[] closeRing(Coordinate[] coordinates) {
+        Coordinate first = coordinates[0];
+        Coordinate last = coordinates[coordinates.length - 1];
+        if (first.equals2D(last)) {
+            return coordinates;
+        }
+        Coordinate[] closed = new Coordinate[coordinates.length + 1];
+        System.arraycopy(coordinates, 0, closed, 0, coordinates.length);
+        closed[closed.length - 1] = new Coordinate(first.x, first.y);
+        return closed;
+    }
+
+    private Coordinate[] requireValidRing(Coordinate[] coordinates) {
+        if (coordinates.length < 4) {
+            throw new AiException(AiErrorCode.AI_INVALID_DETECTION_GEOMETRY);
+        }
+        return coordinates;
+    }
+
+    private Coordinate toCoordinate(Object value) {
+        List<?> pair = asList(value);
+        if (pair.size() < 2 || !(pair.get(0) instanceof Number x) || !(pair.get(1) instanceof Number y)) {
+            throw new AiException(AiErrorCode.AI_INVALID_DETECTION_GEOMETRY);
+        }
+        return new Coordinate(x.doubleValue(), y.doubleValue());
+    }
+
+    private List<?> asList(Object value) {
+        if (value instanceof List<?> list) {
+            return list;
+        }
+        throw new AiException(AiErrorCode.AI_INVALID_DETECTION_GEOMETRY);
+    }
+
+    private Node resolveSavedNode(UUID requestNodeId, Map<UUID, Node> savedNodesByRequestId) {
+        return requestNodeId != null ? savedNodesByRequestId.get(requestNodeId) : null;
+    }
+
+    private UUID resolveSavedNodeId(UUID requestNodeId, Map<UUID, Node> savedNodesByRequestId) {
+        Node savedNode = resolveSavedNode(requestNodeId, savedNodesByRequestId);
+        return savedNode != null ? savedNode.getId() : null;
     }
 
     private String toNodeCacheKey(Point point) {
@@ -1120,4 +1857,547 @@ public class MapEditorService {
         }
         return null;
     }
+
+    @Transactional(readOnly = true)
+    public List<MapEditorVerticalConnectorDTO> getVerticalConnectors(UUID tenantId, UUID buildingId, UUID userId) {
+        Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        DraftMapVersionResult draftResult = getOrCreateBuildingDraftMapVersion(building, userId);
+        MapVersion draftMapVersion = draftResult.mapVersion();
+
+        List<VerticalConnector> connectors = verticalConnectorRepository.findByMapVersionId(draftMapVersion.getId());
+        List<VerticalConnectorNode> connectorNodes = verticalConnectorNodeRepository.findByConnectorMapVersionId(draftMapVersion.getId());
+
+        Map<UUID, List<MapEditorVerticalConnectorNodeDTO>> nodesByConnectorId = new HashMap<>();
+        for (VerticalConnectorNode cn : connectorNodes) {
+            UUID connectorId = cn.getConnector().getId();
+            MapEditorVerticalConnectorNodeDTO nodeDTO = new MapEditorVerticalConnectorNodeDTO(
+                    cn.getFloor().getId(),
+                    cn.getFloor().getName(),
+                    cn.getNode().getId(),
+                    cn.getNode().getNameKo() != null ? cn.getNode().getNameKo() : (cn.getNode().getKindCode() + " 노드")
+            );
+            nodesByConnectorId.computeIfAbsent(connectorId, k -> new ArrayList<>()).add(nodeDTO);
+        }
+
+        List<MapEditorVerticalConnectorDTO> result = new ArrayList<>();
+        for (VerticalConnector c : connectors) {
+            result.add(new MapEditorVerticalConnectorDTO(
+                    c.getId(),
+                    c.getKind(),
+                    c.getName(),
+                    nodesByConnectorId.getOrDefault(c.getId(), List.of())
+            ));
+        }
+        return result;
+    }
+
+    @Transactional
+    public MapEditorVerticalConnectorDTO createVerticalConnector(
+            UUID tenantId,
+            UUID buildingId,
+            UUID userId,
+            MapEditorVerticalConnectorCreateRequestDTO request
+    ) {
+        Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        DraftMapVersionResult draftResult = getOrCreateBuildingDraftMapVersion(building, userId);
+        MapVersion draftMapVersion = draftResult.mapVersion();
+
+        VerticalConnector connector = VerticalConnector.builder()
+                .tenantId(tenantId)
+                .mapVersion(draftMapVersion)
+                .building(building)
+                .kind(request.kind())
+                .name(request.name())
+                .direction("both")
+                .accessibility(Map.of())
+                .build();
+
+        VerticalConnector saved = verticalConnectorRepository.save(connector);
+        return new MapEditorVerticalConnectorDTO(saved.getId(), saved.getKind(), saved.getName(), List.of());
+    }
+
+    @Transactional
+    public void deleteVerticalConnector(UUID tenantId, UUID buildingId, UUID connectorId, UUID userId) {
+        VerticalConnector connector = verticalConnectorRepository.findById(connectorId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        if (!connector.getTenantId().equals(tenantId) || !connector.getBuilding().getId().equals(buildingId)) {
+            throw new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND);
+        }
+
+        verticalConnectorNodeRepository.deleteByConnectorId(connectorId);
+        verticalConnectorRepository.delete(connector);
+    }
+
+    @Transactional
+    public MapEditorVerticalConnectorDTO mapVerticalConnectorNode(
+            UUID tenantId,
+            UUID buildingId,
+            UUID connectorId,
+            UUID userId,
+            MapEditorVerticalConnectorMapRequestDTO request
+    ) {
+        VerticalConnector connector = verticalConnectorRepository.findById(connectorId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        if (!connector.getTenantId().equals(tenantId) || !connector.getBuilding().getId().equals(buildingId)) {
+            throw new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND);
+        }
+
+        Node node = nodeRepository.findById(request.nodeId())
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        Floor floor = floorRepository.findById(request.floorId())
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.FLOOR_NOT_FOUND));
+
+        // 1. 해당 커넥터의 동일 층 기존 연결 삭제
+        verticalConnectorNodeRepository.deleteByConnectorIdAndFloorId(connectorId, request.floorId());
+        verticalConnectorNodeRepository.flush();
+
+        // 2. 신규 매핑 생성
+        VerticalConnectorNode mapping = VerticalConnectorNode.builder()
+                .tenantId(tenantId)
+                .connector(connector)
+                .node(node)
+                .floor(floor)
+                .build();
+
+        verticalConnectorNodeRepository.save(mapping);
+        verticalConnectorNodeRepository.flush();
+
+        // 3. 갱신된 커넥터 정보 리턴
+        return getVerticalConnectors(tenantId, buildingId, userId).stream()
+                .filter(c -> c.id().equals(connectorId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Transactional
+    public MapEditorVerticalConnectorDTO unmapVerticalConnectorNode(
+            UUID tenantId,
+            UUID buildingId,
+            UUID connectorId,
+            UUID floorId,
+            UUID userId
+    ) {
+        VerticalConnector connector = verticalConnectorRepository.findById(connectorId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        if (!connector.getTenantId().equals(tenantId) || !connector.getBuilding().getId().equals(buildingId)) {
+            throw new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND);
+        }
+
+        verticalConnectorNodeRepository.deleteByConnectorIdAndFloorId(connectorId, floorId);
+        verticalConnectorNodeRepository.flush();
+
+        return getVerticalConnectors(tenantId, buildingId, userId).stream()
+                .filter(c -> c.id().equals(connectorId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Transactional
+    public MapEditorInitBuildingDraftResponseDTO publishBuildingDraft(
+            UUID tenantId,
+            UUID buildingId,
+            UUID userId
+    ) {
+        Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+        List<Floor> floors = floorRepository.findAllByBuilding_IdOrderByLevelDesc(buildingId);
+
+        MapVersion draftMapVersion = mapVersionRepository
+                .findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(buildingId, MapType.BUILDING, "draft")
+                .orElseThrow(() -> new com.insideout.backend.domain.map.exception.MapException(
+                        com.insideout.backend.domain.map.exception.MapErrorCode.MAP_VERSION_NOT_FOUND
+                ));
+
+        validatePublishPreconditions(tenantId, building, draftMapVersion);
+
+        List<MapVersion> existingPublished = mapVersionRepository.findAllByBuildingIdAndMapTypeAndStatus(buildingId, MapType.BUILDING, "published");
+        for (MapVersion pv : existingPublished) {
+            pv.archive();
+        }
+        // Flush the archive updates first so the partial unique index on published versions
+        // sees no active published row before we promote the draft version.
+        mapVersionRepository.saveAllAndFlush(existingPublished);
+
+        draftMapVersion.publish();
+        mapVersionRepository.save(draftMapVersion);
+        building.updateActivationStatus("active");
+        if (building.getTenant() != null && !"approved".equals(building.getTenant().getStatus())) {
+            building.getTenant().updateStatus("approved");
+        }
+
+        Campus campus = building.getCampus();
+        if (campus != null && campus.getMeta() != null) {
+            Object gatesValue = campus.getMeta().get("gates");
+            if (gatesValue instanceof List<?> gates) {
+                Map<String, Coordinate> gateCoordsById = new HashMap<>();
+                for (Object item : gates) {
+                    if (item instanceof Map<?, ?> entry) {
+                        Object idObj = entry.get("id");
+                        Object locObj = entry.get("location");
+                        if (idObj != null && locObj instanceof Map<?, ?> loc) {
+                            Object lonObj = loc.get("longitude");
+                            Object latObj = loc.get("latitude");
+                            if (lonObj instanceof Number lonNum && latObj instanceof Number latNum) {
+                                gateCoordsById.put(String.valueOf(idObj), new Coordinate(lonNum.doubleValue(), latNum.doubleValue()));
+                            }
+                        }
+                    }
+                }
+
+                List<BuildingEntranceMapping> mappings = buildingEntranceMappingRepository.findAllByTenantIdAndBuildingIdOrderByCreatedAtAsc(tenantId, buildingId);
+                List<MapPointPair> pairs = new ArrayList<>();
+                for (BuildingEntranceMapping m : mappings) {
+                    Node node = nodeRepository.findById(m.getEntranceNodeId()).orElse(null);
+                    Coordinate gateCoord = gateCoordsById.get(m.getCampusGateId());
+                    if (node != null && node.getGeomPx() != null && gateCoord != null) {
+                        pairs.add(new MapPointPair(
+                                node.getGeomPx().getX(),
+                                node.getGeomPx().getY(),
+                                gateCoord.x,
+                                gateCoord.y
+                        ));
+                    }
+                }
+
+                List<Poi> draftPois = poiRepository.findByMapVersionId(draftMapVersion.getId());
+                for (Poi p : draftPois) {
+                    if (p.getGeomWgs84() != null && p.getGeomPx() != null && p.getExternalApiId() != null) {
+                        pairs.add(new MapPointPair(
+                                p.getGeomPx().getX(),
+                                p.getGeomPx().getY(),
+                                p.getGeomWgs84().getX(),
+                                p.getGeomWgs84().getY()
+                        ));
+                    }
+                }
+
+                List<Double> affine = calculateAffineTransform(pairs);
+                if (affine != null) {
+                    double a = affine.get(0);
+                    double b = affine.get(1);
+                    double d = affine.get(2);
+                    double e = affine.get(3);
+                    double xoff = affine.get(4);
+                    double yoff = affine.get(5);
+
+                    for (Floor floor : floors) {
+                        Floorplan floorplan = floorplanRepository.findByFloorIdAndIsCurrentTrue(floor.getId()).orElse(null);
+                        if (floorplan != null) {
+                            FloorplanCalibration calibration = floorplanCalibrationRepository.findByFloorplanId(floorplan.getId())
+                                    .orElse(FloorplanCalibration.builder()
+                                            .tenantId(tenantId)
+                                            .floorplan(floorplan)
+                                            .gcp(Map.of())
+                                            .build());
+                            calibration.updateAffine(affine);
+                            floorplanCalibrationRepository.save(calibration);
+                        }
+                    }
+
+                    UUID mapVersionId = draftMapVersion.getId();
+
+                    entityManager.createNativeQuery(
+                            "UPDATE node n " +
+                            "SET geom_wgs84 = CAST(ST_Force3D(ST_SetSRID(ST_Affine(n.geom_px, :a, :b, :d, :e, :xoff, :yoff), 4326)) AS geography) " +
+                            "WHERE n.map_version_id = :mapVersionId"
+                    )
+                    .setParameter("a", a)
+                    .setParameter("b", b)
+                    .setParameter("d", d)
+                    .setParameter("e", e)
+                    .setParameter("xoff", xoff)
+                    .setParameter("yoff", yoff)
+                    .setParameter("mapVersionId", mapVersionId)
+                    .executeUpdate();
+
+                    entityManager.createNativeQuery(
+                            "UPDATE poi p " +
+                            "SET geom_wgs84 = CAST(ST_SetSRID(ST_Affine(p.geom_px, :a, :b, :d, :e, :xoff, :yoff), 4326) AS geography) " +
+                            "WHERE p.map_version_id = :mapVersionId AND p.geom_wgs84 IS NULL"
+                    )
+                    .setParameter("a", a)
+                    .setParameter("b", b)
+                    .setParameter("d", d)
+                    .setParameter("e", e)
+                    .setParameter("xoff", xoff)
+                    .setParameter("yoff", yoff)
+                    .setParameter("mapVersionId", mapVersionId)
+                    .executeUpdate();
+
+                    entityManager.createNativeQuery(
+                            "UPDATE edge e " +
+                            "SET geom_wgs84 = CAST(ST_Force3D(ST_SetSRID(ST_Affine(e.geom_px, :a, :b, :d, :e, :xoff, :yoff), 4326)) AS geography) " +
+                            "WHERE e.map_version_id = :mapVersionId"
+                    )
+                    .setParameter("a", a)
+                    .setParameter("b", b)
+                    .setParameter("d", d)
+                    .setParameter("e", e)
+                    .setParameter("xoff", xoff)
+                    .setParameter("yoff", yoff)
+                    .setParameter("mapVersionId", mapVersionId)
+                    .executeUpdate();
+
+                    entityManager.createNativeQuery(
+                            "UPDATE edge e " +
+                            "SET length_m = CAST(ST_Length(e.geom_wgs84) AS numeric(10,2)) " +
+                            "WHERE e.map_version_id = :mapVersionId"
+                    )
+                    .setParameter("mapVersionId", mapVersionId)
+                    .executeUpdate();
+                }
+            }
+        }
+
+        List<UUID> floorIds = floors.stream().map(Floor::getId).toList();
+        java.util.Map<UUID, Floorplan> currentFloorplansByFloorId = floorIds.isEmpty()
+                ? java.util.Map.of()
+                : floorplanRepository.findAllByFloorIdInAndIsCurrentTrue(floorIds).stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        floorplan -> floorplan.getFloor().getId(),
+                        floorplan -> floorplan,
+                        (existing, replacement) -> existing,
+                        java.util.LinkedHashMap::new
+                ));
+
+        List<UUID> currentFloorplanIds = currentFloorplansByFloorId.values().stream()
+                .map(Floorplan::getId)
+                .toList();
+        java.util.Set<UUID> analyzedFloorplanIds = currentFloorplanIds.isEmpty()
+                ? java.util.Set.of()
+                : new java.util.LinkedHashSet<>(aiDetectionRepository.findAnalyzedFloorplanIdsByTenantIdAndFloorplanIds(tenantId, currentFloorplanIds));
+
+        List<MapEditorInitBuildingDraftFloorDTO> floorStates = new ArrayList<>();
+        int analyzedFloorCount = 0;
+        int draftReadyFloorCount = 0;
+
+        for (Floor floor : floors) {
+            Floorplan currentFloorplan = currentFloorplansByFloorId.get(floor.getId());
+            boolean analyzed = currentFloorplan != null && analyzedFloorplanIds.contains(currentFloorplan.getId());
+            FloorDraftContentState contentState = getFloorDraftContentState(draftMapVersion.getId(), floor.getId());
+
+            if (analyzed) {
+                analyzedFloorCount++;
+            }
+
+            if (contentState.isFullyReady()) {
+                draftReadyFloorCount++;
+            }
+
+            floorStates.add(MapEditorInitBuildingDraftFloorDTO.of(
+                floor,
+                currentFloorplan,
+                analyzed,
+                contentState.isFullyReady(),
+                false
+            ));
+        }
+
+        return MapEditorInitBuildingDraftResponseDTO.of(
+                building,
+                draftMapVersion,
+                false,
+                analyzedFloorCount,
+                draftReadyFloorCount,
+                floorStates
+        );
+    }
+
+    private List<Double> calculateAffineTransform(List<MapPointPair> pairs) {
+        int n = pairs.size();
+        if (n < 3) return null;
+
+        double sumX = 0, sumY = 0, sumXX = 0, sumYY = 0, sumXY = 0;
+        double sumLon = 0, sumLat = 0;
+        double sumXLon = 0, sumYLon = 0;
+        double sumXLat = 0, sumYLat = 0;
+
+        for (MapPointPair pair : pairs) {
+            double x = pair.pxX();
+            double y = pair.pxY();
+            double lon = pair.lon();
+            double lat = pair.lat();
+
+            sumX += x;
+            sumY += y;
+            sumXX += x * x;
+            sumYY += y * y;
+            sumXY += x * y;
+            
+            sumLon += lon;
+            sumLat += lat;
+            sumXLon += x * lon;
+            sumYLon += y * lon;
+            sumXLat += x * lat;
+            sumYLat += y * lat;
+        }
+
+        double[][] M = {
+            {sumXX, sumXY, sumX},
+            {sumXY, sumYY, sumY},
+            {sumX, sumY, (double) n}
+        };
+
+        double det = M[0][0] * (M[1][1] * M[2][2] - M[1][2] * M[2][1])
+                   - M[0][1] * (M[1][0] * M[2][2] - M[1][2] * M[2][0])
+                   + M[0][2] * (M[1][0] * M[2][1] - M[1][1] * M[2][0]);
+
+        if (Math.abs(det) < 1e-12) {
+            return null;
+        }
+
+        double[][] adj = {
+            {M[1][1] * M[2][2] - M[1][2] * M[2][1], M[0][2] * M[2][1] - M[0][1] * M[2][2], M[0][1] * M[1][2] - M[0][2] * M[1][1]},
+            {M[1][2] * M[2][0] - M[1][0] * M[2][2], M[0][0] * M[2][2] - M[0][2] * M[2][0], M[0][2] * M[1][0] - M[0][0] * M[1][2]},
+            {M[1][0] * M[2][1] - M[1][1] * M[2][0], M[0][1] * M[2][0] - M[0][0] * M[2][1], M[0][0] * M[1][1] - M[0][1] * M[1][0]}
+        };
+
+        double[][] Minv = new double[3][3];
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                Minv[i][j] = adj[i][j] / det;
+            }
+        }
+
+        double[] Vlon = {sumXLon, sumYLon, sumLon};
+        double a = Minv[0][0] * Vlon[0] + Minv[0][1] * Vlon[1] + Minv[0][2] * Vlon[2];
+        double b = Minv[1][0] * Vlon[0] + Minv[1][1] * Vlon[1] + Minv[1][2] * Vlon[2];
+        double xoff = Minv[2][0] * Vlon[0] + Minv[2][1] * Vlon[1] + Minv[2][2] * Vlon[2];
+
+        double[] Vlat = {sumXLat, sumYLat, sumLat};
+        double d = Minv[0][0] * Vlat[0] + Minv[0][1] * Vlat[1] + Minv[0][2] * Vlat[2];
+        double e = Minv[1][0] * Vlat[0] + Minv[1][1] * Vlat[1] + Minv[1][2] * Vlat[2];
+        double yoff = Minv[2][0] * Vlat[0] + Minv[2][1] * Vlat[1] + Minv[2][2] * Vlat[2];
+
+        return List.of(a, b, d, e, xoff, yoff);
+    }
+
+    public List<MapEditorDraftPoiResponseDTO> getBuildingDraftPois(UUID tenantId, UUID buildingId) {
+        Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        MapVersion draftMapVersion = mapVersionRepository
+                .findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(buildingId, MapType.BUILDING, "draft")
+                .orElseThrow(() -> new com.insideout.backend.domain.map.exception.MapException(
+                        com.insideout.backend.domain.map.exception.MapErrorCode.MAP_VERSION_NOT_FOUND
+                ));
+
+        List<Poi> pois = poiRepository.findByMapVersionId(draftMapVersion.getId());
+
+        return pois.stream()
+                .map(p -> new MapEditorDraftPoiResponseDTO(
+                        p.getId(),
+                        p.getName(),
+                        p.getCode(),
+                        p.getFloor() != null ? p.getFloor().getName() : "-",
+                        p.getGeomPx() != null ? p.getGeomPx().getX() : null,
+                        p.getGeomPx() != null ? p.getGeomPx().getY() : null,
+                        p.getExternalApiId(),
+                        p.getGeomWgs84() != null ? p.getGeomWgs84().getY() : null, // latitude (Y)
+                        p.getGeomWgs84() != null ? p.getGeomWgs84().getX() : null,  // longitude (X)
+                        p.getExternalMappingPlaceName(),
+                        p.getExternalMappingAddress(),
+                        p.getExternalMappingStatus()
+                ))
+                .toList();
+    }
+
+    @Transactional
+    public void saveBuildingPoiMappings(UUID tenantId, UUID buildingId, MapEditorPoiMappingsSaveRequestDTO request) {
+        Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
+                .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
+
+        GeometryFactory wgsGeometryFactory = new GeometryFactory(new org.locationtech.jts.geom.PrecisionModel(), 4326);
+
+        for (MapEditorPoiMappingRequestDTO mapping : request.mappings()) {
+            Poi poi = poiRepository.findById(mapping.poiId())
+                    .orElseThrow(() -> new com.insideout.backend.domain.map.exception.MapException(
+                            com.insideout.backend.domain.map.exception.MapErrorCode.MAP_VERSION_NOT_FOUND
+                    ));
+
+            if (!poi.getMapVersion().getBuilding().getId().equals(buildingId)) {
+                throw new com.insideout.backend.domain.map.exception.MapException(
+                        com.insideout.backend.domain.map.exception.MapErrorCode.MAP_VERSION_NOT_FOUND
+                );
+            }
+
+            if (Boolean.TRUE.equals(mapping.excluded())) {
+                poi.markExternalMappingExcluded();
+            } else if (!StringUtils.hasText(mapping.externalApiId())) {
+                poi.updateExternalMapping(null, null, null, null);
+            } else {
+                Point geomWgs84 = wgsGeometryFactory.createPoint(new Coordinate(mapping.longitude(), mapping.latitude()));
+                geomWgs84.setSRID(4326);
+                poi.updateExternalMapping(mapping.externalApiId(), geomWgs84, mapping.placeName(), mapping.address());
+            }
+            poiRepository.save(poi);
+        }
+    }
+
+    private void validatePublishPreconditions(UUID tenantId, Building building, MapVersion draftMapVersion) {
+        validateEntranceCalibrationForPublish(tenantId, building);
+        validatePoiExternalMappingsForPublish(draftMapVersion);
+    }
+
+    private void validateEntranceCalibrationForPublish(UUID tenantId, Building building) {
+        Campus campus = building.getCampus();
+        if (campus == null || campus.getMeta() == null) {
+            return;
+        }
+
+        Object gatesValue = campus.getMeta().get("gates");
+        if (!(gatesValue instanceof List<?> gates) || gates.isEmpty()) {
+            return;
+        }
+
+        Set<String> expectedGateIds = new LinkedHashSet<>();
+        for (Object item : gates) {
+            if (!(item instanceof Map<?, ?> gateEntry)) {
+                continue;
+            }
+
+            Object rawId = gateEntry.get("id");
+            if (rawId != null && !String.valueOf(rawId).isBlank()) {
+                expectedGateIds.add(String.valueOf(rawId));
+            }
+        }
+
+        if (expectedGateIds.isEmpty()) {
+            return;
+        }
+
+        Set<String> mappedGateIds = buildingEntranceMappingRepository
+                .findAllByTenantIdAndBuildingIdOrderByCreatedAtAsc(tenantId, building.getId())
+                .stream()
+                .map(BuildingEntranceMapping::getCampusGateId)
+                .filter(StringUtils::hasText)
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+
+        if (!mappedGateIds.containsAll(expectedGateIds)) {
+            throw new com.insideout.backend.domain.map.exception.MapException(
+                    com.insideout.backend.domain.map.exception.MapErrorCode.PUBLISH_REQUIRES_ENTRANCE_CALIBRATION
+            );
+        }
+    }
+
+    private void validatePoiExternalMappingsForPublish(MapVersion draftMapVersion) {
+        boolean hasPendingPoi = poiRepository.findByMapVersionId(draftMapVersion.getId()).stream()
+                .anyMatch(poi -> !"confirmed".equals(poi.getExternalMappingStatus()) && !"excluded".equals(poi.getExternalMappingStatus()));
+
+        if (hasPendingPoi) {
+            throw new com.insideout.backend.domain.map.exception.MapException(
+                    com.insideout.backend.domain.map.exception.MapErrorCode.PUBLISH_REQUIRES_POI_EXTERNAL_MAPPING
+            );
+        }
+    }
+
+    private record MapPointPair(double pxX, double pxY, double lon, double lat) {}
 }

--- a/src/main/java/com/insideout/backend/domain/map/service/MapEditorService.java
+++ b/src/main/java/com/insideout/backend/domain/map/service/MapEditorService.java
@@ -51,6 +51,8 @@ import com.insideout.backend.domain.map.entity.PoiCategory;
 import com.insideout.backend.domain.map.entity.Zone;
 import com.insideout.backend.domain.map.entity.ZoneKind;
 import com.insideout.backend.domain.map.enums.MapType;
+import com.insideout.backend.domain.map.exception.MapErrorCode;
+import com.insideout.backend.domain.map.exception.MapException;
 import com.insideout.backend.domain.map.repository.EdgeRepository;
 import com.insideout.backend.domain.map.repository.FloorplanObjectRepository;
 import com.insideout.backend.domain.map.repository.MapVersionRepository;
@@ -477,9 +479,10 @@ public class MapEditorService {
                     .toList());
         }
 
+        Map<UUID, Poi> clonedPoisBySourceId = new LinkedHashMap<>();
         List<Poi> sourcePois = poiRepository.findByMapVersionId(publishedMapVersion.getId());
         if (!sourcePois.isEmpty()) {
-            poiRepository.saveAll(sourcePois.stream()
+            List<Poi> savedPois = poiRepository.saveAll(sourcePois.stream()
                     .map(poi -> Poi.builder()
                             .tenantId(draftMapVersion.getTenantId())
                             .mapVersion(draftMapVersion)
@@ -498,6 +501,10 @@ public class MapEditorService {
                             .aiDetectionId(poi.getAiDetectionId())
                             .build())
                     .toList());
+
+            for (int index = 0; index < sourcePois.size(); index++) {
+                clonedPoisBySourceId.put(sourcePois.get(index).getId(), savedPois.get(index));
+            }
         }
 
         List<Edge> sourceEdges = edgeRepository.findByMapVersionId(publishedMapVersion.getId());
@@ -554,6 +561,23 @@ public class MapEditorService {
                             .build())
                     .filter(connectorNode -> connectorNode.getConnector() != null && connectorNode.getNode() != null)
                     .toList());
+        }
+
+        List<BuildingEntranceMapping> mappings = buildingEntranceMappingRepository
+                .findAllByTenantIdAndBuildingIdOrderByCreatedAtAsc(building.getTenant().getId(), building.getId());
+        if (!mappings.isEmpty()) {
+            for (BuildingEntranceMapping mapping : mappings) {
+                UUID newEntranceNodeId = mapping.getEntranceNodeId();
+                if (clonedNodesBySourceId.containsKey(newEntranceNodeId)) {
+                    newEntranceNodeId = clonedNodesBySourceId.get(newEntranceNodeId).getId();
+                }
+                UUID newEntrancePoiId = mapping.getEntrancePoiId();
+                if (newEntrancePoiId != null && clonedPoisBySourceId.containsKey(newEntrancePoiId)) {
+                    newEntrancePoiId = clonedPoisBySourceId.get(newEntrancePoiId).getId();
+                }
+                mapping.updateEntrance(newEntranceNodeId, newEntrancePoiId);
+            }
+            buildingEntranceMappingRepository.saveAll(mappings);
         }
     }
 
@@ -888,8 +912,9 @@ public class MapEditorService {
 
         Map<String, Long> categoryIdsByCode = loadPoiCategoryIdsFromCodes(
                 pois.stream()
-                        .map(MapEditorDraftPoiSaveDTO::code)
+                        .map(poi -> normalizePoiCategoryCodeForDraft(poi.code(), poi.attrs()))
                         .filter(Objects::nonNull)
+                        .distinct()
                         .toList()
         );
 
@@ -1863,8 +1888,12 @@ public class MapEditorService {
         Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
                 .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
 
-        DraftMapVersionResult draftResult = getOrCreateBuildingDraftMapVersion(building, userId);
-        MapVersion draftMapVersion = draftResult.mapVersion();
+        Optional<MapVersion> draftMapVersionOpt = mapVersionRepository
+                .findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(building.getId(), MapType.BUILDING, "draft");
+        if (draftMapVersionOpt.isEmpty()) {
+            return List.of();
+        }
+        MapVersion draftMapVersion = draftMapVersionOpt.get();
 
         List<VerticalConnector> connectors = verticalConnectorRepository.findByMapVersionId(draftMapVersion.getId());
         List<VerticalConnectorNode> connectorNodes = verticalConnectorNodeRepository.findByConnectorMapVersionId(draftMapVersion.getId());
@@ -1929,6 +1958,11 @@ public class MapEditorService {
             throw new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND);
         }
 
+        MapVersion draftMapVersion = getDraftMapVersionOrThrow(buildingId);
+        if (!connector.getMapVersion().getId().equals(draftMapVersion.getId())) {
+            throw new MapException(MapErrorCode.MAP_VERSION_NOT_EDITABLE);
+        }
+
         verticalConnectorNodeRepository.deleteByConnectorId(connectorId);
         verticalConnectorRepository.delete(connector);
     }
@@ -1948,11 +1982,37 @@ public class MapEditorService {
             throw new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND);
         }
 
+        MapVersion draftMapVersion = getDraftMapVersionOrThrow(buildingId);
+        if (!connector.getMapVersion().getId().equals(draftMapVersion.getId())) {
+            throw new MapException(MapErrorCode.MAP_VERSION_NOT_EDITABLE);
+        }
+
         Node node = nodeRepository.findById(request.nodeId())
                 .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
 
         Floor floor = floorRepository.findById(request.floorId())
                 .orElseThrow(() -> new BuildingException(BuildingErrorCode.FLOOR_NOT_FOUND));
+
+        if (!tenantId.equals(node.getTenantId())) {
+            throw new MapException(MapErrorCode.VERTICAL_CONNECTOR_TENANT_MISMATCH);
+        }
+
+        if (node.getFloor() == null || !request.floorId().equals(node.getFloor().getId())) {
+            throw new MapException(MapErrorCode.VERTICAL_CONNECTOR_FLOOR_MISMATCH);
+        }
+
+        if (node.getMapVersion() == null || node.getMapVersion().getBuilding() == null
+                || !buildingId.equals(node.getMapVersion().getBuilding().getId())) {
+            throw new MapException(MapErrorCode.BUILDING_MISMATCH);
+        }
+
+        if (!node.getMapVersion().getId().equals(draftMapVersion.getId())) {
+            throw new MapException(MapErrorCode.MAP_VERSION_NOT_EDITABLE);
+        }
+
+        if (floor.getBuilding() == null || !buildingId.equals(floor.getBuilding().getId())) {
+            throw new BuildingException(BuildingErrorCode.BUILDING_FLOOR_MISMATCH);
+        }
 
         // 1. 해당 커넥터의 동일 층 기존 연결 삭제
         verticalConnectorNodeRepository.deleteByConnectorIdAndFloorId(connectorId, request.floorId());
@@ -1991,6 +2051,11 @@ public class MapEditorService {
             throw new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND);
         }
 
+        MapVersion draftMapVersion = getDraftMapVersionOrThrow(buildingId);
+        if (!connector.getMapVersion().getId().equals(draftMapVersion.getId())) {
+            throw new MapException(MapErrorCode.MAP_VERSION_NOT_EDITABLE);
+        }
+
         verticalConnectorNodeRepository.deleteByConnectorIdAndFloorId(connectorId, floorId);
         verticalConnectorNodeRepository.flush();
 
@@ -1998,6 +2063,12 @@ public class MapEditorService {
                 .filter(c -> c.id().equals(connectorId))
                 .findFirst()
                 .orElse(null);
+    }
+
+    private MapVersion getDraftMapVersionOrThrow(UUID buildingId) {
+        return mapVersionRepository
+                .findFirstByBuildingIdAndMapTypeAndStatusOrderByCreatedAtDesc(buildingId, MapType.BUILDING, "draft")
+                .orElseThrow(() -> new MapException(MapErrorCode.MAP_VERSION_NOT_FOUND));
     }
 
     @Transactional
@@ -2029,6 +2100,9 @@ public class MapEditorService {
         draftMapVersion.publish();
         mapVersionRepository.save(draftMapVersion);
         building.updateActivationStatus("active");
+        
+        long entranceCount = nodeRepository.countByMapVersion_Building_IdAndKindCodeAndMapVersion_Status(buildingId, "entrance", "published");
+        building.updateEntranceCount((int) entranceCount);
         if (building.getTenant() != null && !"approved".equals(building.getTenant().getStatus())) {
             building.getTenant().updateStatus("approved");
         }
@@ -2091,7 +2165,7 @@ public class MapEditorService {
                     for (Floor floor : floors) {
                         Floorplan floorplan = floorplanRepository.findByFloorIdAndIsCurrentTrue(floor.getId()).orElse(null);
                         if (floorplan != null) {
-                            FloorplanCalibration calibration = floorplanCalibrationRepository.findByFloorplanId(floorplan.getId())
+                            FloorplanCalibration calibration = floorplanCalibrationRepository.findTopByFloorplanIdOrderByCreatedAtDesc(floorplan.getId())
                                     .orElse(FloorplanCalibration.builder()
                                             .tenantId(tenantId)
                                             .floorplan(floorplan)
@@ -2315,6 +2389,8 @@ public class MapEditorService {
         Building building = buildingRepository.findByIdAndTenant_Id(buildingId, tenantId)
                 .orElseThrow(() -> new BuildingException(BuildingErrorCode.BUILDING_NOT_FOUND));
 
+        MapVersion draftMapVersion = getDraftMapVersionOrThrow(buildingId);
+
         GeometryFactory wgsGeometryFactory = new GeometryFactory(new org.locationtech.jts.geom.PrecisionModel(), 4326);
 
         for (MapEditorPoiMappingRequestDTO mapping : request.mappings()) {
@@ -2323,13 +2399,14 @@ public class MapEditorService {
                             com.insideout.backend.domain.map.exception.MapErrorCode.MAP_VERSION_NOT_FOUND
                     ));
 
-            if (!poi.getMapVersion().getBuilding().getId().equals(buildingId)) {
+            if (!poi.getTenantId().equals(tenantId) || poi.getMapVersion() == null
+                    || !poi.getMapVersion().getId().equals(draftMapVersion.getId())) {
                 throw new com.insideout.backend.domain.map.exception.MapException(
                         com.insideout.backend.domain.map.exception.MapErrorCode.MAP_VERSION_NOT_FOUND
                 );
             }
 
-            if (Boolean.TRUE.equals(mapping.excluded())) {
+            if (mapping.excluded()) {
                 poi.markExternalMappingExcluded();
             } else if (!StringUtils.hasText(mapping.externalApiId())) {
                 poi.updateExternalMapping(null, null, null, null);

--- a/src/main/java/com/insideout/backend/domain/tenant/dto/response/TenantSummaryResDTO.java
+++ b/src/main/java/com/insideout/backend/domain/tenant/dto/response/TenantSummaryResDTO.java
@@ -13,15 +13,21 @@ public record TenantSummaryResDTO(
         String slug,
         String displayName,
         String status,
+        int buildingCount,
         String role,
         OffsetDateTime joinedAt
 ) {
     public static TenantSummaryResDTO from(Tenant tenant, String role, OffsetDateTime joinedAt) {
+        return from(tenant, role, joinedAt, false, 0);
+    }
+
+    public static TenantSummaryResDTO from(Tenant tenant, String role, OffsetDateTime joinedAt, boolean approvedByPublishedMap, int buildingCount) {
         return new TenantSummaryResDTO(
                 tenant.getId(),
                 tenant.getSlug(),
                 tenant.getDisplayName(),
-                tenant.getStatus(),
+                approvedByPublishedMap ? "approved" : tenant.getStatus(),
+                buildingCount,
                 role,
                 joinedAt
         );

--- a/src/main/java/com/insideout/backend/domain/tenant/service/TenantService.java
+++ b/src/main/java/com/insideout/backend/domain/tenant/service/TenantService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -40,27 +41,48 @@ public class TenantService {
      */
     public List<TenantSummaryResDTO> getMyTenants(UUID userId) {
         List<TenantMembership> memberships = tenantMembershipRepository.findAllByUser_Id(userId);
+        if (memberships.isEmpty()) {
+            return List.of();
+        }
+
+        List<UUID> tenantIds = memberships.stream()
+                .map(m -> m.getTenant().getId())
+                .toList();
+
+        // 1. 모든 테넌트들의 빌딩을 한 번에 배치 조회
+        List<Building> allBuildings = buildingRepository.findByTenant_IdIn(tenantIds);
+
+        // 2. 테넌트 ID 별 빌딩 목록 그룹핑
+        Map<UUID, List<Building>> buildingsByTenantId = allBuildings.stream()
+                .collect(java.util.stream.Collectors.groupingBy(b -> b.getTenant().getId()));
+
+        // 3. 모든 빌딩 ID 수집 후 한 번에 published 여부 조회
+        List<UUID> buildingIds = allBuildings.stream()
+                .map(Building::getId)
+                .toList();
+
+        Set<UUID> publishedBuildingIds = buildingIds.isEmpty()
+                ? Set.of()
+                : mapVersionRepository.findBuildingIdsByMapTypeAndStatus(buildingIds, MapType.BUILDING, "published");
 
         return memberships.stream()
                 .map(membership -> {
-                    List<Building> buildings = buildingRepository.findByTenant_IdOrderByCreatedAtDesc(membership.getTenant().getId());
-                    Set<UUID> publishedBuildingIds = buildings.isEmpty()
-                            ? Set.of()
-                            : mapVersionRepository.findBuildingIdsByMapTypeAndStatus(
-                                    buildings.stream().map(Building::getId).toList(),
-                                    MapType.BUILDING,
-                                    "published"
-                            );
+                    UUID tenantId = membership.getTenant().getId();
+                    List<Building> tenantBuildings = buildingsByTenantId.getOrDefault(tenantId, List.of());
+
+                    // 테넌트에 속한 빌딩 중 published된 빌딩이 최소 하나라도 있는지 확인
+                    boolean hasPublishedBuilding = tenantBuildings.stream()
+                            .anyMatch(b -> publishedBuildingIds.contains(b.getId()));
 
                     boolean approvedByPublishedMap =
-                            "approved".equals(membership.getTenant().getStatus()) || !publishedBuildingIds.isEmpty();
+                            "approved".equals(membership.getTenant().getStatus()) || hasPublishedBuilding;
 
                     return TenantSummaryResDTO.from(
                             membership.getTenant(),
                             membership.getRole(),
                             membership.getJoinedAt(),
                             approvedByPublishedMap,
-                            buildings.size()
+                            tenantBuildings.size()
                     );
                 })
                 .toList();

--- a/src/main/java/com/insideout/backend/domain/tenant/service/TenantService.java
+++ b/src/main/java/com/insideout/backend/domain/tenant/service/TenantService.java
@@ -111,7 +111,14 @@ public class TenantService {
                 .orElseThrow(() -> new TenantException(TenantErrorCode.TENANT_NOT_FOUND));
 
         tenant.updateStatus("approved");
-        return TenantSummaryResDTO.from(tenant, membership.getRole(), membership.getJoinedAt());
+        int buildingCount = buildingRepository.findByTenant_IdOrderByCreatedAtDesc(tenantId).size();
+        return TenantSummaryResDTO.from(
+                tenant,
+                membership.getRole(),
+                membership.getJoinedAt(),
+                true,
+                buildingCount
+        );
     }
 
 }

--- a/src/main/java/com/insideout/backend/domain/tenant/service/TenantService.java
+++ b/src/main/java/com/insideout/backend/domain/tenant/service/TenantService.java
@@ -1,5 +1,9 @@
 package com.insideout.backend.domain.tenant.service;
 
+import com.insideout.backend.domain.building.entity.Building;
+import com.insideout.backend.domain.building.repository.BuildingRepository;
+import com.insideout.backend.domain.map.enums.MapType;
+import com.insideout.backend.domain.map.repository.MapVersionRepository;
 import com.insideout.backend.domain.tenant.dto.response.TenantSummaryResDTO;
 import com.insideout.backend.domain.tenant.dto.request.TenantCreateReqDTO;
 import com.insideout.backend.domain.tenant.entity.Tenant;
@@ -17,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -27,6 +32,8 @@ public class TenantService {
     private final TenantMembershipRepository tenantMembershipRepository;
     private final UserRepository userRepository;
     private final TenantRepository tenantRepository;
+    private final BuildingRepository buildingRepository;
+    private final MapVersionRepository mapVersionRepository;
 
     /**
      * 유저가 소속된 모든 테넌트 목록을 반환합니다.
@@ -35,7 +42,27 @@ public class TenantService {
         List<TenantMembership> memberships = tenantMembershipRepository.findAllByUser_Id(userId);
 
         return memberships.stream()
-                .map(m -> TenantSummaryResDTO.from(m.getTenant(), m.getRole(), m.getJoinedAt()))
+                .map(membership -> {
+                    List<Building> buildings = buildingRepository.findByTenant_IdOrderByCreatedAtDesc(membership.getTenant().getId());
+                    Set<UUID> publishedBuildingIds = buildings.isEmpty()
+                            ? Set.of()
+                            : mapVersionRepository.findBuildingIdsByMapTypeAndStatus(
+                                    buildings.stream().map(Building::getId).toList(),
+                                    MapType.BUILDING,
+                                    "published"
+                            );
+
+                    boolean approvedByPublishedMap =
+                            "approved".equals(membership.getTenant().getStatus()) || !publishedBuildingIds.isEmpty();
+
+                    return TenantSummaryResDTO.from(
+                            membership.getTenant(),
+                            membership.getRole(),
+                            membership.getJoinedAt(),
+                            approvedByPublishedMap,
+                            buildings.size()
+                    );
+                })
                 .toList();
     }
 

--- a/src/main/resources/db/migration/V20__add_unique_constraints_to_building_entrance_mapping.sql
+++ b/src/main/resources/db/migration/V20__add_unique_constraints_to_building_entrance_mapping.sql
@@ -1,0 +1,28 @@
+-- Remove duplicates for uk_building_entrance_mapping_gate (keep latest by created_at)
+DELETE FROM building_entrance_mapping
+WHERE id NOT IN (
+    SELECT id
+    FROM (
+        SELECT id, ROW_NUMBER() OVER (PARTITION BY tenant_id, campus_id, campus_gate_id ORDER BY created_at DESC) as rn
+        FROM building_entrance_mapping
+    ) t
+    WHERE t.rn = 1
+);
+
+-- Remove duplicates for uk_building_entrance_mapping_node (keep latest by created_at)
+DELETE FROM building_entrance_mapping
+WHERE id NOT IN (
+    SELECT id
+    FROM (
+        SELECT id, ROW_NUMBER() OVER (PARTITION BY tenant_id, building_id, entrance_node_id ORDER BY created_at DESC) as rn
+        FROM building_entrance_mapping
+    ) t
+    WHERE t.rn = 1
+);
+
+-- Add unique constraints
+ALTER TABLE building_entrance_mapping
+ADD CONSTRAINT uk_building_entrance_mapping_gate UNIQUE (tenant_id, campus_id, campus_gate_id);
+
+ALTER TABLE building_entrance_mapping
+ADD CONSTRAINT uk_building_entrance_mapping_node UNIQUE (tenant_id, building_id, entrance_node_id);


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #69 

## 📝작업 내용

관리자 웹의 맵 에디터 데이터 통합 관리 및 빌딩 출입구/도면 캘리브레이션 연동을 위한 백엔드 API들을 전반적으로 구현 및 개선했습니다.

1. 맵 에디터 임시저장(Draft) 및 최종 배포(Publish) 로직 구현

POI, Node, Edge, Zone 등 맵 에디터에서 생성된 데이터의 버전을 나누어 상태(임시저장/배포)를 관리할 수 있도록 개선
엘리베이터 등 수직 이동수단(Vertical Connector) 데이터 처리를 위한 신규 엔티티 및 DTO, 관련 Repository 추가

2. 빌딩 출입구(Entrance) 및 도면 캘리브레이션 관리 기능 신설

빌딩의 실제 위치와 출입구를 매핑하기 위한 BuildingEntrance 도메인(Controller, Service, Repository) 추가
픽셀 좌표와 WGS84 위경도 변환을 위한 도면 캘리브레이션 처리 관련 클래스(PixelCoordinateDTO, FloorRequestDTO 등) 신설 및 엔티티 업데이트

3. 기타 개선 사항

테넌트(입점 매장) 응답 데이터(TenantSummaryResDTO) 구조 수정 및 TenantService 로직 최적화

### 스크린샷 (선택)
<img width="1506" height="691" alt="스크린샷 2026-06-04 오후 1 46 46" src="https://github.com/user-attachments/assets/7e407339-a3d6-44aa-a970-d47bdbebc7a9" />
<img width="1453" height="242" alt="스크린샷 2026-06-04 오후 1 46 59" src="https://github.com/user-attachments/assets/cc476108-9784-4905-befe-5cd214d9d8b5" />
<img width="1468" height="307" alt="스크린샷 2026-06-04 오후 1 47 25" src="https://github.com/user-attachments/assets/a4870fb6-145c-4d1f-8d42-31c132f86fc6" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 건물에 층 추가 API 추가
  * 건물 출입구/게이트 관리: 출입구 조회·생성·캠퍼스 게이트 매핑 지원
  * 지도 편집기 강화: 층 드래프트 저장·퍼블리시, 드래프트 POI 조회·외부 매핑 저장
  * 수직 이동수단(커넥터) 관리: 목록·생성·삭제·노드 매핑/해제 기능 추가
* **개선**
  * 빌딩 요약에 게시(published) 상태 및 빌딩 수 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->