### PR TITLE
fix: 정류장 파싱 로직 추가, 검색 엔진 예외처리 및 tmap api 하드코딩 수정(#72)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/dto/NavigationResponseDto.java
@@ -82,6 +82,7 @@ public record NavigationResponseDto(
             Integer durationSeconds,
             Integer distanceMeters,
             Integer stationCount,
+            List<TransitStopDto> stops,
             String startName,
             String endName,
             MapType mapType,
@@ -104,9 +105,17 @@ public record NavigationResponseDto(
                 String endName,
                 List<StepDto> steps
         ) {
-            this(mode, routeName, transitType, durationSeconds, distanceMeters, stationCount,
+            this(mode, routeName, transitType, durationSeconds, distanceMeters, stationCount, List.of(),
                     startName, endName, null, null, null, null, null, null, List.of(), steps);
         }
+    }
+
+    public record TransitStopDto(
+            String name,
+            String stationId,
+            Double x,
+            Double y
+    ) {
     }
 
     public record FloorSegmentDto(

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -333,16 +333,16 @@ public class NavigationService {
     }
 
     private String normalizeApiKey(String apiKey) {
-        if (apiKey == null) {
-            return "";
-        }
-        String normalized = apiKey.trim();
+        String normalized = apiKey == null ? "" : apiKey.trim();
         if (normalized.length() >= 2) {
             char first = normalized.charAt(0);
             char last = normalized.charAt(normalized.length() - 1);
             if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
-                return normalized.substring(1, normalized.length() - 1).trim();
+                normalized = normalized.substring(1, normalized.length() - 1).trim();
             }
+        }
+        if (normalized.isBlank()) {
+            throw new IllegalStateException("tmap.api.key must not be blank");
         }
         return normalized;
     }

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -1221,7 +1221,7 @@ public class NavigationService {
         String startName = getNullableText(legNode.path("start").path("name"));
         String endName = getNullableText(legNode.path("end").path("name"));
         List<TransitStopDto> stops = new ArrayList<>();
-        Set<String> seenNames = new HashSet<>();
+        Set<String> seenStopKeys = new HashSet<>();
 
         for (JsonNode stationNode : stationList) {
             String name = firstText(
@@ -1233,17 +1233,19 @@ public class NavigationService {
                     "name",
                     "title"
             );
+            String stationId = firstText(stationNode, "stationID", "stationId", "stopId", "stopID", "id");
             String normalizedName = normalizeTransitStopName(name);
+            String stopKey = transitStopDedupeKey(stationId, normalizedName);
             if (normalizedName == null
                     || normalizedName.equals(normalizeTransitStopName(startName))
                     || normalizedName.equals(normalizeTransitStopName(endName))
-                    || !seenNames.add(normalizedName)) {
+                    || !seenStopKeys.add(stopKey)) {
                 continue;
             }
 
             stops.add(new TransitStopDto(
                     name,
-                    firstText(stationNode, "stationID", "stationId", "stopId", "stopID", "id"),
+                    stationId,
                     firstNonNull(
                             getNullableDouble(stationNode.path("lon")),
                             firstNonNull(getNullableDouble(stationNode.path("x")), getNullableDouble(stationNode.path("stationX")))
@@ -1256,6 +1258,13 @@ public class NavigationService {
         }
 
         return stops;
+    }
+
+    private String transitStopDedupeKey(String stationId, String normalizedName) {
+        if (stationId != null && !stationId.isBlank()) {
+            return "id:" + stationId.strip();
+        }
+        return "name:" + normalizedName;
     }
 
     private JsonNode transitStationListNode(JsonNode legNode) {

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -24,6 +24,7 @@ import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteFa
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteMode;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteOption;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.StepDto;
+import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.TransitStopDto;
 import com.insideout.backend.domain.navigation.exception.NavigationErrorCode;
 import com.insideout.backend.domain.navigation.exception.NavigationException;
 import com.insideout.backend.global.apiPayload.code.BaseErrorCode;
@@ -309,7 +310,7 @@ public class NavigationService {
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set("appKey", tmapApiKey);
+        headers.set("appKey", normalizeApiKey(tmapApiKey));
 
         try {
             JsonNode response = restTemplate.postForObject(url, new HttpEntity<>(body, headers), JsonNode.class);
@@ -329,6 +330,21 @@ public class NavigationService {
             log.warn("TMAP API request failed. url={}", url, e);
             throw new NavigationException(NavigationErrorCode.TMAP_CONNECTION_FAILED, e);
         }
+    }
+
+    private String normalizeApiKey(String apiKey) {
+        if (apiKey == null) {
+            return "";
+        }
+        String normalized = apiKey.trim();
+        if (normalized.length() >= 2) {
+            char first = normalized.charAt(0);
+            char last = normalized.charAt(normalized.length() - 1);
+            if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
+                return normalized.substring(1, normalized.length() - 1).trim();
+            }
+        }
+        return normalized;
     }
 
     private List<RouteDto> parseTransitRoutes(JsonNode response, RouteTarget target) {
@@ -376,15 +392,24 @@ public class NavigationService {
 
         for (JsonNode legNode : legsNode) {
             LegMode mode = parseTransitLegMode(getNullableText(legNode.path("mode")));
+            List<TransitStopDto> stops = parseTransitStops(legNode);
             legs.add(new LegDto(
                     mode,
                     resolveTransitRouteName(legNode),
                     getNullableText(legNode.path("type")),
                     getNullableInt(legNode.path("sectionTime")),
                     getNullableInt(legNode.path("distance")),
-                    countTransitStations(legNode),
+                    firstNonNull(countTransitStations(legNode), stops.isEmpty() ? null : stops.size()),
+                    stops,
                     getNullableText(legNode.path("start").path("name")),
                     getNullableText(legNode.path("end").path("name")),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    List.of(),
+                    List.of(),
                     parseTransitSteps(legNode)
             ));
         }
@@ -737,6 +762,7 @@ public class NavigationService {
                 null,
                 null,
                 null,
+                List.of(),
                 startName,
                 endName,
                 mapType,
@@ -849,6 +875,7 @@ public class NavigationService {
                 null,
                 null,
                 null,
+                List.of(),
                 target.campusEntranceName(),
                 target.entranceName(),
                 MapType.CAMPUS,
@@ -874,6 +901,7 @@ public class NavigationService {
                 null,
                 null,
                 null,
+                List.of(),
                 target.entranceName(),
                 endName,
                 MapType.BUILDING,
@@ -899,6 +927,7 @@ public class NavigationService {
                 null,
                 null,
                 null,
+                List.of(),
                 startName,
                 target.entranceName(),
                 MapType.BUILDING,
@@ -920,6 +949,7 @@ public class NavigationService {
                 null,
                 null,
                 null,
+                List.of(),
                 target.entranceName(),
                 target.campusEntranceName(),
                 MapType.CAMPUS,
@@ -1175,14 +1205,78 @@ public class NavigationService {
     }
 
     private Integer countTransitStations(JsonNode legNode) {
-        JsonNode stationList = legNode.path("passStopList").path("stationList");
-        if (!stationList.isArray()) {
-            stationList = legNode.path("passStopList").path("stations");
-        }
+        JsonNode stationList = transitStationListNode(legNode);
         if (stationList.isArray()) {
             return stationList.size();
         }
         return null;
+    }
+
+    private List<TransitStopDto> parseTransitStops(JsonNode legNode) {
+        JsonNode stationList = transitStationListNode(legNode);
+        if (!stationList.isArray()) {
+            return List.of();
+        }
+
+        String startName = getNullableText(legNode.path("start").path("name"));
+        String endName = getNullableText(legNode.path("end").path("name"));
+        List<TransitStopDto> stops = new ArrayList<>();
+        Set<String> seenNames = new HashSet<>();
+
+        for (JsonNode stationNode : stationList) {
+            String name = firstText(
+                    stationNode,
+                    "stationName",
+                    "stationNm",
+                    "stopName",
+                    "stopNm",
+                    "name",
+                    "title"
+            );
+            String normalizedName = normalizeTransitStopName(name);
+            if (normalizedName == null
+                    || normalizedName.equals(normalizeTransitStopName(startName))
+                    || normalizedName.equals(normalizeTransitStopName(endName))
+                    || !seenNames.add(normalizedName)) {
+                continue;
+            }
+
+            stops.add(new TransitStopDto(
+                    name,
+                    firstText(stationNode, "stationID", "stationId", "stopId", "stopID", "id"),
+                    firstNonNull(
+                            getNullableDouble(stationNode.path("lon")),
+                            firstNonNull(getNullableDouble(stationNode.path("x")), getNullableDouble(stationNode.path("stationX")))
+                    ),
+                    firstNonNull(
+                            getNullableDouble(stationNode.path("lat")),
+                            firstNonNull(getNullableDouble(stationNode.path("y")), getNullableDouble(stationNode.path("stationY")))
+                    )
+            ));
+        }
+
+        return stops;
+    }
+
+    private JsonNode transitStationListNode(JsonNode legNode) {
+        JsonNode stationList = legNode.path("passStopList").path("stationList");
+        if (!stationList.isArray()) {
+            stationList = legNode.path("passStopList").path("stations");
+        }
+        if (!stationList.isArray()) {
+            stationList = legNode.path("stationList");
+        }
+        if (!stationList.isArray()) {
+            stationList = legNode.path("stations");
+        }
+        return stationList;
+    }
+
+    private String normalizeTransitStopName(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.replaceAll("\\s+", "");
     }
 
     private LegMode parseTransitLegMode(String mode) {

--- a/src/main/java/com/insideout/backend/domain/place/service/suggest/PlaceSuggestService.java
+++ b/src/main/java/com/insideout/backend/domain/place/service/suggest/PlaceSuggestService.java
@@ -36,8 +36,18 @@ public class PlaceSuggestService {
         PlaceSearchSupport.validateCoordinate(lat, lng, true);
         int resolvedSize = normalizeSize(size);
 
-        List<PlaceSuggestElasticsearchClient.SuggestDocument> fromElasticsearch = placeSuggestElasticsearchClient
-                .suggest(normalizedQuery, resolvedSize, lat, lng);
+        List<PlaceSuggestElasticsearchClient.SuggestDocument> fromElasticsearch;
+        try {
+            fromElasticsearch = placeSuggestElasticsearchClient
+                    .suggest(normalizedQuery, resolvedSize, lat, lng);
+        } catch (PlaceException ex) {
+            if (ex.getErrorCode() != PlaceErrorCode.SEARCH_SERVICE_UNAVAILABLE) {
+                throw ex;
+            }
+            log.warn("Elasticsearch unavailable for suggest query='{}' lat={} lng={} size={}. Falling back to Kakao.",
+                    normalizedQuery, lat, lng, resolvedSize, ex);
+            fromElasticsearch = List.of();
+        }
 
         List<PlaceSuggestElasticsearchClient.SuggestDocument> mergedSuggested = fromElasticsearch;
         int fallbackSize = PlaceSuggestFallbackPolicy.resolveFallbackSize(resolvedSize, fromElasticsearch.size(), lat, lng);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,8 +1,4 @@
 spring:
-  config:
-    import:
-      - optional:file:.env[.properties]
-
   elasticsearch:
     uris: http://localhost:9200
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
 
   config:
     import:
+      - optional:file:.env[.properties]
+      - optional:file:backend/.env[.properties]
       - optional:classpath:db.properties
       - optional:classpath:security.yml
 

--- a/src/test/java/com/insideout/backend/BackendApplicationTests.java
+++ b/src/test/java/com/insideout/backend/BackendApplicationTests.java
@@ -5,6 +5,7 @@ import com.insideout.backend.domain.ai.repository.AiJobRepository;
 import com.insideout.backend.domain.ai.repository.CampusAiDetectionRepository;
 import com.insideout.backend.domain.ai.repository.CampusAiJobRepository;
 import com.insideout.backend.domain.building.repository.BuildingDirectoryRepository;
+import com.insideout.backend.domain.building.repository.BuildingEntranceMappingRepository;
 import com.insideout.backend.domain.building.repository.BuildingRepository;
 import com.insideout.backend.domain.building.repository.CampusMapRepository;
 import com.insideout.backend.domain.building.repository.CampusRepository;
@@ -12,9 +13,11 @@ import com.insideout.backend.domain.building.repository.FloorRepository;
 import com.insideout.backend.domain.building.repository.FloorplanCalibrationRepository;
 import com.insideout.backend.domain.building.repository.FloorplanRepository;
 import com.insideout.backend.domain.map.repository.EdgeRepository;
+import com.insideout.backend.domain.map.repository.FloorplanObjectRepository;
 import com.insideout.backend.domain.map.repository.MapVersionRepository;
 import com.insideout.backend.domain.map.repository.NodeRepository;
 import com.insideout.backend.domain.map.repository.ObstacleRepository;
+import com.insideout.backend.domain.map.repository.PoiCategoryRepository;
 import com.insideout.backend.domain.map.repository.PoiRepository;
 import com.insideout.backend.domain.map.repository.VerticalConnectorNodeRepository;
 import com.insideout.backend.domain.map.repository.VerticalConnectorRepository;
@@ -23,6 +26,8 @@ import com.insideout.backend.domain.map.storage.MapAssetStorage;
 import com.insideout.backend.domain.tenant.repository.TenantMembershipRepository;
 import com.insideout.backend.domain.tenant.repository.TenantRepository;
 import com.insideout.backend.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
@@ -51,6 +56,9 @@ class BackendApplicationTests {
 
     @MockitoBean
     private BuildingRepository buildingRepository;
+
+    @MockitoBean
+    private BuildingEntranceMappingRepository buildingEntranceMappingRepository;
 
     @MockitoBean
     private PoiRepository poiRepository;
@@ -104,6 +112,12 @@ class BackendApplicationTests {
     private FloorplanCalibrationRepository floorplanCalibrationRepository;
 
     @MockitoBean
+    private FloorplanObjectRepository floorplanObjectRepository;
+
+    @MockitoBean
+    private PoiCategoryRepository poiCategoryRepository;
+
+    @MockitoBean
     private VerticalConnectorRepository verticalConnectorRepository;
 
     @MockitoBean
@@ -111,6 +125,12 @@ class BackendApplicationTests {
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    private EntityManager entityManager;
+
+    @MockitoBean
+    private EntityManagerFactory entityManagerFactory;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -242,13 +242,16 @@ class NavigationServiceTest {
                 .findFirst()
                 .orElseThrow();
 
-        assertThat(busLeg.stationCount()).isEqualTo(4);
+        assertThat(busLeg.stationCount()).isEqualTo(6);
         assertThat(busLeg.stops())
                 .extracting(NavigationResponseDto.TransitStopDto::name)
-                .containsExactly("중간정류장1", "중간정류장2");
+                .containsExactly("중간정류장1", "중간정류장2", "중복정류장", "중복정류장");
         assertThat(busLeg.stops().get(0).stationId()).isEqualTo("S-1");
         assertThat(busLeg.stops().get(0).x()).isEqualTo(126.95);
         assertThat(busLeg.stops().get(0).y()).isEqualTo(37.45);
+        assertThat(busLeg.stops())
+                .extracting(NavigationResponseDto.TransitStopDto::stationId)
+                .containsExactly("S-1", "S-2", "S-3", "S-4");
     }
 
     @Test
@@ -554,6 +557,8 @@ class NavigationServiceTest {
                                   {"stationName": "승차정류장", "stationID": "START", "lon": "126.90", "lat": "37.40"},
                                   {"stationName": "중간정류장1", "stationID": "S-1", "lon": "126.95", "lat": "37.45"},
                                   {"stationName": "중간정류장2", "stationID": "S-2", "lon": 127.0, "lat": 37.48},
+                                  {"stationName": "중복정류장", "stationID": "S-3", "lon": 127.03, "lat": 37.49},
+                                  {"stationName": "중복정류장", "stationID": "S-4", "lon": 127.05, "lat": 37.495},
                                   {"stationName": "하차정류장", "stationID": "END", "lon": "127.10", "lat": "37.50"}
                                 ]
                               }

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -1,8 +1,10 @@
 package com.insideout.backend.domain.navigation.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -92,6 +94,32 @@ class NavigationServiceTest {
         );
         assertThat(entityCaptor.getAllValues())
                 .allSatisfy(entity -> assertThat(entity.getHeaders().getFirst("appKey")).isEqualTo("test-tmap-key"));
+    }
+
+    @Test
+    @DisplayName("TMAP 키가 비어 있으면 외부 호출 전에 설정 오류를 드러낸다")
+    void blankTmapApiKeyFailsBeforeSendingRequest() {
+        ReflectionTestUtils.setField(navigationService, "tmapApiKey", "  \"\"  ");
+
+        assertThatThrownBy(() -> navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발지",
+                "목적지",
+                null,
+                false,
+                List.of(RouteType.WALK)
+        )))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("tmap.api.key must not be blank");
+
+        verify(restTemplate, never()).postForObject(
+                any(String.class),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        );
     }
 
     @Test

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -3,6 +3,8 @@ package com.insideout.backend.domain.navigation.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -25,9 +27,11 @@ import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteFa
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteMode;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.RouteOption;
 import com.insideout.backend.domain.navigation.dto.NavigationResponseDto.StepDto;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
@@ -56,6 +60,38 @@ class NavigationServiceTest {
     void setUp() {
         navigationService = new NavigationService(mapQueryFacade, restTemplate);
         ReflectionTestUtils.setField(navigationService, "tmapApiKey", "test-tmap-key");
+    }
+
+    @Test
+    @DisplayName(".env에서 따옴표로 감싼 TMAP 키를 읽어도 appKey 헤더에는 따옴표 없이 전달한다")
+    void tmapApiKeyStripsWrappingQuotesBeforeSendingHeader() throws Exception {
+        ReflectionTestUtils.setField(navigationService, "tmapApiKey", "\"test-tmap-key\"");
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(walkRouteResponse());
+
+        navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발지",
+                "목적지",
+                null,
+                false,
+                List.of(RouteType.WALK)
+        ));
+
+        ArgumentCaptor<HttpEntity> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate, times(2)).postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
+                entityCaptor.capture(),
+                eq(JsonNode.class)
+        );
+        assertThat(entityCaptor.getAllValues())
+                .allSatisfy(entity -> assertThat(entity.getHeaders().getFirst("appKey")).isEqualTo("test-tmap-key"));
     }
 
     @Test
@@ -179,6 +215,40 @@ class NavigationServiceTest {
         assertThat(response.failures())
                 .extracting(RouteFailureDto::routeOption)
                 .containsOnly(RouteOption.TRANSIT_CANDIDATE);
+    }
+
+    @Test
+    void transitLegIncludesIntermediateStops() throws Exception {
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/transit/routes"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(transitRouteResponseWithPassStops());
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발지",
+                "목적지",
+                null,
+                false,
+                List.of(RouteType.TRANSIT)
+        ));
+
+        LegDto busLeg = response.routes().get(0).legs().stream()
+                .filter(leg -> leg.mode() == LegMode.BUS)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(busLeg.stationCount()).isEqualTo(4);
+        assertThat(busLeg.stops())
+                .extracting(NavigationResponseDto.TransitStopDto::name)
+                .containsExactly("중간정류장1", "중간정류장2");
+        assertThat(busLeg.stops().get(0).stationId()).isEqualTo("S-1");
+        assertThat(busLeg.stops().get(0).x()).isEqualTo(126.95);
+        assertThat(busLeg.stops().get(0).y()).isEqualTo(37.45);
     }
 
     @Test
@@ -451,6 +521,42 @@ class NavigationServiceTest {
                               "distance": 600,
                               "start": {"name": "출발지", "lon": 126.9, "lat": 37.4},
                               "end": {"name": "정류장", "lon": 127.0, "lat": 37.45}
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+                """);
+    }
+
+    private JsonNode transitRouteResponseWithPassStops() throws Exception {
+        return OBJECT_MAPPER.readTree("""
+                {
+                  "metaData": {
+                    "plan": {
+                      "itineraries": [
+                        {
+                          "totalTime": 1200,
+                          "totalDistance": 5000,
+                          "legs": [
+                            {
+                              "mode": "BUS",
+                              "route": "간선 101",
+                              "type": "bus",
+                              "sectionTime": 900,
+                              "distance": 4400,
+                              "start": {"name": "승차정류장"},
+                              "end": {"name": "하차정류장"},
+                              "passStopList": {
+                                "stationList": [
+                                  {"stationName": "승차정류장", "stationID": "START", "lon": "126.90", "lat": "37.40"},
+                                  {"stationName": "중간정류장1", "stationID": "S-1", "lon": "126.95", "lat": "37.45"},
+                                  {"stationName": "중간정류장2", "stationID": "S-2", "lon": 127.0, "lat": 37.48},
+                                  {"stationName": "하차정류장", "stationID": "END", "lon": "127.10", "lat": "37.50"}
+                                ]
+                              }
                             }
                           ]
                         }

--- a/src/test/java/com/insideout/backend/domain/place/service/PlaceSuggestServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/place/service/PlaceSuggestServiceTest.java
@@ -191,6 +191,24 @@ class PlaceSuggestServiceTest {
     }
 
     @Test
+    void suggest_whenElasticsearchUnavailable_usesKakaoFallback() {
+        when(placeSuggestElasticsearchClient.suggest("신세계", 10, null, null))
+                .thenThrow(new PlaceException(PlaceErrorCode.SEARCH_SERVICE_UNAVAILABLE));
+        when(kakaoPlaceSearchClient.searchByKeyword("신세계", null, null, null, 10))
+                .thenReturn(List.of(
+                        new PlaceSearchItemResponse("신세계백화점 본점", "서울 중구", "서울 중구 소공로 63", 37.5609, 126.9810, false, "1", null)
+                ));
+        when(buildingRepository.findRegisteredPlacesByExternalApiIds(Set.of("1")))
+                .thenReturn(List.of());
+
+        List<PlaceSearchItemResponse> result = placeSuggestService.suggest("신세계", null, null, 10);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo("신세계백화점 본점");
+        verify(placeSearchIndexingService).upsertFromSearchResultsAsync(any());
+    }
+
+    @Test
     void suggest_withCoordinate_evenWhenElasticsearchHasEnoughResults_fetchesNearbyFallback() {
         when(placeSuggestElasticsearchClient.suggest("스타벅스", 10, 37.5609, 126.9810))
                 .thenReturn(List.of(


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #72

## 📝작업 내용

>대중교통 경로 안내 시 경유 정류장 정보를 제공하고, 검색 실패 시 Fallback 로직을 구축합니다. 더불어 로컬 개발 및 테스트 편의성과 보안성 향상을 위해 환경 변수 관리 방식을 개선합니다.


### 1. 대중교통 및 티맵(Tmap) 연동 고도화
* 대중교통 경로 데이터(`leg`)에 경유 정류장 목록(`stops`) 구조 추가
* Tmap API 응답에서 경유 정류장을 올바르게 추출하기 위한 파싱 로직 구현

### 2. 외부 환경 변수를 활용한 API Key 관리 개선 (하드코딩 제거)
- 로컬 `.env` 파일에 정의된 환경 변수를 `application.yml`이 자동으로 읽어와 주입하도록 설정 방식 개선 (민감 정보 보호 및 로컬 테스트 자동화 환경 구축)

### 3. 검색 엔진(Elasticsearch) 안정성 확보
* Elasticsearch `suggest` 쿼리 실패 시, 시스템이 중단되지 않고 카카오 검색 API를 호출하도록 예외 처리 및 Fallback 로직 구현

### 4. 테스트 코드 보강 및 안정화
* 신규 기능(Stops, Fallback)에 대한 관련 테스트 코드 추가
* `BackendApplicationTests` 실행 시 필요한 Mock Bean을 추가하여 전체 테스트 컨텍스트 빌드 오류 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 경로 탐색 결과에 대중교통 중간 정류장 정보 포함

* **버그 수정**
  * 검색 서비스 장애 시 대체 검색으로 자동 전환되도록 개선
  * API 키 처리 시 불필요한 따옴표 자동 제거

* **기타**
  * 환경 설정 파일 로드 경로 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->