### PR TITLE
[fix] MinIO 공개 endpoint 분리로 이미지 접근 경로 보완

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -13,5 +13,13 @@
 
 assets.insideout-socks.store {
     encode gzip zstd
+
+    header {
+        X-Content-Type-Options nosniff
+        X-Frame-Options DENY
+        Referrer-Policy no-referrer
+        Strict-Transport-Security "max-age=31536000"
+    }
+
     reverse_proxy minio:9000
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -10,3 +10,8 @@
 
     reverse_proxy app:8080
 }
+
+assets.insideout-socks.store {
+    encode gzip zstd
+    reverse_proxy minio:9000
+}

--- a/src/main/java/com/insideout/backend/global/infra/storage/config/S3Config.java
+++ b/src/main/java/com/insideout/backend/global/infra/storage/config/S3Config.java
@@ -51,8 +51,12 @@ public class S3Config {
      */
     @Bean
     public S3Presigner s3Presigner(S3Properties props) {
+        String presignerEndpoint = (props.publicEndpoint() == null || props.publicEndpoint().isBlank())
+                ? props.endpoint()
+                : props.publicEndpoint();
+
         return S3Presigner.builder()
-                .endpointOverride(URI.create(props.endpoint()))
+                .endpointOverride(URI.create(presignerEndpoint))
                 .region(Region.of(props.region()))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(

--- a/src/main/java/com/insideout/backend/global/infra/storage/config/S3Config.java
+++ b/src/main/java/com/insideout/backend/global/infra/storage/config/S3Config.java
@@ -51,12 +51,8 @@ public class S3Config {
      */
     @Bean
     public S3Presigner s3Presigner(S3Properties props) {
-        String presignerEndpoint = (props.publicEndpoint() == null || props.publicEndpoint().isBlank())
-                ? props.endpoint()
-                : props.publicEndpoint();
-
         return S3Presigner.builder()
-                .endpointOverride(URI.create(presignerEndpoint))
+                .endpointOverride(resolvePresignerEndpoint(props))
                 .region(Region.of(props.region()))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(
@@ -68,5 +64,17 @@ public class S3Config {
                         .pathStyleAccessEnabled(props.pathStyleAccess())
                         .build())
                 .build();
+    }
+
+    private URI resolvePresignerEndpoint(S3Properties props) {
+        String endpoint = (props.publicEndpoint() == null || props.publicEndpoint().isBlank())
+                ? props.endpoint()
+                : props.publicEndpoint();
+
+        if (!endpoint.startsWith("http://") && !endpoint.startsWith("https://")) {
+            throw new IllegalArgumentException("S3 public endpoint must include http:// or https://");
+        }
+
+        return URI.create(endpoint);
     }
 }

--- a/src/main/java/com/insideout/backend/global/infra/storage/config/S3Properties.java
+++ b/src/main/java/com/insideout/backend/global/infra/storage/config/S3Properties.java
@@ -19,6 +19,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "storage.s3")
 public record S3Properties(
         String endpoint,
+        String publicEndpoint,
         String region,
         String accessKey,
         String secretKey,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,7 @@ management:
 storage:
   s3:
     endpoint: ${S3_ENDPOINT:http://localhost:9000}
+    public-endpoint: ${S3_PUBLIC_ENDPOINT:}
     region: ${S3_REGION:ap-northeast-2}
     access-key: ${S3_ACCESS_KEY}
     secret-key: ${S3_SECRET_KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Related #86

## 📝작업 내용

> MinIO 내부 endpoint와 브라우저 공개 endpoint를 분리하여,
> 프론트에서 presigned URL 기반 이미지 접근이 가능하도록 배포 구성을 보완했습니다.

- `storage.s3.public-endpoint` 설정 추가
- presigned URL 생성 시 공개 endpoint 사용하도록 수정
- Caddy에 `assets.insideout-socks.store` -> `minio:9000` 프록시 추가

## 💬리뷰 요구사항(선택)

> 배포 환경에서 presigned URL 호스트가 공개 도메인으로 정상 생성되는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * S3 저장소의 공개 엔드포인트 설정 지원 추가
  * 자산 저장소 도메인 라우팅 구성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->