### PR TITLE
[fix] poi radius 150으로 완화(#92)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -53,7 +53,7 @@ public class MapQueryFacade {
 
     private static final double REGISTERED_BUILDING_SEARCH_RADIUS_METERS = 50.0;
     private static final double INSTRUCTION_LANDMARK_RADIUS_PX = 180.0;
-    private static final double POI_ANCHOR_SNAP_RADIUS_PX = 120.0;
+    private static final double POI_ANCHOR_SNAP_RADIUS_PX = 150.0;
 
     private final NodeRepository nodeRepository;
     private final BuildingDirectoryRepository buildingDirectoryRepository;

--- a/src/test/java/com/insideout/backend/domain/map/facade/MapQueryFacadeTest.java
+++ b/src/test/java/com/insideout/backend/domain/map/facade/MapQueryFacadeTest.java
@@ -217,7 +217,7 @@ class MapQueryFacadeTest {
                 .mapVersion(mapVersion)
                 .floor(floor)
                 .kindCode("corridor")
-                .geomPx(geometryFactory.createPoint(new Coordinate(121, 0)))
+                .geomPx(geometryFactory.createPoint(new Coordinate(151, 0)))
                 .build();
         ReflectionTestUtils.setField(farNode, "id", UUID.randomUUID());
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #92 

## 📝작업 내용

> MapQueryFacade.java (line 53)에서 POI_ANCHOR_SNAP_RADIUS_PX를 120.0 -> 150.0으로 바꿨고, MapQueryFacadeTest.java (line 220)의 “반경 밖이면 실패” 테스트도 새 기준에 맞춰 121px -> 151px로 조정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * POI 앵커 노드 감지 범위를 확대하여 더 먼 거리에서의 인식 정확도를 향상시켰습니다.

* **테스트**
  * 거리 임계값 동작을 검증하기 위한 테스트 케이스를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->