### PR TITLE
[fix] 캠퍼스 출입구 로직 수정(#95)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -4,8 +4,10 @@ import com.insideout.backend.domain.building.entity.Floor;
 import com.insideout.backend.domain.building.entity.Building;
 import com.insideout.backend.domain.building.entity.Campus;
 import com.insideout.backend.domain.building.entity.BuildingDirectory;
+import com.insideout.backend.domain.building.entity.BuildingEntranceMapping;
 import com.insideout.backend.domain.building.repository.BuildingRepository;
 import com.insideout.backend.domain.building.repository.BuildingDirectoryRepository;
+import com.insideout.backend.domain.building.repository.BuildingEntranceMappingRepository;
 import com.insideout.backend.domain.building.repository.FloorRepository;
 import com.insideout.backend.domain.map.entity.Edge;
 import com.insideout.backend.domain.map.entity.MapVersion;
@@ -58,6 +60,7 @@ public class MapQueryFacade {
     private final NodeRepository nodeRepository;
     private final BuildingDirectoryRepository buildingDirectoryRepository;
     private final BuildingRepository buildingRepository;
+    private final BuildingEntranceMappingRepository buildingEntranceMappingRepository;
     private final FloorRepository floorRepository;
     private final PoiRepository poiRepository;
     private final EdgeRepository edgeRepository;
@@ -71,6 +74,22 @@ public class MapQueryFacade {
             double destinationX,
             double destinationY
     ) {
+        return findIndoorDestinationAnchor(
+                destinationBuildingId,
+                destinationX,
+                destinationY,
+                destinationX,
+                destinationY
+        );
+    }
+
+    public Optional<IndoorDestinationAnchor> findIndoorDestinationAnchor(
+            UUID destinationBuildingId,
+            double destinationX,
+            double destinationY,
+            double outdoorReferenceX,
+            double outdoorReferenceY
+    ) {
         Optional<BuildingDirectory> building = destinationBuildingId != null
                 ? buildingDirectoryRepository.findByIdAndIsPublicTrue(destinationBuildingId)
                 : buildingDirectoryRepository.findNearestPublicBuilding(
@@ -79,9 +98,10 @@ public class MapQueryFacade {
                         REGISTERED_BUILDING_SEARCH_RADIUS_METERS
                 );
 
-        return building.flatMap(directory -> nodeRepository
-                .findNearestEntranceByBuildingId(directory.getId(), destinationX, destinationY)
-                .flatMap(node -> toIndoorDestinationAnchor(directory, node)));
+        return building.flatMap(directory -> findMappedEntranceAnchor(directory, outdoorReferenceX, outdoorReferenceY)
+                .or(() -> nodeRepository
+                        .findNearestEntranceByBuildingId(directory.getId(), destinationX, destinationY)
+                        .flatMap(node -> toIndoorDestinationAnchor(directory, node))));
     }
 
     public Optional<IndoorPoiDestination> findIndoorPoiDestination(Long destinationPoiId) {
@@ -331,6 +351,120 @@ public class MapQueryFacade {
         return value == null ? 0.0 : value.doubleValue();
     }
 
+    private Optional<IndoorDestinationAnchor> findMappedEntranceAnchor(
+            BuildingDirectory directory,
+            double outdoorReferenceX,
+            double outdoorReferenceY
+    ) {
+        if (directory.getPublishedVersion() == null) {
+            return Optional.empty();
+        }
+
+        Optional<Building> buildingEntity = buildingRepository.findById(directory.getId());
+        Campus campus = buildingEntity.map(Building::getCampus).orElse(null);
+        if (campus == null) {
+            return Optional.empty();
+        }
+
+        Map<String, CampusGate> gatesById = extractCampusGates(campus).stream()
+                .collect(Collectors.toMap(CampusGate::id, gate -> gate, (first, ignored) -> first));
+        if (gatesById.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<BuildingEntranceMapping> mappings = buildingEntranceMappingRepository
+                .findAllByTenantIdAndBuildingIdAndMapVersionIdOrderByCreatedAtAsc(
+                        directory.getTenant().getId(),
+                        directory.getId(),
+                        directory.getPublishedVersion().getId()
+                );
+
+        return mappings.stream()
+                .map(mapping -> {
+                    CampusGate gate = gatesById.get(mapping.getCampusGateId());
+                    if (gate == null) {
+                        return null;
+                    }
+                    return new MappedEntranceCandidate(
+                            mapping,
+                            gate,
+                            geographicDistanceSquared(outdoorReferenceX, outdoorReferenceY, gate.x(), gate.y())
+                    );
+                })
+                .filter(Objects::nonNull)
+                .min(Comparator.comparingDouble(MappedEntranceCandidate::distance))
+                .flatMap(candidate -> nodeRepository.findById(candidate.mapping().getEntranceNodeId())
+                        .flatMap(node -> toIndoorDestinationAnchor(directory, node, campus, candidate.gate())));
+    }
+
+    private boolean hasPublishedCampusMap(Campus campus) {
+        return campus != null && mapVersionRepository
+                .findFirstByCampusIdAndMapTypeAndStatusOrderByCreatedAtDesc(
+                        campus.getId(),
+                        MapType.CAMPUS,
+                        "published"
+                )
+                .isPresent();
+    }
+
+    private List<CampusGate> extractCampusGates(Campus campus) {
+        Object gatesValue = campus.getMeta() == null ? null : campus.getMeta().get("gates");
+        if (!(gatesValue instanceof List<?> gates)) {
+            return List.of();
+        }
+
+        return gates.stream()
+                .map(this::toCampusGate)
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<CampusGate> toCampusGate(Object value) {
+        if (!(value instanceof Map<?, ?> gate)) {
+            return Optional.empty();
+        }
+
+        Object locationValue = gate.get("location");
+        if (!(locationValue instanceof Map<?, ?> location)) {
+            return Optional.empty();
+        }
+
+        String id = asString(gate.get("id"));
+        String name = asString(gate.get("name"));
+        Double x = asDouble(location.get("longitude"));
+        Double y = asDouble(location.get("latitude"));
+        if (id == null || id.isBlank() || x == null || y == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new CampusGate(id, name, x, y));
+    }
+
+    private String asString(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private Double asDouble(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            try {
+                return Double.parseDouble(text);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private double geographicDistanceSquared(double firstX, double firstY, double secondX, double secondY) {
+        double dx = firstX - secondX;
+        double dy = firstY - secondY;
+        return dx * dx + dy * dy;
+    }
+
     private Optional<IndoorDestinationAnchor> toIndoorDestinationAnchor(BuildingDirectory building, Node node) {
         Point point = node.getGeomWgs84();
         if (point == null) {
@@ -339,13 +473,7 @@ public class MapQueryFacade {
 
         Optional<Building> buildingEntity = buildingRepository.findById(building.getId());
         Campus campus = buildingEntity.map(Building::getCampus).orElse(null);
-        boolean hasPublishedCampusMap = campus != null && mapVersionRepository
-                .findFirstByCampusIdAndMapTypeAndStatusOrderByCreatedAtDesc(
-                        campus.getId(),
-                        MapType.CAMPUS,
-                        "published"
-                )
-                .isPresent();
+        boolean hasPublishedCampusMap = hasPublishedCampusMap(campus);
         Point campusEntrance = campus == null ? null : campus.getPrimaryEntrance();
 
         return Optional.of(IndoorDestinationAnchor.builder()
@@ -361,6 +489,36 @@ public class MapQueryFacade {
                 .x(point.getX())
                 .y(point.getY())
                 .build());
+    }
+
+    private Optional<IndoorDestinationAnchor> toIndoorDestinationAnchor(
+            BuildingDirectory building,
+            Node node,
+            Campus campus,
+            CampusGate gate
+    ) {
+        Point point = node.getGeomWgs84();
+        if (point == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(IndoorDestinationAnchor.builder()
+                .campusId(hasPublishedCampusMap(campus) ? campus.getId() : null)
+                .campusName(hasPublishedCampusMap(campus) ? campus.getName() : null)
+                .campusEntranceName(gate.name())
+                .campusEntranceX(gate.x())
+                .campusEntranceY(gate.y())
+                .buildingId(building.getId())
+                .buildingName(building.getName())
+                .entranceNodeId(node.getId())
+                .entranceName(defaultText(node.getNameKo(), gate.name()))
+                .x(point.getX())
+                .y(point.getY())
+                .build());
+    }
+
+    private String defaultText(String value, String defaultValue) {
+        return value == null || value.isBlank() ? defaultValue : value;
     }
 
     private Optional<IndoorPoiDestination> toIndoorPoiDestination(Poi poi) {
@@ -447,19 +605,23 @@ public class MapQueryFacade {
             return campusId != null && campusEntranceX != null && campusEntranceY != null;
         }
 
+        public boolean hasOutdoorGate() {
+            return campusEntranceX != null && campusEntranceY != null;
+        }
+
         public double outdoorTargetX() {
-            return hasCampus() ? campusEntranceX : x;
+            return hasOutdoorGate() ? campusEntranceX : x;
         }
 
         public double outdoorTargetY() {
-            return hasCampus() ? campusEntranceY : y;
+            return hasOutdoorGate() ? campusEntranceY : y;
         }
 
         public String outdoorTargetName() {
-            if (hasCampus() && campusEntranceName != null && !campusEntranceName.isBlank()) {
+            if (hasOutdoorGate() && campusEntranceName != null && !campusEntranceName.isBlank()) {
                 return campusEntranceName;
             }
-            if (hasCampus()) {
+            if (hasOutdoorGate() && campusName != null && !campusName.isBlank()) {
                 return campusName;
             }
             if (entranceName != null && !entranceName.isBlank()) {
@@ -491,6 +653,21 @@ public class MapQueryFacade {
             UUID floorId,
             String floorName,
             String mapImageUrl
+    ) {
+    }
+
+    private record CampusGate(
+            String id,
+            String name,
+            double x,
+            double y
+    ) {
+    }
+
+    private record MappedEntranceCandidate(
+            BuildingEntranceMapping mapping,
+            CampusGate gate,
+            double distance
     ) {
     }
 

--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -388,7 +388,7 @@ public class MapQueryFacade {
                     return new MappedEntranceCandidate(
                             mapping,
                             gate,
-                            geographicDistanceSquared(outdoorReferenceX, outdoorReferenceY, gate.x(), gate.y())
+                            geographicDistanceMeters(outdoorReferenceX, outdoorReferenceY, gate.x(), gate.y())
                     );
                 })
                 .filter(Objects::nonNull)
@@ -459,10 +459,16 @@ public class MapQueryFacade {
         return null;
     }
 
-    private double geographicDistanceSquared(double firstX, double firstY, double secondX, double secondY) {
-        double dx = firstX - secondX;
-        double dy = firstY - secondY;
-        return dx * dx + dy * dy;
+    private double geographicDistanceMeters(double firstX, double firstY, double secondX, double secondY) {
+        double lat1 = Math.toRadians(firstY);
+        double lat2 = Math.toRadians(secondY);
+        double dLat = Math.toRadians(secondY - firstY);
+        double dLon = Math.toRadians(secondX - firstX);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return 6_371_000.0 * c;
     }
 
     private Optional<IndoorDestinationAnchor> toIndoorDestinationAnchor(BuildingDirectory building, Node node) {

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -233,6 +233,8 @@ public class NavigationService {
             Optional<IndoorDestinationAnchor> exitAnchor = mapQueryFacade.findIndoorDestinationAnchor(
                     source.get().buildingId(),
                     request.endX(),
+                    request.endY(),
+                    request.endX(),
                     request.endY()
             );
 
@@ -255,7 +257,9 @@ public class NavigationService {
         Optional<IndoorDestinationAnchor> anchor = mapQueryFacade.findIndoorDestinationAnchor(
                 destination.get().buildingId(),
                 request.endX(),
-                request.endY()
+                request.endY(),
+                request.startX(),
+                request.startY()
         );
 
         return anchor
@@ -394,7 +398,7 @@ public class NavigationService {
         for (JsonNode itinerary : itineraries) {
             Integer totalTimeSeconds = getNullableInt(itinerary.path("totalTime"));
             Integer totalDistanceMeters = getNullableInt(itinerary.path("totalDistance"));
-            List<LegDto> legs = parseTransitLegs(itinerary.path("legs"));
+            List<LegDto> legs = normalizeOutdoorBoundaryLegs(parseTransitLegs(itinerary.path("legs")), target);
             List<RouteFailureDto> failures = new ArrayList<>();
             applyHybridLegs(legs, failures, target, RouteMode.TRANSIT, RouteOption.TRANSIT_CANDIDATE);
 
@@ -593,7 +597,7 @@ public class NavigationService {
         Integer totalTimeSeconds = getNullableInt(summary.path("totalTime"));
         Integer totalDistanceMeters = getNullableInt(summary.path("totalDistance"));
         List<StepDto> steps = rewriteOutdoorArrivalSteps(parseFeatureSteps(features), target);
-        List<CoordinateDto> path = parseFeaturePath(features);
+        List<CoordinateDto> path = normalizeOutdoorBoundaryPath(parseFeaturePath(features), target);
         List<LegDto> legs = new ArrayList<>();
         List<RouteFailureDto> failures = new ArrayList<>();
         prependExitLegsIfNeeded(legs, failures, target, routeMode, routeOption);
@@ -674,22 +678,28 @@ public class NavigationService {
             if (!normalizeInstruction(step.instruction()).contains("도착")) {
                 continue;
             }
-            rewritten.set(index, new StepDto(
-                    buildingArrivalInstruction(target),
-                    step.distanceMeters(),
-                    step.durationSeconds(),
-                    step.x(),
-                    step.y(),
-                    step.turnType(),
-                    "BUILDING",
-                    step.streetName(),
-                    step.pathStartIndex(),
-                    step.pathEndIndex()
-            ));
+            rewritten.set(index, rewriteOutdoorBoundaryArrivalStep(step, target));
             return rewritten;
         }
 
+        int lastIndex = rewritten.size() - 1;
+        rewritten.set(lastIndex, rewriteOutdoorBoundaryArrivalStep(rewritten.get(lastIndex), target));
         return rewritten;
+    }
+
+    private StepDto rewriteOutdoorBoundaryArrivalStep(StepDto step, RouteTarget target) {
+        return new StepDto(
+                outdoorBoundaryArrivalInstruction(target),
+                step.distanceMeters(),
+                step.durationSeconds(),
+                target.endX(),
+                target.endY(),
+                step.turnType(),
+                "BUILDING",
+                target.endName(),
+                step.pathStartIndex(),
+                step.pathEndIndex()
+        );
     }
 
     private String indoorEntryInstruction(RouteTarget target) {
@@ -697,9 +707,28 @@ public class NavigationService {
         return (buildingName == null || buildingName.isBlank() ? "건물" : buildingName) + " 입구 진입";
     }
 
-    private String buildingArrivalInstruction(RouteTarget target) {
+    private String outdoorBoundaryArrivalInstruction(RouteTarget target) {
+        String entranceName = target.entranceName();
         String buildingName = target.buildingName();
-        return (buildingName == null || buildingName.isBlank() ? "건물" : buildingName) + " 도착";
+        if (entranceName != null && !entranceName.isBlank()) {
+            if (buildingName != null && !buildingName.isBlank() && !sameText(buildingName, entranceName)) {
+                return buildingName + " " + entranceName + " 도착";
+            }
+            return entranceName + " 도착";
+        }
+
+        String boundaryName = target.endName();
+        if (boundaryName == null || boundaryName.isBlank()) {
+            boundaryName = buildingName;
+        }
+        if (sameText(boundaryName, buildingName)) {
+            boundaryName = boundaryName + " 출입구";
+        }
+        return (boundaryName == null || boundaryName.isBlank() ? "출입구" : boundaryName) + " 도착";
+    }
+
+    private boolean sameText(String first, String second) {
+        return normalizeInstruction(first).equals(normalizeInstruction(second));
     }
 
     private String indoorExitInstruction(RouteTarget target) {
@@ -716,6 +745,99 @@ public class NavigationService {
         }
 
         return path;
+    }
+
+    private List<LegDto> normalizeOutdoorBoundaryLegs(List<LegDto> legs, RouteTarget target) {
+        if (legs.isEmpty() || !target.includesIndoor()) {
+            return legs;
+        }
+
+        List<LegDto> normalized = new ArrayList<>(legs);
+        if (target.startsIndoor()) {
+            int firstOutdoorLegIndex = firstOutdoorLegIndex(normalized);
+            if (firstOutdoorLegIndex >= 0) {
+                LegDto leg = normalized.get(firstOutdoorLegIndex);
+                normalized.set(firstOutdoorLegIndex, withPath(leg, normalizeOutdoorBoundaryPath(leg.path(), target)));
+            }
+            return normalized;
+        }
+
+        int lastOutdoorLegIndex = lastOutdoorLegIndex(normalized);
+        if (lastOutdoorLegIndex >= 0) {
+            LegDto leg = normalized.get(lastOutdoorLegIndex);
+            normalized.set(lastOutdoorLegIndex, withPath(leg, normalizeOutdoorBoundaryPath(leg.path(), target)));
+        }
+        return normalized;
+    }
+
+    private int firstOutdoorLegIndex(List<LegDto> legs) {
+        for (int index = 0; index < legs.size(); index++) {
+            if (isOutdoorLeg(legs.get(index))) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private int lastOutdoorLegIndex(List<LegDto> legs) {
+        for (int index = legs.size() - 1; index >= 0; index--) {
+            if (isOutdoorLeg(legs.get(index))) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private boolean isOutdoorLeg(LegDto leg) {
+        return leg != null && leg.coordinateType() == CoordinateType.WGS84;
+    }
+
+    private LegDto withPath(LegDto leg, List<CoordinateDto> path) {
+        return new LegDto(
+                leg.mode(),
+                leg.routeName(),
+                leg.transitType(),
+                leg.durationSeconds(),
+                leg.distanceMeters(),
+                leg.stationCount(),
+                leg.stops(),
+                leg.startName(),
+                leg.endName(),
+                leg.mapType(),
+                leg.mapImageUrl(),
+                leg.floorId(),
+                leg.floorName(),
+                leg.coordinateType(),
+                path,
+                leg.floorSegments(),
+                leg.steps()
+        );
+    }
+
+    private List<CoordinateDto> normalizeOutdoorBoundaryPath(List<CoordinateDto> path, RouteTarget target) {
+        if (!target.includesIndoor()) {
+            return path;
+        }
+
+        CoordinateDto boundary = target.startsIndoor()
+                ? new CoordinateDto(target.resolvedOutdoorStartX(), target.resolvedOutdoorStartY(), target.resolvedOutdoorStartName())
+                : new CoordinateDto(target.endX(), target.endY(), target.endName());
+        if (boundary.x() == null || boundary.y() == null) {
+            return path;
+        }
+
+        List<CoordinateDto> normalized = path == null ? new ArrayList<>() : new ArrayList<>(path);
+        if (normalized.isEmpty()) {
+            normalized.add(boundary);
+            return normalized;
+        }
+
+        if (target.startsIndoor()) {
+            normalized.set(0, boundary);
+        } else {
+            normalized.set(normalized.size() - 1, boundary);
+        }
+        return normalized;
     }
 
     private void appendGeometryCoordinates(List<CoordinateDto> path, JsonNode coordinates) {
@@ -2115,6 +2237,10 @@ public class NavigationService {
 
         private double resolvedOutdoorStartY() {
             return outdoorStartY == null ? endY : outdoorStartY;
+        }
+
+        private String resolvedOutdoorStartName() {
+            return outdoorStartName == null ? endName : outdoorStartName;
         }
     }
 }

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -668,7 +668,7 @@ public class NavigationService {
     }
 
     private List<StepDto> rewriteOutdoorArrivalSteps(List<StepDto> steps, RouteTarget target) {
-        if (!target.includesIndoor() || target.startsIndoor() || target.buildingName() == null || steps.isEmpty()) {
+        if (!target.includesIndoor() || target.startsIndoor() || steps.isEmpty()) {
             return steps;
         }
 

--- a/src/test/java/com/insideout/backend/domain/map/facade/MapQueryFacadeTest.java
+++ b/src/test/java/com/insideout/backend/domain/map/facade/MapQueryFacadeTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import com.insideout.backend.domain.building.entity.Building;
 import com.insideout.backend.domain.building.entity.Floor;
 import com.insideout.backend.domain.building.repository.BuildingDirectoryRepository;
+import com.insideout.backend.domain.building.repository.BuildingEntranceMappingRepository;
 import com.insideout.backend.domain.building.repository.BuildingRepository;
 import com.insideout.backend.domain.building.repository.FloorRepository;
 import com.insideout.backend.domain.map.entity.MapVersion;
@@ -48,6 +49,9 @@ class MapQueryFacadeTest {
     private BuildingRepository buildingRepository;
 
     @Mock
+    private BuildingEntranceMappingRepository buildingEntranceMappingRepository;
+
+    @Mock
     private FloorRepository floorRepository;
 
     @Mock
@@ -81,6 +85,7 @@ class MapQueryFacadeTest {
                 nodeRepository,
                 buildingDirectoryRepository,
                 buildingRepository,
+                buildingEntranceMappingRepository,
                 floorRepository,
                 poiRepository,
                 edgeRepository,

--- a/src/test/java/com/insideout/backend/domain/map/facade/MapQueryFacadeTest.java
+++ b/src/test/java/com/insideout/backend/domain/map/facade/MapQueryFacadeTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.insideout.backend.domain.building.entity.Building;
+import com.insideout.backend.domain.building.entity.BuildingDirectory;
+import com.insideout.backend.domain.building.entity.BuildingEntranceMapping;
+import com.insideout.backend.domain.building.entity.Campus;
 import com.insideout.backend.domain.building.entity.Floor;
 import com.insideout.backend.domain.building.repository.BuildingDirectoryRepository;
 import com.insideout.backend.domain.building.repository.BuildingEntranceMappingRepository;
@@ -21,7 +24,9 @@ import com.insideout.backend.domain.map.repository.PoiRepository;
 import com.insideout.backend.domain.map.repository.VerticalConnectorNodeRepository;
 import com.insideout.backend.domain.map.storage.MapAssetDescriptor;
 import com.insideout.backend.domain.map.storage.MapAssetStorage;
+import com.insideout.backend.domain.tenant.entity.Tenant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
@@ -231,5 +236,116 @@ class MapQueryFacadeTest {
                 .thenReturn(Optional.of(farNode));
 
         assertThat(mapQueryFacade.findIndoorPoiDestination(publicId)).isEmpty();
+    }
+
+    @Test
+    void findIndoorDestinationAnchorChoosesMappedGateByMeterDistance() {
+        UUID tenantId = UUID.randomUUID();
+        UUID campusId = UUID.randomUUID();
+        UUID buildingId = UUID.randomUUID();
+        UUID mapVersionId = UUID.randomUUID();
+        UUID eastNodeId = UUID.randomUUID();
+        UUID northNodeId = UUID.randomUUID();
+
+        Tenant tenant = Tenant.builder()
+                .slug("tenant")
+                .displayName("Tenant")
+                .build();
+        ReflectionTestUtils.setField(tenant, "id", tenantId);
+
+        Campus campus = Campus.builder()
+                .tenant(tenant)
+                .name("테스트 캠퍼스")
+                .meta(Map.of("gates", List.of(
+                        Map.of(
+                                "id", "east",
+                                "name", "동문",
+                                "location", Map.of("longitude", 127.0020, "latitude", 60.0000)
+                        ),
+                        Map.of(
+                                "id", "north",
+                                "name", "북문",
+                                "location", Map.of("longitude", 127.0000, "latitude", 60.0011)
+                        )
+                )))
+                .build();
+        ReflectionTestUtils.setField(campus, "id", campusId);
+
+        Building building = Building.builder()
+                .tenant(tenant)
+                .campus(campus)
+                .name("테스트 건물")
+                .build();
+        ReflectionTestUtils.setField(building, "id", buildingId);
+
+        MapVersion publishedVersion = MapVersion.builder()
+                .tenantId(tenantId)
+                .mapType(MapType.BUILDING)
+                .building(building)
+                .status("published")
+                .label("published")
+                .build();
+        ReflectionTestUtils.setField(publishedVersion, "id", mapVersionId);
+
+        BuildingDirectory directory = BuildingDirectory.builder()
+                .id(buildingId)
+                .tenant(tenant)
+                .campus(campus)
+                .name("테스트 건물")
+                .isPublic(true)
+                .publishedVersion(publishedVersion)
+                .build();
+
+        BuildingEntranceMapping eastMapping = BuildingEntranceMapping.builder()
+                .tenantId(tenantId)
+                .campusId(campusId)
+                .buildingId(buildingId)
+                .mapVersion(publishedVersion)
+                .campusGateId("east")
+                .entranceNodeId(eastNodeId)
+                .build();
+        BuildingEntranceMapping northMapping = BuildingEntranceMapping.builder()
+                .tenantId(tenantId)
+                .campusId(campusId)
+                .buildingId(buildingId)
+                .mapVersion(publishedVersion)
+                .campusGateId("north")
+                .entranceNodeId(northNodeId)
+                .build();
+
+        Node eastNode = Node.builder()
+                .tenantId(tenantId)
+                .mapVersion(publishedVersion)
+                .kindCode("entrance")
+                .nameKo("동문 출입구")
+                .geomPx(geometryFactory.createPoint(new Coordinate(0, 0)))
+                .geomWgs84(geometryFactory.createPoint(new Coordinate(127.0020, 60.0000)))
+                .build();
+        ReflectionTestUtils.setField(eastNode, "id", eastNodeId);
+        Node northNode = Node.builder()
+                .tenantId(tenantId)
+                .mapVersion(publishedVersion)
+                .kindCode("entrance")
+                .nameKo("북문 출입구")
+                .geomPx(geometryFactory.createPoint(new Coordinate(0, 0)))
+                .geomWgs84(geometryFactory.createPoint(new Coordinate(127.0000, 60.0011)))
+                .build();
+        ReflectionTestUtils.setField(northNode, "id", northNodeId);
+
+        when(buildingDirectoryRepository.findByIdAndIsPublicTrue(buildingId)).thenReturn(Optional.of(directory));
+        when(buildingRepository.findById(buildingId)).thenReturn(Optional.of(building));
+        when(buildingEntranceMappingRepository.findAllByTenantIdAndBuildingIdAndMapVersionIdOrderByCreatedAtAsc(
+                tenantId,
+                buildingId,
+                mapVersionId
+        )).thenReturn(List.of(eastMapping, northMapping));
+        when(nodeRepository.findById(eastNodeId)).thenReturn(Optional.of(eastNode));
+
+        MapQueryFacade.IndoorDestinationAnchor anchor = mapQueryFacade
+                .findIndoorDestinationAnchor(buildingId, 127.0000, 60.0000)
+                .orElseThrow();
+
+        assertThat(anchor.entranceNodeId()).isEqualTo(eastNodeId);
+        assertThat(anchor.campusEntranceName()).isEqualTo("동문");
     }
 }

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -272,7 +272,7 @@ class NavigationServiceTest {
                         "1F",
                         buildingId
                 )));
-        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000))
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000, 127.1000, 37.5000))
                 .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
         when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
                 .thenReturn(Optional.of(RoutingGraph.builder()
@@ -334,6 +334,12 @@ class NavigationServiceTest {
                 .extracting(StepDto::instruction)
                 .contains("테스트 건물 출구로 나가기")
                 .doesNotContain("테스트 건물 도착");
+        LegDto outdoorLeg = response.routes().get(0).legs().stream()
+                .filter(leg -> leg.mode() == LegMode.WALK)
+                .findFirst()
+                .orElseThrow();
+        assertThat(outdoorLeg.path().get(0).x()).isEqualTo(127.2000);
+        assertThat(outdoorLeg.path().get(0).y()).isEqualTo(37.6000);
         assertThat(response.indoor().floorplans())
                 .extracting(NavigationResponseDto.FloorplanDto::floorName)
                 .containsExactly("1F", "2F");
@@ -388,7 +394,7 @@ class NavigationServiceTest {
                         "1F",
                         buildingId
                 )));
-        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000))
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000, 126.9000, 37.4000))
                 .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
         when(restTemplate.postForObject(
                 eq("https://apis.openapi.sk.com/transit/routes"),
@@ -478,7 +484,7 @@ class NavigationServiceTest {
                         "2F",
                         buildingId
                 )));
-        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000))
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000, 126.9000, 37.4000))
                 .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
         when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
                 .thenReturn(Optional.of(RoutingGraph.builder()
@@ -571,7 +577,7 @@ class NavigationServiceTest {
                         "1F",
                         buildingId
                 )));
-        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000))
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000, 126.9000, 37.4000))
                 .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
         when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
                 .thenReturn(Optional.of(RoutingGraph.builder()
@@ -630,6 +636,74 @@ class NavigationServiceTest {
         StepDto arrivalStep = indoorLeg.floorSegments().get(0).steps().get(3);
         assertThat(arrivalStep.pathStartIndex()).isEqualTo(2);
         assertThat(arrivalStep.pathEndIndex()).isEqualTo(2);
+    }
+
+    @Test
+    void outdoorToIndoorOutdoorLegEndsAtSelectedEntrance() throws Exception {
+        UUID buildingId = UUID.randomUUID();
+        UUID mapVersionId = UUID.randomUUID();
+        UUID entranceNodeId = UUID.randomUUID();
+        UUID destinationNodeId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Long destinationPoiId = 1001L;
+
+        when(mapQueryFacade.findIndoorPoiDestination(null)).thenReturn(Optional.empty());
+        when(mapQueryFacade.findIndoorPoiDestination(destinationPoiId))
+                .thenReturn(Optional.of(indoorPoiDestination(
+                        destinationPoiId,
+                        destinationNodeId,
+                        floorId,
+                        "1F",
+                        buildingId
+                )));
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000, 126.9000, 37.4000))
+                .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
+        when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
+                .thenReturn(Optional.of(RoutingGraph.builder()
+                        .mapVersionId(mapVersionId)
+                        .mapType(MapType.BUILDING)
+                        .mapImageUrl("https://signed.example/fallback.png")
+                        .nodes(List.of(
+                                routingNode(entranceNodeId, "entrance", "정문", floorId, "1F", 10, 10),
+                                routingNode(destinationNodeId, "poi", "목적지 POI", floorId, "1F", 20, 20)
+                        ))
+                        .edges(List.of(routingEdge(entranceNodeId, destinationNodeId)))
+                        .verticalLinks(List.of())
+                        .obstacles(List.of())
+                        .build()));
+        when(mapQueryFacade.findCurrentFloorplanImageUrl(floorId))
+                .thenReturn(Optional.of("https://signed.example/1f.png"));
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(walkRouteResponse());
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발지",
+                "목적지",
+                buildingId,
+                destinationPoiId,
+                true,
+                List.of(RouteType.WALK)
+        ));
+
+        LegDto outdoorLeg = response.routes().get(0).legs().stream()
+                .filter(leg -> leg.mode() == LegMode.WALK)
+                .findFirst()
+                .orElseThrow();
+        NavigationResponseDto.CoordinateDto lastOutdoorPoint = outdoorLeg.path().get(outdoorLeg.path().size() - 1);
+
+        assertThat(lastOutdoorPoint.x()).isEqualTo(127.2000);
+        assertThat(lastOutdoorPoint.y()).isEqualTo(37.6000);
+        assertThat(outdoorLeg.steps().get(outdoorLeg.steps().size() - 1).instruction()).isEqualTo("테스트 건물 정문 도착");
+        assertThat(outdoorLeg.steps().get(outdoorLeg.steps().size() - 1).mode()).isEqualTo("BUILDING");
+        assertThat(outdoorLeg.steps().get(outdoorLeg.steps().size() - 1).x()).isEqualTo(127.2000);
+        assertThat(outdoorLeg.steps().get(outdoorLeg.steps().size() - 1).y()).isEqualTo(37.6000);
     }
 
     private JsonNode walkRouteResponse() throws Exception {

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -706,6 +706,80 @@ class NavigationServiceTest {
         assertThat(outdoorLeg.steps().get(outdoorLeg.steps().size() - 1).y()).isEqualTo(37.6000);
     }
 
+    @Test
+    void outdoorToIndoorRewritesOutdoorArrivalStepWhenBuildingNameIsMissing() throws Exception {
+        UUID buildingId = UUID.randomUUID();
+        UUID mapVersionId = UUID.randomUUID();
+        UUID entranceNodeId = UUID.randomUUID();
+        UUID destinationNodeId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Long destinationPoiId = 1001L;
+
+        when(mapQueryFacade.findIndoorPoiDestination(null)).thenReturn(Optional.empty());
+        when(mapQueryFacade.findIndoorPoiDestination(destinationPoiId))
+                .thenReturn(Optional.of(IndoorPoiDestination.builder()
+                        .publicId(destinationPoiId)
+                        .poiId(UUID.randomUUID())
+                        .name("목적지 POI")
+                        .anchorNodeId(destinationNodeId)
+                        .floorId(floorId)
+                        .floorName("1F")
+                        .buildingId(buildingId)
+                        .build()));
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000, 126.9000, 37.4000))
+                .thenReturn(Optional.of(IndoorDestinationAnchor.builder()
+                        .buildingId(buildingId)
+                        .entranceNodeId(entranceNodeId)
+                        .entranceName("정문")
+                        .x(127.2000)
+                        .y(37.6000)
+                        .build()));
+        when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
+                .thenReturn(Optional.of(RoutingGraph.builder()
+                        .mapVersionId(mapVersionId)
+                        .mapType(MapType.BUILDING)
+                        .mapImageUrl("https://signed.example/fallback.png")
+                        .nodes(List.of(
+                                routingNode(entranceNodeId, "entrance", "정문", floorId, "1F", 10, 10),
+                                routingNode(destinationNodeId, "poi", "목적지 POI", floorId, "1F", 20, 20)
+                        ))
+                        .edges(List.of(routingEdge(entranceNodeId, destinationNodeId)))
+                        .verticalLinks(List.of())
+                        .obstacles(List.of())
+                        .build()));
+        when(mapQueryFacade.findCurrentFloorplanImageUrl(floorId))
+                .thenReturn(Optional.of("https://signed.example/1f.png"));
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(walkRouteResponse());
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발지",
+                "목적지",
+                buildingId,
+                destinationPoiId,
+                true,
+                List.of(RouteType.WALK)
+        ));
+
+        LegDto outdoorLeg = response.routes().get(0).legs().stream()
+                .filter(leg -> leg.mode() == LegMode.WALK)
+                .findFirst()
+                .orElseThrow();
+        StepDto arrivalStep = outdoorLeg.steps().get(outdoorLeg.steps().size() - 1);
+
+        assertThat(arrivalStep.instruction()).isEqualTo("정문 도착");
+        assertThat(arrivalStep.mode()).isEqualTo("BUILDING");
+        assertThat(arrivalStep.x()).isEqualTo(127.2000);
+        assertThat(arrivalStep.y()).isEqualTo(37.6000);
+    }
+
     private JsonNode walkRouteResponse() throws Exception {
         return OBJECT_MAPPER.readTree("""
                 {


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #95 

## 📝작업 내용

> 실외 마지막 좌표가 건물 출입구로 매핑되지 않는 문제를 해결했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 건물 출입구 매핑을 통한 실내 목적지 앵커 선택 개선
  * 캠퍼스 게이트 정보 기반의 더 정확한 입구 결정

* **개선사항**
  * 실내/실외 경계에서의 경로 정규화 강화
  * 실외 도착 안내 메시지 개선 및 입구/건물명 기반의 명확한 도착 안내

<!-- end of auto-generated comment: release notes by coderabbit.ai -->