### PR TITLE
[feat] 실내->실내 길찾기 구현(#97)

### DIFF
--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -805,9 +805,9 @@ public class NavigationService {
     }
 
     private String indoorExitInstruction(RouteTarget target) {
-        String buildingName = target.buildingName();
-        String safeBuildingName = buildingName == null || buildingName.isBlank() ? "건물" : buildingName;
-        return safeBuildingName + " 출구로 나가기";
+        String entranceName = target.entranceName();
+        String safeEntranceName = entranceName == null || entranceName.isBlank() ? "출입구" : entranceName;
+        return safeEntranceName + "으로 나가기";
     }
 
     private List<CoordinateDto> parseFeaturePath(JsonNode features) {
@@ -830,7 +830,7 @@ public class NavigationService {
             int firstOutdoorLegIndex = firstOutdoorLegIndex(normalized);
             if (firstOutdoorLegIndex >= 0) {
                 LegDto leg = normalized.get(firstOutdoorLegIndex);
-                normalized.set(firstOutdoorLegIndex, withPath(leg, normalizeOutdoorBoundaryPath(leg.path(), target)));
+                normalized.set(firstOutdoorLegIndex, withOutdoorBoundaryLeg(leg, target));
             }
             return normalized;
         }
@@ -838,7 +838,7 @@ public class NavigationService {
         int lastOutdoorLegIndex = lastOutdoorLegIndex(normalized);
         if (lastOutdoorLegIndex >= 0) {
             LegDto leg = normalized.get(lastOutdoorLegIndex);
-            normalized.set(lastOutdoorLegIndex, withPath(leg, normalizeOutdoorBoundaryPath(leg.path(), target)));
+            normalized.set(lastOutdoorLegIndex, withOutdoorBoundaryLeg(leg, target));
         }
         return normalized;
     }
@@ -865,7 +865,11 @@ public class NavigationService {
         return leg != null && leg.coordinateType() == CoordinateType.WGS84;
     }
 
-    private LegDto withPath(LegDto leg, List<CoordinateDto> path) {
+    private LegDto withOutdoorBoundaryLeg(LegDto leg, RouteTarget target) {
+        CoordinateDto boundary = outdoorBoundaryCoordinate(target);
+        List<CoordinateDto> path = normalizeOutdoorBoundaryPath(leg.path(), boundary, target.startsIndoor());
+        String boundaryName = outdoorBoundaryName(boundary);
+
         return new LegDto(
                 leg.mode(),
                 leg.routeName(),
@@ -874,8 +878,8 @@ public class NavigationService {
                 leg.distanceMeters(),
                 leg.stationCount(),
                 leg.stops(),
-                leg.startName(),
-                leg.endName(),
+                target.startsIndoor() ? boundaryName : leg.startName(),
+                target.startsIndoor() ? leg.endName() : boundaryName,
                 leg.mapType(),
                 leg.mapImageUrl(),
                 leg.floorId(),
@@ -883,8 +887,54 @@ public class NavigationService {
                 leg.coordinateType(),
                 path,
                 leg.floorSegments(),
-                leg.steps()
+                normalizeOutdoorBoundarySteps(leg.steps(), target, boundary)
         );
+    }
+
+    private List<StepDto> normalizeOutdoorBoundarySteps(List<StepDto> steps, RouteTarget target, CoordinateDto boundary) {
+        if (steps == null || steps.isEmpty()) {
+            return steps;
+        }
+
+        return target.startsIndoor()
+                ? rewriteOutdoorDepartureSteps(steps, boundary)
+                : rewriteOutdoorArrivalSteps(steps, target);
+    }
+
+    private List<StepDto> rewriteOutdoorDepartureSteps(List<StepDto> steps, CoordinateDto boundary) {
+        List<StepDto> rewritten = new ArrayList<>(steps);
+        rewritten.set(0, rewriteOutdoorBoundaryDepartureStep(rewritten.get(0), boundary));
+        return rewritten;
+    }
+
+    private StepDto rewriteOutdoorBoundaryDepartureStep(StepDto step, CoordinateDto boundary) {
+        return new StepDto(
+                outdoorBoundaryDepartureInstruction(boundary),
+                step.distanceMeters(),
+                step.durationSeconds(),
+                boundary.x(),
+                boundary.y(),
+                step.turnType(),
+                step.mode(),
+                outdoorBoundaryName(boundary),
+                step.pathStartIndex(),
+                step.pathEndIndex()
+        );
+    }
+
+    private String outdoorBoundaryDepartureInstruction(CoordinateDto boundary) {
+        return outdoorBoundaryName(boundary) + "에서 출발";
+    }
+
+    private CoordinateDto outdoorBoundaryCoordinate(RouteTarget target) {
+        return target.startsIndoor()
+                ? new CoordinateDto(target.resolvedOutdoorStartX(), target.resolvedOutdoorStartY(), target.resolvedOutdoorStartName())
+                : new CoordinateDto(target.endX(), target.endY(), target.endName());
+    }
+
+    private String outdoorBoundaryName(CoordinateDto boundary) {
+        String boundaryName = boundary.name();
+        return boundaryName == null || boundaryName.isBlank() ? "출입구" : boundaryName;
     }
 
     private List<CoordinateDto> normalizeOutdoorBoundaryPath(List<CoordinateDto> path, RouteTarget target) {
@@ -892,9 +942,10 @@ public class NavigationService {
             return path;
         }
 
-        CoordinateDto boundary = target.startsIndoor()
-                ? new CoordinateDto(target.resolvedOutdoorStartX(), target.resolvedOutdoorStartY(), target.resolvedOutdoorStartName())
-                : new CoordinateDto(target.endX(), target.endY(), target.endName());
+        return normalizeOutdoorBoundaryPath(path, outdoorBoundaryCoordinate(target), target.startsIndoor());
+    }
+
+    private List<CoordinateDto> normalizeOutdoorBoundaryPath(List<CoordinateDto> path, CoordinateDto boundary, boolean replaceStart) {
         if (boundary.x() == null || boundary.y() == null) {
             return path;
         }
@@ -905,7 +956,7 @@ public class NavigationService {
             return normalized;
         }
 
-        if (target.startsIndoor()) {
+        if (replaceStart) {
             normalized.set(0, boundary);
         } else {
             normalized.set(normalized.size() - 1, boundary);

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -302,14 +302,21 @@ public class NavigationService {
             createIndoorOnlyRouteDto(target, RouteOption.SHORTEST, failures).ifPresent(routes::add);
             createIndoorOnlyRouteDto(target, RouteOption.COMFORTABLE, failures).ifPresent(routes::add);
         } else {
-            createIndoorOnlyRouteDto(target, RouteOption.SHORTEST, failures).ifPresent(routes::add);
+            routeTypes.stream()
+                    .map(this::toRouteMode)
+                    .forEach(routeMode -> failures.add(routeFailure(NavigationErrorCode.ROUTE_NOT_FOUND, routeMode, null, null, null)));
         }
 
         if (routes.isEmpty() && failures.isEmpty()) {
             failures.add(routeFailure(NavigationErrorCode.INDOOR_ROUTE_NOT_FOUND, RouteMode.WALK, RouteOption.SHORTEST, LegMode.INDOOR, MapType.BUILDING));
         }
 
-        List<RouteMode> notFoundRouteTypes = routes.isEmpty() ? List.of(RouteMode.WALK) : List.of();
+        List<RouteMode> notFoundRouteTypes = routes.isEmpty()
+                ? failures.stream()
+                .map(RouteFailureDto::routeMode)
+                .distinct()
+                .toList()
+                : List.of();
         return new NavigationResponseDto(
                 new CoordinateDto(request.endX(), request.endY(), request.endName()),
                 new CoordinateDto(request.endX(), request.endY(), target.destination().name()),
@@ -319,6 +326,14 @@ public class NavigationService {
                 failures,
                 resolveRouteMessage(routes, notFoundRouteTypes, failures)
         );
+    }
+
+    private RouteMode toRouteMode(RouteType routeType) {
+        return switch (routeType) {
+            case TRANSIT -> RouteMode.TRANSIT;
+            case CAR -> RouteMode.CAR;
+            case WALK -> RouteMode.WALK;
+        };
     }
 
     private Optional<RouteDto> createIndoorOnlyRouteDto(
@@ -807,7 +822,16 @@ public class NavigationService {
     private String indoorExitInstruction(RouteTarget target) {
         String entranceName = target.entranceName();
         String safeEntranceName = entranceName == null || entranceName.isBlank() ? "출입구" : entranceName;
-        return safeEntranceName + "으로 나가기";
+        return safeEntranceName + koreanDirectionalParticle(safeEntranceName) + " 나가기";
+    }
+
+    private String koreanDirectionalParticle(String value) {
+        char lastChar = value.charAt(value.length() - 1);
+        if (lastChar < 0xAC00 || lastChar > 0xD7A3) {
+            return "으로";
+        }
+
+        return (lastChar - 0xAC00) % 28 == 0 ? "로" : "으로";
     }
 
     private List<CoordinateDto> parseFeaturePath(JsonNode features) {

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -229,7 +229,7 @@ public class NavigationService {
 
     private RouteTarget resolveRouteTarget(NavigationRequestDto request) {
         if (Boolean.FALSE.equals(request.includeIndoor())) {
-            return RouteTarget.outdoorOnly(request.endX(), request.endY(), request.endName());
+            return outdoorOnlyTarget(request);
         }
 
         Optional<IndoorPoiDestination> source = mapQueryFacade.findIndoorPoiDestination(request.startPoiId());
@@ -247,28 +247,29 @@ public class NavigationService {
                 );
             }
 
+            OutdoorDestination outdoorDestination = resolveOutdoorDestination(request, destination.isEmpty());
             Optional<IndoorDestinationAnchor> exitAnchor = mapQueryFacade.findIndoorDestinationAnchor(
                     source.get().buildingId(),
-                    request.endX(),
-                    request.endY(),
-                    request.endX(),
-                    request.endY()
+                    outdoorDestination.x(),
+                    outdoorDestination.y(),
+                    outdoorDestination.x(),
+                    outdoorDestination.y()
             );
 
             return exitAnchor
                     .map(value -> RouteTarget.fromIndoorToOutdoor(
                             value,
                             source.get(),
-                            request.endX(),
-                            request.endY(),
-                            request.endName()
+                            outdoorDestination.x(),
+                            outdoorDestination.y(),
+                            outdoorDestination.name()
                     ))
-                    .orElseGet(() -> RouteTarget.outdoorOnly(request.endX(), request.endY(), request.endName()));
+                    .orElseGet(() -> RouteTarget.outdoorOnly(outdoorDestination.x(), outdoorDestination.y(), outdoorDestination.name()));
         }
 
         Optional<IndoorPoiDestination> destination = mapQueryFacade.findIndoorPoiDestination(request.destinationPoiId());
         if (destination.isEmpty()) {
-            return RouteTarget.outdoorOnly(request.endX(), request.endY(), request.endName());
+            return outdoorOnlyTarget(request);
         }
 
         Optional<IndoorDestinationAnchor> anchor = mapQueryFacade.findIndoorDestinationAnchor(
@@ -288,6 +289,43 @@ public class NavigationService {
                         request.endName()
                 ))
                 .orElseGet(() -> RouteTarget.outdoorOnly(request.endX(), request.endY(), request.endName()));
+    }
+
+    private RouteTarget outdoorOnlyTarget(NavigationRequestDto request) {
+        OutdoorDestination destination = resolveOutdoorDestination(request, true);
+        return RouteTarget.outdoorOnly(destination.x(), destination.y(), destination.name());
+    }
+
+    private OutdoorDestination resolveOutdoorDestination(NavigationRequestDto request, boolean useBuildingAnchor) {
+        if (!useBuildingAnchor) {
+            return originalOutdoorDestination(request);
+        }
+
+        return findBuildingDestinationAnchor(request)
+                .map(this::toOutdoorDestination)
+                .orElseGet(() -> originalOutdoorDestination(request));
+    }
+
+    private OutdoorDestination originalOutdoorDestination(NavigationRequestDto request) {
+        return new OutdoorDestination(request.endX(), request.endY(), request.endName());
+    }
+
+    private OutdoorDestination toOutdoorDestination(IndoorDestinationAnchor anchor) {
+        return new OutdoorDestination(anchor.outdoorTargetX(), anchor.outdoorTargetY(), anchor.outdoorTargetName());
+    }
+
+    private Optional<IndoorDestinationAnchor> findBuildingDestinationAnchor(NavigationRequestDto request) {
+        if (request.destinationBuildingId() == null) {
+            return Optional.empty();
+        }
+
+        return mapQueryFacade.findIndoorDestinationAnchor(
+                request.destinationBuildingId(),
+                request.endX(),
+                request.endY(),
+                request.startX(),
+                request.startY()
+        );
     }
 
     private NavigationResponseDto findIndoorOnlyRoutes(
@@ -2255,6 +2293,13 @@ public class NavigationService {
             List<StepDto> steps,
             List<StepDto> rawSteps,
             List<RoutingNode> nodes
+    ) {
+    }
+
+    private record OutdoorDestination(
+            double x,
+            double y,
+            String name
     ) {
     }
 

--- a/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
+++ b/src/main/java/com/insideout/backend/domain/navigation/service/NavigationService.java
@@ -90,6 +90,9 @@ public class NavigationService {
     public NavigationResponseDto findRoutes(NavigationRequestDto request) {
         RouteTarget target = resolveRouteTarget(request);
         EnumSet<RouteType> routeTypes = resolveRouteTypes(request);
+        if (target.isIndoorOnly()) {
+            return findIndoorOnlyRoutes(request, target, routeTypes);
+        }
         List<RouteDto> routes = new ArrayList<>();
         List<RouteMode> notFoundRouteTypes = new ArrayList<>();
         List<RouteFailureDto> failures = new ArrayList<>();
@@ -172,16 +175,17 @@ public class NavigationService {
             return new IndoorInfoDto(false, null, null, null, null, null, null, null, List.of());
         }
 
-        var floorplans = mapQueryFacade.findCurrentBuildingFloorplans(target.anchor().buildingId());
+        UUID buildingId = target.indoorBuildingId();
+        var floorplans = mapQueryFacade.findCurrentBuildingFloorplans(buildingId);
         return new IndoorInfoDto(
                 true,
-                target.anchor().campusId(),
-                target.anchor().campusName(),
-                target.anchor().campusEntranceName(),
-                target.anchor().buildingId(),
-                target.anchor().buildingName(),
-                target.anchor().entranceNodeId(),
-                target.anchor().entranceName(),
+                target.campusId(),
+                target.campusName(),
+                target.campusEntranceName(),
+                buildingId,
+                target.buildingName(),
+                target.anchor() == null ? null : target.anchor().entranceNodeId(),
+                target.entranceName(),
                 (floorplans == null ? List.<MapQueryFacade.PublishedFloorplan>of() : floorplans).stream()
                         .map(floorplan -> new FloorplanDto(
                                 floorplan.floorId(),
@@ -230,6 +234,19 @@ public class NavigationService {
 
         Optional<IndoorPoiDestination> source = mapQueryFacade.findIndoorPoiDestination(request.startPoiId());
         if (source.isPresent()) {
+            Optional<IndoorPoiDestination> destination = request.destinationPoiId() == null
+                    ? Optional.empty()
+                    : mapQueryFacade.findIndoorPoiDestination(request.destinationPoiId());
+            if (destination.isPresent() && sameId(source.get().buildingId(), destination.get().buildingId())) {
+                return RouteTarget.fromIndoorToIndoor(
+                        source.get(),
+                        destination.get(),
+                        request.endX(),
+                        request.endY(),
+                        request.endName()
+                );
+            }
+
             Optional<IndoorDestinationAnchor> exitAnchor = mapQueryFacade.findIndoorDestinationAnchor(
                     source.get().buildingId(),
                     request.endX(),
@@ -271,6 +288,62 @@ public class NavigationService {
                         request.endName()
                 ))
                 .orElseGet(() -> RouteTarget.outdoorOnly(request.endX(), request.endY(), request.endName()));
+    }
+
+    private NavigationResponseDto findIndoorOnlyRoutes(
+            NavigationRequestDto request,
+            RouteTarget target,
+            EnumSet<RouteType> routeTypes
+    ) {
+        List<RouteDto> routes = new ArrayList<>();
+        List<RouteFailureDto> failures = new ArrayList<>();
+
+        if (routeTypes.contains(RouteType.WALK)) {
+            createIndoorOnlyRouteDto(target, RouteOption.SHORTEST, failures).ifPresent(routes::add);
+            createIndoorOnlyRouteDto(target, RouteOption.COMFORTABLE, failures).ifPresent(routes::add);
+        } else {
+            createIndoorOnlyRouteDto(target, RouteOption.SHORTEST, failures).ifPresent(routes::add);
+        }
+
+        if (routes.isEmpty() && failures.isEmpty()) {
+            failures.add(routeFailure(NavigationErrorCode.INDOOR_ROUTE_NOT_FOUND, RouteMode.WALK, RouteOption.SHORTEST, LegMode.INDOOR, MapType.BUILDING));
+        }
+
+        List<RouteMode> notFoundRouteTypes = routes.isEmpty() ? List.of(RouteMode.WALK) : List.of();
+        return new NavigationResponseDto(
+                new CoordinateDto(request.endX(), request.endY(), request.endName()),
+                new CoordinateDto(request.endX(), request.endY(), target.destination().name()),
+                toIndoorInfo(target),
+                routes,
+                notFoundRouteTypes,
+                failures,
+                resolveRouteMessage(routes, notFoundRouteTypes, failures)
+        );
+    }
+
+    private Optional<RouteDto> createIndoorOnlyRouteDto(
+            RouteTarget target,
+            RouteOption routeOption,
+            List<RouteFailureDto> failures
+    ) {
+        Optional<LegDto> indoorLeg = createIndoorPointToPointLeg(target, routeOption);
+        if (indoorLeg.isEmpty()) {
+            failures.add(routeFailure(NavigationErrorCode.INDOOR_ROUTE_NOT_FOUND, RouteMode.WALK, routeOption, LegMode.INDOOR, MapType.BUILDING));
+            return Optional.empty();
+        }
+
+        return Optional.of(new RouteDto(
+                RouteMode.WALK,
+                routeOption,
+                null,
+                null,
+                formatDuration(null, true),
+                List.of(indoorLeg.get())
+        ));
+    }
+
+    private boolean sameId(UUID first, UUID second) {
+        return first != null && first.equals(second);
     }
 
     private EnumSet<RouteType> resolveRouteTypes(NavigationRequestDto request) {
@@ -1045,6 +1118,31 @@ public class NavigationService {
                         route,
                         target.source().name() + "에서 출발",
                         indoorExitInstruction(target)
+                ));
+    }
+
+    private Optional<LegDto> createIndoorPointToPointLeg(RouteTarget target, RouteOption routeOption) {
+        if (target.source() == null || target.destination() == null) {
+            return Optional.empty();
+        }
+
+        Optional<RoutingGraph> graph = mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, target.source().buildingId());
+        if (graph.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return computeIndoorRoute(graph.get(), target.source().anchorNodeId(), target.destination().anchorNodeId(), routeOption)
+                .map(route -> toNavigationLeg(
+                        LegMode.INDOOR,
+                        MapType.BUILDING,
+                        mapQueryFacade.findCurrentFloorplanImageUrl(target.source().floorId()).orElse(graph.get().mapImageUrl()),
+                        target.source().floorId(),
+                        target.source().floorName(),
+                        target.source().name(),
+                        target.destination().name(),
+                        route,
+                        target.source().name() + "에서 출발",
+                        target.destination().name() + " 도착"
                 ));
     }
 
@@ -2182,6 +2280,36 @@ public class NavigationService {
             );
         }
 
+        private static RouteTarget fromIndoorToIndoor(
+                IndoorPoiDestination source,
+                IndoorPoiDestination destination,
+                double originalEndX,
+                double originalEndY,
+                String originalEndName
+        ) {
+            return new RouteTarget(
+                    originalEndX,
+                    originalEndY,
+                    null,
+                    null,
+                    null,
+                    originalEndX,
+                    originalEndY,
+                    source.name(),
+                    destination.name(),
+                    true,
+                    true,
+                    originalEndName,
+                    source,
+                    destination,
+                    null
+            );
+        }
+
+        private boolean isIndoorOnly() {
+            return source != null && destination != null && anchor == null;
+        }
+
         private boolean hasCampus() {
             return anchor != null && anchor.hasCampus();
         }
@@ -2194,8 +2322,38 @@ public class NavigationService {
             return anchor == null ? null : anchor.outdoorTargetName();
         }
 
+        private UUID campusId() {
+            if (anchor != null) {
+                return anchor.campusId();
+            }
+            if (destination != null && destination.campusId() != null) {
+                return destination.campusId();
+            }
+            return source == null ? null : source.campusId();
+        }
+
+        private String campusName() {
+            if (anchor != null) {
+                return anchor.campusName();
+            }
+            if (destination != null && destination.campusName() != null && !destination.campusName().isBlank()) {
+                return destination.campusName();
+            }
+            return source == null ? null : source.campusName();
+        }
+
         private String entranceName() {
             return anchor == null ? null : anchor.entranceName();
+        }
+
+        private UUID indoorBuildingId() {
+            if (anchor != null) {
+                return anchor.buildingId();
+            }
+            if (destination != null && destination.buildingId() != null) {
+                return destination.buildingId();
+            }
+            return source == null ? null : source.buildingId();
         }
 
         private String buildingName() {

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -43,6 +43,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -218,12 +219,15 @@ class NavigationServiceTest {
     }
 
     @Test
-    void buildingOnlyDestinationUsesOutdoorRouteWithoutIndoorLeg() throws Exception {
+    void buildingOnlyDestinationUsesNearestEntranceAsOutdoorDestination() throws Exception {
         UUID buildingId = UUID.randomUUID();
         double originalEndX = 127.1000;
         double originalEndY = 37.5000;
+        double entranceX = 127.2000;
+        double entranceY = 37.6000;
 
-        when(mapQueryFacade.findIndoorPoiDestination(null)).thenReturn(Optional.empty());
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, originalEndX, originalEndY, 126.9000, 37.4000))
+                .thenReturn(Optional.of(indoorAnchor(buildingId, UUID.randomUUID(), entranceX, entranceY)));
         when(restTemplate.postForObject(
                 eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
                 any(HttpEntity.class),
@@ -238,18 +242,33 @@ class NavigationServiceTest {
                 "출발지",
                 "실제 목적지",
                 buildingId,
-                true,
+                false,
                 List.of(RouteType.WALK)
         ));
 
         RouteDto route = response.routes().get(0);
 
-        assertThat(response.routedDestination().x()).isEqualTo(originalEndX);
-        assertThat(response.routedDestination().y()).isEqualTo(originalEndY);
+        assertThat(response.routedDestination().x()).isEqualTo(entranceX);
+        assertThat(response.routedDestination().y()).isEqualTo(entranceY);
+        assertThat(response.routedDestination().name()).isEqualTo("정문");
         assertThat(route.legs())
                 .extracting(LegDto::mode)
                 .doesNotContain(LegMode.INDOOR);
-        verify(mapQueryFacade, never()).findIndoorDestinationAnchor(buildingId, originalEndX, originalEndY);
+        ArgumentCaptor<HttpEntity> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate, times(2)).postForObject(
+                eq("https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1"),
+                entityCaptor.capture(),
+                eq(JsonNode.class)
+        );
+        assertThat(entityCaptor.getAllValues())
+                .allSatisfy(entity -> {
+                    Object body = entity.getBody();
+                    assertThat(body).isInstanceOf(Map.class);
+                    Map<?, ?> requestBody = (Map<?, ?>) body;
+                    assertThat(requestBody.get("endX")).isEqualTo(entranceX);
+                    assertThat(requestBody.get("endY")).isEqualTo(entranceY);
+                    assertThat(requestBody.get("endName")).isEqualTo("정문");
+                });
         assertThat(route.failures()).isEmpty();
         assertThat(response.failures()).isEmpty();
     }
@@ -491,10 +510,10 @@ class NavigationServiceTest {
         ));
 
         assertThat(response.routes()).isEmpty();
-        assertThat(response.notFoundRouteTypes()).containsExactly(RouteMode.TRANSIT, RouteMode.CAR);
+        assertThat(response.notFoundRouteTypes()).containsExactlyInAnyOrder(RouteMode.TRANSIT, RouteMode.CAR);
         assertThat(response.failures())
                 .extracting(RouteFailureDto::routeMode)
-                .containsExactly(RouteMode.TRANSIT, RouteMode.CAR);
+                .containsExactlyInAnyOrder(RouteMode.TRANSIT, RouteMode.CAR);
         assertThat(response.message()).isEqualTo("경로를 찾을 수 없습니다.");
         verify(mapQueryFacade, never()).findPublishedRoutingGraph(MapType.BUILDING, buildingId);
         verify(restTemplate, never()).postForObject(

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -328,11 +328,11 @@ class NavigationServiceTest {
                 .containsExactly(LegMode.INDOOR, LegMode.WALK);
         assertThat(indoorLeg.steps())
                 .extracting(StepDto::instruction)
-                .contains("테스트 건물 출구로 나가기")
+                .contains("정문으로 나가기")
                 .doesNotContain("테스트 건물 도착");
         assertThat(indoorLeg.floorSegments().get(0).steps())
                 .extracting(StepDto::instruction)
-                .contains("테스트 건물 출구로 나가기")
+                .contains("정문으로 나가기")
                 .doesNotContain("테스트 건물 도착");
         LegDto outdoorLeg = response.routes().get(0).legs().stream()
                 .filter(leg -> leg.mode() == LegMode.WALK)
@@ -514,12 +514,83 @@ class NavigationServiceTest {
         RouteDto route = response.routes().get(0);
 
         assertThat(route.routeOption()).isEqualTo(RouteOption.TRANSIT_CANDIDATE);
+        LegDto outdoorLeg = findLeg(route.legs(), LegMode.WALK);
+        assertThat(outdoorLeg.endName()).isEqualTo("정문");
+        assertThat(outdoorLeg.path().get(outdoorLeg.path().size() - 1).x()).isEqualTo(127.2000);
+        assertThat(outdoorLeg.path().get(outdoorLeg.path().size() - 1).y()).isEqualTo(37.6000);
+        assertThat(outdoorLeg.steps().get(outdoorLeg.steps().size() - 1).instruction()).isEqualTo("테스트 건물 정문 도착");
         assertThat(route.failures())
                 .extracting(RouteFailureDto::routeOption)
                 .containsOnly(RouteOption.TRANSIT_CANDIDATE);
         assertThat(response.failures())
                 .extracting(RouteFailureDto::routeOption)
                 .containsOnly(RouteOption.TRANSIT_CANDIDATE);
+    }
+
+    @Test
+    void transitIndoorToOutdoorStartsOutdoorLegAtBuildingEntrance() throws Exception {
+        UUID buildingId = UUID.randomUUID();
+        UUID mapVersionId = UUID.randomUUID();
+        UUID sourceNodeId = UUID.randomUUID();
+        UUID entranceNodeId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Long startPoiId = 2001L;
+
+        when(mapQueryFacade.findIndoorPoiDestination(startPoiId))
+                .thenReturn(Optional.of(indoorPoiDestination(
+                        startPoiId,
+                        sourceNodeId,
+                        floorId,
+                        "1F",
+                        buildingId
+                )));
+        when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000, 127.1000, 37.5000))
+                .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
+        when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
+                .thenReturn(Optional.of(RoutingGraph.builder()
+                        .mapVersionId(mapVersionId)
+                        .mapType(MapType.BUILDING)
+                        .mapImageUrl("https://signed.example/fallback.png")
+                        .nodes(List.of(
+                                routingNode(sourceNodeId, "poi", "출발 POI", floorId, "1F", 10, 10),
+                                routingNode(entranceNodeId, "entrance", "정문", floorId, "1F", 30, 30)
+                        ))
+                        .edges(List.of(routingEdge(sourceNodeId, entranceNodeId)))
+                        .verticalLinks(List.of())
+                        .obstacles(List.of())
+                        .build()));
+        when(mapQueryFacade.findCurrentFloorplanImageUrl(floorId))
+                .thenReturn(Optional.of("https://signed.example/1f.png"));
+        when(restTemplate.postForObject(
+                eq("https://apis.openapi.sk.com/transit/routes"),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        )).thenReturn(transitRouteResponse());
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발 POI",
+                "실외 목적지",
+                startPoiId,
+                null,
+                null,
+                true,
+                List.of(RouteType.TRANSIT)
+        ));
+
+        RouteDto route = response.routes().get(0);
+        LegDto outdoorLeg = findLeg(route.legs(), LegMode.WALK);
+
+        assertThat(route.legs())
+                .extracting(LegDto::mode)
+                .containsExactly(LegMode.INDOOR, LegMode.WALK);
+        assertThat(outdoorLeg.startName()).isEqualTo("정문");
+        assertThat(outdoorLeg.path().get(0).x()).isEqualTo(127.2000);
+        assertThat(outdoorLeg.path().get(0).y()).isEqualTo(37.6000);
+        assertThat(outdoorLeg.steps().get(0).instruction()).isEqualTo("정문에서 출발");
     }
 
     @Test
@@ -964,6 +1035,13 @@ class NavigationServiceTest {
                 .length(10)
                 .baseWeight(1)
                 .build();
+    }
+
+    private LegDto findLeg(List<LegDto> legs, LegMode mode) {
+        return legs.stream()
+                .filter(leg -> leg.mode() == mode)
+                .findFirst()
+                .orElseThrow();
     }
 
     private JsonNode transitRouteResponse() throws Exception {

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -273,7 +273,14 @@ class NavigationServiceTest {
                         buildingId
                 )));
         when(mapQueryFacade.findIndoorDestinationAnchor(buildingId, 127.1000, 37.5000, 127.1000, 37.5000))
-                .thenReturn(Optional.of(indoorAnchor(buildingId, entranceNodeId, 127.2000, 37.6000)));
+                .thenReturn(Optional.of(IndoorDestinationAnchor.builder()
+                        .buildingId(buildingId)
+                        .buildingName("테스트 건물")
+                        .entranceNodeId(entranceNodeId)
+                        .entranceName("입구")
+                        .x(127.2000)
+                        .y(37.6000)
+                        .build()));
         when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
                 .thenReturn(Optional.of(RoutingGraph.builder()
                         .mapVersionId(mapVersionId)
@@ -282,7 +289,7 @@ class NavigationServiceTest {
                         .nodes(List.of(
                                 routingNode(sourceNodeId, "poi", "출발 POI", floorId, "1F", 10, 10),
                                 routingNode(middleNodeId, "corridor", "복도", floorId, "1F", 20, 20),
-                                routingNode(entranceNodeId, "entrance", "정문", floorId, "1F", 30, 30)
+                                routingNode(entranceNodeId, "entrance", "입구", floorId, "1F", 30, 30)
                         ))
                         .edges(List.of(
                                 routingEdge(sourceNodeId, middleNodeId),
@@ -328,11 +335,11 @@ class NavigationServiceTest {
                 .containsExactly(LegMode.INDOOR, LegMode.WALK);
         assertThat(indoorLeg.steps())
                 .extracting(StepDto::instruction)
-                .contains("정문으로 나가기")
+                .contains("입구로 나가기")
                 .doesNotContain("테스트 건물 도착");
         assertThat(indoorLeg.floorSegments().get(0).steps())
                 .extracting(StepDto::instruction)
-                .contains("정문으로 나가기")
+                .contains("입구로 나가기")
                 .doesNotContain("테스트 건물 도착");
         LegDto outdoorLeg = response.routes().get(0).legs().stream()
                 .filter(leg -> leg.mode() == LegMode.WALK)
@@ -434,6 +441,62 @@ class NavigationServiceTest {
         assertThat(response.indoor().floorplans())
                 .extracting(NavigationResponseDto.FloorplanDto::floorName)
                 .containsExactly("1F");
+        verify(restTemplate, never()).postForObject(
+                any(String.class),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        );
+    }
+
+    @Test
+    void indoorOnlyWithoutWalkReturnsRequestedModesAsNotFoundWithoutWalkRoute() {
+        UUID buildingId = UUID.randomUUID();
+        UUID sourceNodeId = UUID.randomUUID();
+        UUID destinationNodeId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Long startPoiId = 2001L;
+        Long destinationPoiId = 1001L;
+
+        when(mapQueryFacade.findIndoorPoiDestination(startPoiId))
+                .thenReturn(Optional.of(indoorPoiDestination(
+                        startPoiId,
+                        sourceNodeId,
+                        floorId,
+                        "1F",
+                        buildingId
+                )));
+        when(mapQueryFacade.findIndoorPoiDestination(destinationPoiId))
+                .thenReturn(Optional.of(indoorPoiDestination(
+                        destinationPoiId,
+                        destinationNodeId,
+                        floorId,
+                        "1F",
+                        buildingId
+                )));
+        when(mapQueryFacade.findCurrentBuildingFloorplans(buildingId))
+                .thenReturn(List.of(new PublishedFloorplan(floorId, "1F", "https://signed.example/1f.png")));
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발 POI",
+                "목적지 POI",
+                startPoiId,
+                buildingId,
+                destinationPoiId,
+                true,
+                List.of(RouteType.CAR, RouteType.TRANSIT)
+        ));
+
+        assertThat(response.routes()).isEmpty();
+        assertThat(response.notFoundRouteTypes()).containsExactly(RouteMode.TRANSIT, RouteMode.CAR);
+        assertThat(response.failures())
+                .extracting(RouteFailureDto::routeMode)
+                .containsExactly(RouteMode.TRANSIT, RouteMode.CAR);
+        assertThat(response.message()).isEqualTo("경로를 찾을 수 없습니다.");
+        verify(mapQueryFacade, never()).findPublishedRoutingGraph(MapType.BUILDING, buildingId);
         verify(restTemplate, never()).postForObject(
                 any(String.class),
                 any(HttpEntity.class),

--- a/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
+++ b/src/test/java/com/insideout/backend/domain/navigation/service/NavigationServiceTest.java
@@ -346,6 +346,102 @@ class NavigationServiceTest {
     }
 
     @Test
+    void indoorToIndoorUsesOnlyIndoorLegWithoutTmapLookup() {
+        UUID buildingId = UUID.randomUUID();
+        UUID mapVersionId = UUID.randomUUID();
+        UUID sourceNodeId = UUID.randomUUID();
+        UUID middleNodeId = UUID.randomUUID();
+        UUID destinationNodeId = UUID.randomUUID();
+        UUID floorId = UUID.randomUUID();
+        Long startPoiId = 2001L;
+        Long destinationPoiId = 1001L;
+
+        when(mapQueryFacade.findIndoorPoiDestination(startPoiId))
+                .thenReturn(Optional.of(IndoorPoiDestination.builder()
+                        .publicId(startPoiId)
+                        .poiId(UUID.randomUUID())
+                        .name("출발 POI")
+                        .anchorNodeId(sourceNodeId)
+                        .floorId(floorId)
+                        .floorName("1F")
+                        .buildingId(buildingId)
+                        .buildingName("테스트 건물")
+                        .build()));
+        when(mapQueryFacade.findIndoorPoiDestination(destinationPoiId))
+                .thenReturn(Optional.of(IndoorPoiDestination.builder()
+                        .publicId(destinationPoiId)
+                        .poiId(UUID.randomUUID())
+                        .name("목적지 POI")
+                        .anchorNodeId(destinationNodeId)
+                        .floorId(floorId)
+                        .floorName("1F")
+                        .buildingId(buildingId)
+                        .buildingName("테스트 건물")
+                        .build()));
+        when(mapQueryFacade.findPublishedRoutingGraph(MapType.BUILDING, buildingId))
+                .thenReturn(Optional.of(RoutingGraph.builder()
+                        .mapVersionId(mapVersionId)
+                        .mapType(MapType.BUILDING)
+                        .mapImageUrl("https://signed.example/fallback.png")
+                        .nodes(List.of(
+                                routingNode(sourceNodeId, "poi", "출발 POI", floorId, "1F", 10, 10),
+                                routingNode(middleNodeId, "corridor", "복도", floorId, "1F", 20, 20),
+                                routingNode(destinationNodeId, "poi", "목적지 POI", floorId, "1F", 30, 30)
+                        ))
+                        .edges(List.of(
+                                routingEdge(sourceNodeId, middleNodeId),
+                                routingEdge(middleNodeId, destinationNodeId)
+                        ))
+                        .verticalLinks(List.of())
+                        .obstacles(List.of())
+                        .build()));
+        when(mapQueryFacade.findCurrentFloorplanImageUrl(floorId))
+                .thenReturn(Optional.of("https://signed.example/1f.png"));
+        when(mapQueryFacade.findCurrentBuildingFloorplans(buildingId))
+                .thenReturn(List.of(new PublishedFloorplan(floorId, "1F", "https://signed.example/1f.png")));
+
+        NavigationResponseDto response = navigationService.findRoutes(new NavigationRequestDto(
+                126.9000,
+                37.4000,
+                127.1000,
+                37.5000,
+                "출발 POI",
+                "목적지 POI",
+                startPoiId,
+                buildingId,
+                destinationPoiId,
+                true,
+                List.of(RouteType.WALK)
+        ));
+
+        assertThat(response.routes()).hasSize(2);
+        assertThat(response.routes())
+                .extracting(RouteDto::routeOption)
+                .containsExactly(RouteOption.SHORTEST, RouteOption.COMFORTABLE);
+        assertThat(response.routes())
+                .allSatisfy(route -> assertThat(route.legs())
+                        .extracting(LegDto::mode)
+                        .containsExactly(LegMode.INDOOR));
+
+        LegDto indoorLeg = response.routes().get(0).legs().get(0);
+        assertThat(indoorLeg.startName()).isEqualTo("출발 POI");
+        assertThat(indoorLeg.endName()).isEqualTo("목적지 POI");
+        assertThat(indoorLeg.steps())
+                .extracting(StepDto::instruction)
+                .startsWith("출발 POI에서 출발")
+                .endsWith("목적지 POI 도착");
+        assertThat(response.indoor().buildingName()).isEqualTo("테스트 건물");
+        assertThat(response.indoor().floorplans())
+                .extracting(NavigationResponseDto.FloorplanDto::floorName)
+                .containsExactly("1F");
+        verify(restTemplate, never()).postForObject(
+                any(String.class),
+                any(HttpEntity.class),
+                eq(JsonNode.class)
+        );
+    }
+
+    @Test
     void routeLookupFailureIsIsolatedByRouteMode() throws Exception {
         when(restTemplate.postForObject(
                 eq("https://apis.openapi.sk.com/tmap/routes?version=1&format=json"),


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #97 

## 📝작업 내용

> 실내-실내 길찾기를 추가로 구현했어요

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 실내 전용 라우팅(실내→실내 포함)과 실내 전용 응답(점-점 경로 포함) 추가 및 실패 상태 세분화

* **Bug Fixes**
  * 실내 출구 안내 문구 개선(출입구 기본값 및 조사 처리) 및 안내문 일관성 보장

* **Refactor**
  * 실외 경계(출입구) 처리 흐름 정리 및 경로/스텝 정규화 로직 개선

* **Tests**
  * 실내/실외, 실내→실내 등 다양한 시나리오 검증 테스트 보강·추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->