### PR TITLE
[chore] 백엔드 자동 배포 GitHub Actions 추가

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,32 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-backend-dev
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Deploy to Azure VM via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd "${{ secrets.DEPLOY_PATH }}"
+            git switch dev
+            git pull --ff-only origin dev
+            docker compose --env-file .env.deploy.vm -f docker-compose.deploy.yml up -d --build app caddy
+            docker compose --env-file .env.deploy.vm -f docker-compose.deploy.yml ps app caddy

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Deploy to Azure VM via SSH
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #이슈번호, #이슈번호

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `dev` 브랜치 push 시 Azure VM에 SSH로 접속해 백엔드를 자동 배포하는 GitHub Actions 워크플로를 추가했습니다.
- 수동으로 하던 `git pull` + `docker compose up -d --build app caddy` 배포 과정을 자동화했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 자동화된 백엔드 배포 워크플로우가 추가되었습니다. 개발 브랜치로의 푸시 또는 수동 트리거를 통해 개발 서버로 자동으로 배포할 수 있습니다. 배포 시스템은 동시에 여러 배포 작업이 실행되지 않도록 방지하여 배포 충돌을 효과적으로 예방합니다. 최신 코드 변경 사항을 신속하게 개발 서버에 반영할 수 있으며, 더욱 안정적이고 신뢰할 수 있는 배포 프로세스가 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->