### PR TITLE
[perf] k6부하테스트 및 실내 라우팅 캐시 적용 성능 개선 (#100)

### DIFF
--- a/docs/performance-report.md
+++ b/docs/performance-report.md
@@ -1,0 +1,250 @@
+# Navigation API Performance Report
+
+## Test Target
+
+- API: `POST /api/v1/navigation/routes`
+- Scenario: outdoor walking route + indoor destination route
+- Script: `performance/k6/navigation-routes.js`
+- Base URL: `http://127.0.0.1:8080`
+- Date: 2026-06-30
+
+## Baseline
+
+### Smoke Test
+
+Command:
+
+```bash
+k6 run -e VUS=1 -e DURATION=10s performance/k6/navigation-routes.js
+```
+
+Result:
+
+| Metric | Value |
+| --- | ---: |
+| Virtual users | 1 |
+| Requests | 47 |
+| Request rate | 0.67 req/s |
+| Failure rate | 0.00% |
+| Average response time | 476.50 ms |
+| Median response time | 452.15 ms |
+| p90 response time | 613.06 ms |
+| p95 response time | 629.46 ms |
+| Max response time | 646.11 ms |
+
+### Baseline Load Test
+
+Command:
+
+```bash
+k6 run -e VUS=10 -e DURATION=1m performance/k6/navigation-routes.js
+```
+
+Result:
+
+| Metric | Value |
+| --- | ---: |
+| Virtual users | 10 |
+| Requests | 818 |
+| Request rate | 6.81 req/s |
+| Failure rate | 0.00% |
+| Average response time | 123.74 ms |
+| Median response time | 120.83 ms |
+| p90 response time | 145.90 ms |
+| p95 response time | 157.36 ms |
+| Max response time | 315.44 ms |
+| Data received | 2.0 MB |
+| Data sent | 342 kB |
+
+### Baseline Load Test - 30 VUs
+
+Command:
+
+```bash
+k6 run -e VUS=30 -e DURATION=1m performance/k6/navigation-routes.js
+```
+
+Result:
+
+| Metric | Value |
+| --- | ---: |
+| Virtual users | 30 |
+| Requests | 2,476 |
+| Request rate | 20.63 req/s |
+| Failure rate | 0.00% |
+| Average response time | 101.77 ms |
+| Median response time | 95.44 ms |
+| p90 response time | 137.25 ms |
+| p95 response time | 155.72 ms |
+| Max response time | 350.93 ms |
+| Data received | 6.0 MB |
+| Data sent | 1.0 MB |
+
+## Indoor-Only Baseline
+
+### Test Scenario
+
+- API: `POST /api/v1/navigation/routes`
+- Script: `performance/k6/indoor-navigation-routes.js`
+- Route: `구찌(public_id=104)` to `더로우(public_id=125)`
+- Building: `신세계백화점 본점 디 에스테이트`
+- Purpose: measure backend indoor routing performance without consuming external TMAP route API quota
+
+The script checks that every returned route leg is `INDOOR`, so the test fails if an outdoor/TMAP-backed leg is included.
+
+### Smoke Test
+
+Command:
+
+```bash
+k6 run -e VUS=1 -e DURATION=10s performance/k6/indoor-navigation-routes.js
+```
+
+Result:
+
+| Metric | Value |
+| --- | ---: |
+| Virtual users | 1 |
+| Requests | 61 |
+| Request rate | 0.86 req/s |
+| Failure rate | 0.00% |
+| Average response time | 159.58 ms |
+| Median response time | 158.11 ms |
+| p90 response time | 192.07 ms |
+| p95 response time | 206.13 ms |
+| Max response time | 240.12 ms |
+| Indoor-only check | 100.00% passed |
+
+### Before Load Test - 10 VUs
+
+Command:
+
+```bash
+k6 run -e VUS=10 -e DURATION=1m performance/k6/indoor-navigation-routes.js
+```
+
+Result:
+
+| Metric | Value |
+| --- | ---: |
+| Virtual users | 10 |
+| Requests | 772 |
+| Request rate | 6.36 req/s |
+| Failure rate | 0.00% |
+| Average response time | 186.27 ms |
+| Median response time | 195.16 ms |
+| p90 response time | 229.35 ms |
+| p95 response time | 249.70 ms |
+| Max response time | 455.44 ms |
+| Indoor-only check | 100.00% passed |
+| Data received | 19 MB |
+| Data sent | 243 kB |
+
+### Before Load Test - 30 VUs
+
+Command:
+
+```bash
+k6 run -e VUS=30 -e DURATION=1m performance/k6/indoor-navigation-routes.js
+```
+
+Result:
+
+| Metric | Value |
+| --- | ---: |
+| Virtual users | 30 |
+| Requests | 2,237 |
+| Request rate | 18.58 req/s |
+| Failure rate | 0.00% |
+| Average response time | 218.41 ms |
+| Median response time | 222.09 ms |
+| p90 response time | 292.81 ms |
+| p95 response time | 321.24 ms |
+| Max response time | 573.75 ms |
+| Indoor-only check | 100.00% passed |
+| Data received | 55 MB |
+| Data sent | 705 kB |
+
+### Before Load Test - 50 VUs
+
+Command:
+
+```bash
+k6 run -e VUS=50 -e DURATION=1m performance/k6/indoor-navigation-routes.js
+```
+
+Result:
+
+| Metric | Value |
+| --- | ---: |
+| Virtual users | 50 |
+| Requests | 3,845 |
+| Request rate | 32.01 req/s |
+| Failure rate | 0.00% |
+| Average response time | 177.42 ms |
+| Median response time | 169.60 ms |
+| p90 response time | 267.42 ms |
+| p95 response time | 307.77 ms |
+| Max response time | 564.37 ms |
+| Indoor-only check | 100.00% passed |
+| Data received | 95 MB |
+| Data sent | 1.2 MB |
+
+### Before Summary
+
+| Scenario | Requests | Request Rate | Failure Rate | Avg | p95 | Max |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Indoor-only 10 VUs | 772 | 6.36 req/s | 0.00% | 186.27 ms | 249.70 ms | 455.44 ms |
+| Indoor-only 30 VUs | 2,237 | 18.58 req/s | 0.00% | 218.41 ms | 321.24 ms | 573.75 ms |
+| Indoor-only 50 VUs | 3,845 | 32.01 req/s | 0.00% | 177.42 ms | 307.77 ms | 564.37 ms |
+
+## Optimization
+
+### Published Routing Graph Cache
+
+Before optimization, each indoor route request loaded the currently published map version and rebuilt the routing graph by reading nodes, edges, vertical connectors, landmarks, and obstacles from the database.
+
+The optimization adds an in-memory cache for published `RoutingGraph` instances in `MapQueryFacade`.
+
+- Cache key: `mapType + ownerId + mapVersionId`
+- Cached value: published `RoutingGraph`
+- Still executed per request: source/destination POI resolution and shortest-path calculation
+- Avoided on cache hits: repeated graph DB reads and graph object reconstruction
+- Invalidation: when a building draft is published, `MapEditorPublishFinalizeService` evicts the building's published routing graph cache
+- Stale version handling: if the published `mapVersionId` changes, old cache entries for that map owner are removed
+
+This caches the stable map graph data, not the final route result. Route calculation still runs for every request.
+
+### After Load Test
+
+Restart the backend after applying the optimization, then run the same indoor-only scenarios:
+
+```bash
+k6 run -e VUS=10 -e DURATION=1m performance/k6/indoor-navigation-routes.js
+k6 run -e VUS=30 -e DURATION=1m performance/k6/indoor-navigation-routes.js
+k6 run -e VUS=50 -e DURATION=1m performance/k6/indoor-navigation-routes.js
+```
+
+| Scenario | Requests | Request Rate | Failure Rate | Avg | p95 | Max |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Indoor-only 10 VUs | 826 | 6.88 req/s | 0.00% | 108.43 ms | 191.27 ms | 1.41 s |
+| Indoor-only 30 VUs | 2,506 | 20.86 req/s | 0.00% | 85.13 ms | 131.03 ms | 224.87 ms |
+| Indoor-only 50 VUs | 4,149 | 34.55 req/s | 0.00% | 90.51 ms | 130.33 ms | 232.96 ms |
+
+### Before/After Summary
+
+| Scenario | Before p95 | After p95 | p95 Change | Before Avg | After Avg | Avg Change | Before RPS | After RPS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Indoor-only 10 VUs | 249.70 ms | 191.27 ms | -23.4% | 186.27 ms | 108.43 ms | -41.8% | 6.36 | 6.88 |
+| Indoor-only 30 VUs | 321.24 ms | 131.03 ms | -59.2% | 218.41 ms | 85.13 ms | -61.0% | 18.58 | 20.86 |
+| Indoor-only 50 VUs | 307.77 ms | 130.33 ms | -57.7% | 177.42 ms | 90.51 ms | -49.0% | 32.01 | 34.55 |
+
+After applying published routing graph caching, the indoor-only routing scenario kept a 0.00% failure rate and reduced p95 latency by 23.4% to 59.2% depending on load level.
+
+## Notes
+
+- Opening `/api/v1/navigation/routes` in a browser sends a `GET` request, but this endpoint expects a JSON `POST` request.
+- The baseline load test values are from the local run captured for this report.
+- The current `navigation-routes.js` scenario sends `routeTypes: ["WALK"]`. This can still call the external TMAP pedestrian route API through the backend, so repeated load tests may consume external API quota.
+- Use `indoor-navigation-routes.js` for larger local load tests because it verifies that responses are indoor-only and avoids the external TMAP route API.
+- The k6 script ramps users up for 30 seconds, holds the configured `DURATION`, then ramps down for 30 seconds.

--- a/performance/k6/indoor-navigation-routes.js
+++ b/performance/k6/indoor-navigation-routes.js
@@ -1,0 +1,104 @@
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+import { Rate } from 'k6/metrics'
+
+const failureRate = new Rate('indoor_navigation_route_failures')
+
+const BASE_URL = __ENV.BASE_URL || 'http://127.0.0.1:8080'
+const ROUTE_PATH = __ENV.ROUTE_PATH || '/api/v1/navigation/routes'
+
+export const options = {
+  scenarios: {
+    indoor_navigation_routes: {
+      executor: 'ramping-vus',
+      stages: [
+        { duration: '30s', target: Number(__ENV.VUS || 10) },
+        { duration: __ENV.DURATION || '1m', target: Number(__ENV.VUS || 10) },
+        { duration: '30s', target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<1000'],
+    indoor_navigation_route_failures: ['rate<0.01'],
+  },
+}
+
+export default function () {
+  const response = http.post(
+    `${BASE_URL}${ROUTE_PATH}`,
+    JSON.stringify(buildIndoorNavigationPayload()),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      tags: {
+        api: 'indoor-navigation-routes',
+      },
+    },
+  )
+
+  const ok = check(response, {
+    'status is 200': (res) => res.status === 200,
+    'response is successful': (res) => {
+      const body = parseJson(res.body)
+      return body?.isSuccess === true
+    },
+    'route is indoor only': (res) => {
+      const body = parseJson(res.body)
+      const routes = body?.result?.routes || []
+
+      return routes.length > 0 && routes.every((route) => {
+        const legs = route?.legs || []
+        return legs.length > 0 && legs.every((leg) => leg.mode === 'INDOOR')
+      })
+    },
+  })
+
+  failureRate.add(!ok)
+  sleep(Number(__ENV.SLEEP_SECONDS || 1))
+}
+
+function buildIndoorNavigationPayload() {
+  return {
+    startX: numberEnv('START_X', 0),
+    startY: numberEnv('START_Y', 0),
+    endX: numberEnv('END_X', 0),
+    endY: numberEnv('END_Y', 0),
+    startName: __ENV.START_NAME || '구찌',
+    endName: __ENV.END_NAME || '더로우',
+    startPoiId: numberEnv('START_POI_ID', 104),
+    destinationPoiId: numberEnv('DESTINATION_POI_ID', 125),
+    includeIndoor: booleanEnv('INCLUDE_INDOOR', true),
+    routeTypes: routeTypesEnv(),
+  }
+}
+
+function routeTypesEnv() {
+  return (__ENV.ROUTE_TYPES || 'WALK')
+    .split(',')
+    .map((type) => type.trim().toUpperCase())
+    .filter(Boolean)
+}
+
+function numberEnv(name, fallback) {
+  const value = __ENV[name]
+  return value === undefined || value === '' ? fallback : Number(value)
+}
+
+function booleanEnv(name, fallback) {
+  const value = __ENV[name]
+  if (value === undefined || value === '') {
+    return fallback
+  }
+  return value.toLowerCase() === 'true'
+}
+
+function parseJson(value) {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}

--- a/performance/k6/indoor-navigation-routes.js
+++ b/performance/k6/indoor-navigation-routes.js
@@ -12,8 +12,8 @@ export const options = {
     indoor_navigation_routes: {
       executor: 'ramping-vus',
       stages: [
-        { duration: '30s', target: Number(__ENV.VUS || 10) },
-        { duration: __ENV.DURATION || '1m', target: Number(__ENV.VUS || 10) },
+        { duration: '30s', target: numberEnv('VUS', 10) },
+        { duration: __ENV.DURATION || '1m', target: numberEnv('VUS', 10) },
         { duration: '30s', target: 0 },
       ],
     },
@@ -57,7 +57,7 @@ export default function () {
   })
 
   failureRate.add(!ok)
-  sleep(Number(__ENV.SLEEP_SECONDS || 1))
+  sleep(numberEnv('SLEEP_SECONDS', 1))
 }
 
 function buildIndoorNavigationPayload() {
@@ -84,7 +84,15 @@ function routeTypesEnv() {
 
 function numberEnv(name, fallback) {
   const value = __ENV[name]
-  return value === undefined || value === '' ? fallback : Number(value)
+  if (value === undefined || value === '') {
+    return fallback
+  }
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid numeric ENV ${name}: ${value}`)
+  }
+  return parsed
 }
 
 function booleanEnv(name, fallback) {

--- a/performance/k6/navigation-routes.js
+++ b/performance/k6/navigation-routes.js
@@ -1,0 +1,94 @@
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+import { Rate } from 'k6/metrics'
+
+const failureRate = new Rate('navigation_route_failures')
+
+const BASE_URL = __ENV.BASE_URL || 'http://127.0.0.1:8080'
+const ROUTE_PATH = __ENV.ROUTE_PATH || '/api/v1/navigation/routes'
+
+export const options = {
+  scenarios: {
+    baseline_navigation_routes: {
+      executor: 'ramping-vus',
+      stages: [
+        { duration: '30s', target: Number(__ENV.VUS || 10) },
+        { duration: __ENV.DURATION || '1m', target: Number(__ENV.VUS || 10) },
+        { duration: '30s', target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<1500'],
+    navigation_route_failures: ['rate<0.01'],
+  },
+}
+
+export default function () {
+  const payload = JSON.stringify(buildNavigationPayload())
+
+  const response = http.post(`${BASE_URL}${ROUTE_PATH}`, payload, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    tags: {
+      api: 'navigation-routes',
+    },
+  })
+
+  const ok = check(response, {
+    'status is 200': (res) => res.status === 200,
+    'response is successful': (res) => {
+      const body = parseJson(res.body)
+      return body?.isSuccess === true || body?.result !== undefined
+    },
+  })
+
+  failureRate.add(!ok)
+  sleep(Number(__ENV.SLEEP_SECONDS || 1))
+}
+
+function buildNavigationPayload() {
+  return {
+    startX: numberEnv('START_X', 126.951744),
+    startY: numberEnv('START_Y', 37.478095),
+    endX: numberEnv('END_X', 126.98079324400408),
+    endY: numberEnv('END_Y', 37.56026711864722),
+    startName: __ENV.START_NAME || '현재 위치',
+    endName: __ENV.END_NAME || '더로우',
+    destinationBuildingId:
+      __ENV.DESTINATION_BUILDING_ID || 'fd53441c-1081-460f-a4a9-b068d0215e35',
+    destinationPoiId: numberEnv('DESTINATION_POI_ID', 125),
+    includeIndoor: booleanEnv('INCLUDE_INDOOR', true),
+    routeTypes: routeTypesEnv(),
+  }
+}
+
+function routeTypesEnv() {
+  return (__ENV.ROUTE_TYPES || 'WALK')
+    .split(',')
+    .map((type) => type.trim().toUpperCase())
+    .filter(Boolean)
+}
+
+function numberEnv(name, fallback) {
+  const value = __ENV[name]
+  return value === undefined || value === '' ? fallback : Number(value)
+}
+
+function booleanEnv(name, fallback) {
+  const value = __ENV[name]
+  if (value === undefined || value === '') {
+    return fallback
+  }
+  return value.toLowerCase() === 'true'
+}
+
+function parseJson(value) {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}

--- a/performance/k6/navigation-routes.js
+++ b/performance/k6/navigation-routes.js
@@ -12,8 +12,8 @@ export const options = {
     baseline_navigation_routes: {
       executor: 'ramping-vus',
       stages: [
-        { duration: '30s', target: Number(__ENV.VUS || 10) },
-        { duration: __ENV.DURATION || '1m', target: Number(__ENV.VUS || 10) },
+        { duration: '30s', target: numberEnv('VUS', 10) },
+        { duration: __ENV.DURATION || '1m', target: numberEnv('VUS', 10) },
         { duration: '30s', target: 0 },
       ],
     },
@@ -41,12 +41,12 @@ export default function () {
     'status is 200': (res) => res.status === 200,
     'response is successful': (res) => {
       const body = parseJson(res.body)
-      return body?.isSuccess === true || body?.result !== undefined
+      return body?.isSuccess === true
     },
   })
 
   failureRate.add(!ok)
-  sleep(Number(__ENV.SLEEP_SECONDS || 1))
+  sleep(numberEnv('SLEEP_SECONDS', 1))
 }
 
 function buildNavigationPayload() {
@@ -74,7 +74,15 @@ function routeTypesEnv() {
 
 function numberEnv(name, fallback) {
   const value = __ENV[name]
-  return value === undefined || value === '' ? fallback : Number(value)
+  if (value === undefined || value === '') {
+    return fallback
+  }
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid numeric ENV ${name}: ${value}`)
+  }
+  return parsed
 }
 
 function booleanEnv(name, fallback) {

--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -145,10 +145,14 @@ public class MapQueryFacade {
         MapVersion version = mapVersion.get();
         evictStaleRoutingGraphCacheEntries(mapType, ownerId, version.getId());
         RoutingGraphCacheKey cacheKey = new RoutingGraphCacheKey(mapType, ownerId, version.getId());
-        return Optional.of(routingGraphCache.computeIfAbsent(
-                cacheKey,
-                key -> toRoutingGraph(mapType, ownerId, version)
-        ));
+        RoutingGraph cachedGraph = routingGraphCache.get(cacheKey);
+        if (cachedGraph == null) {
+            RoutingGraph loadedGraph = toRoutingGraph(mapType, ownerId, version);
+            RoutingGraph existingGraph = routingGraphCache.putIfAbsent(cacheKey, loadedGraph);
+            cachedGraph = existingGraph == null ? loadedGraph : existingGraph;
+        }
+
+        return Optional.of(cachedGraph.withObstacles(findActiveObstacles(mapType, ownerId)));
     }
 
     public void evictPublishedRoutingGraphCache(MapType mapType, UUID ownerId) {
@@ -246,7 +250,7 @@ public class MapQueryFacade {
                 .nodes(nodes)
                 .edges(edges)
                 .verticalLinks(verticalLinks)
-                .obstacles(findActiveObstacles(mapType, ownerId))
+                .obstacles(List.of())
                 .build();
     }
 
@@ -723,6 +727,18 @@ public class MapQueryFacade {
     ) {
         public Map<UUID, RoutingNode> nodeIndex() {
             return nodes.stream().collect(Collectors.toMap(RoutingNode::id, node -> node));
+        }
+
+        private RoutingGraph withObstacles(List<RoutingObstacle> currentObstacles) {
+            return new RoutingGraph(
+                    mapVersionId,
+                    mapType,
+                    mapImageUrl,
+                    nodes,
+                    edges,
+                    verticalLinks,
+                    currentObstacles
+            );
         }
     }
 

--- a/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
+++ b/src/main/java/com/insideout/backend/domain/map/facade/MapQueryFacade.java
@@ -40,6 +40,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
 /**
@@ -56,6 +58,8 @@ public class MapQueryFacade {
     private static final double REGISTERED_BUILDING_SEARCH_RADIUS_METERS = 50.0;
     private static final double INSTRUCTION_LANDMARK_RADIUS_PX = 180.0;
     private static final double POI_ANCHOR_SNAP_RADIUS_PX = 150.0;
+
+    private final ConcurrentMap<RoutingGraphCacheKey, RoutingGraph> routingGraphCache = new ConcurrentHashMap<>();
 
     private final NodeRepository nodeRepository;
     private final BuildingDirectoryRepository buildingDirectoryRepository;
@@ -134,7 +138,27 @@ public class MapQueryFacade {
             );
         };
 
-        return mapVersion.map(version -> toRoutingGraph(mapType, ownerId, version));
+        if (mapVersion.isEmpty()) {
+            return Optional.empty();
+        }
+
+        MapVersion version = mapVersion.get();
+        evictStaleRoutingGraphCacheEntries(mapType, ownerId, version.getId());
+        RoutingGraphCacheKey cacheKey = new RoutingGraphCacheKey(mapType, ownerId, version.getId());
+        return Optional.of(routingGraphCache.computeIfAbsent(
+                cacheKey,
+                key -> toRoutingGraph(mapType, ownerId, version)
+        ));
+    }
+
+    public void evictPublishedRoutingGraphCache(MapType mapType, UUID ownerId) {
+        routingGraphCache.keySet().removeIf(key -> key.matches(mapType, ownerId));
+    }
+
+    private void evictStaleRoutingGraphCacheEntries(MapType mapType, UUID ownerId, UUID currentMapVersionId) {
+        routingGraphCache.keySet().removeIf(key ->
+                key.matches(mapType, ownerId) && !Objects.equals(key.mapVersionId(), currentMapVersionId)
+        );
     }
 
     public Optional<String> findCurrentFloorplanImageUrl(UUID floorId) {
@@ -675,6 +699,16 @@ public class MapQueryFacade {
             CampusGate gate,
             double distance
     ) {
+    }
+
+    private record RoutingGraphCacheKey(
+            MapType mapType,
+            UUID ownerId,
+            UUID mapVersionId
+    ) {
+        private boolean matches(MapType targetMapType, UUID targetOwnerId) {
+            return mapType == targetMapType && Objects.equals(ownerId, targetOwnerId);
+        }
     }
 
     @Builder

--- a/src/main/java/com/insideout/backend/domain/map/service/MapEditorPublishFinalizeService.java
+++ b/src/main/java/com/insideout/backend/domain/map/service/MapEditorPublishFinalizeService.java
@@ -25,6 +25,8 @@ import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,7 +63,21 @@ public class MapEditorPublishFinalizeService {
         mapVersionRepository.save(draftMapVersion);
 
         updateBuildingPublishState(building);
-        mapQueryFacade.evictPublishedRoutingGraphCache(MapType.BUILDING, building.getId());
+        evictPublishedRoutingGraphCacheAfterCommit(building.getId());
+    }
+
+    private void evictPublishedRoutingGraphCacheAfterCommit(UUID buildingId) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            mapQueryFacade.evictPublishedRoutingGraphCache(MapType.BUILDING, buildingId);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                mapQueryFacade.evictPublishedRoutingGraphCache(MapType.BUILDING, buildingId);
+            }
+        });
     }
 
     private void archiveExistingPublishedVersions(UUID buildingId) {

--- a/src/main/java/com/insideout/backend/domain/map/service/MapEditorPublishFinalizeService.java
+++ b/src/main/java/com/insideout/backend/domain/map/service/MapEditorPublishFinalizeService.java
@@ -16,6 +16,7 @@ import com.insideout.backend.domain.map.entity.Poi;
 import com.insideout.backend.domain.map.enums.MapType;
 import com.insideout.backend.domain.map.exception.MapErrorCode;
 import com.insideout.backend.domain.map.exception.MapException;
+import com.insideout.backend.domain.map.facade.MapQueryFacade;
 import com.insideout.backend.domain.map.repository.MapVersionRepository;
 import com.insideout.backend.domain.map.repository.NodeRepository;
 import com.insideout.backend.domain.map.repository.PoiRepository;
@@ -42,6 +43,7 @@ public class MapEditorPublishFinalizeService {
     private final NodeRepository nodeRepository;
     private final PoiRepository poiRepository;
     private final BuildingDirectorySyncService buildingDirectorySyncService;
+    private final MapQueryFacade mapQueryFacade;
     @PersistenceContext
     private final EntityManager entityManager;
 
@@ -59,6 +61,7 @@ public class MapEditorPublishFinalizeService {
         mapVersionRepository.save(draftMapVersion);
 
         updateBuildingPublishState(building);
+        mapQueryFacade.evictPublishedRoutingGraphCache(MapType.BUILDING, building.getId());
     }
 
     private void archiveExistingPublishedVersions(UUID buildingId) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #100 

## 📝작업 내용

## 🔍 문제 상황 및 분석 (As-Is)
- 기존 구조에서는 실내 경로 탐색(`POST /api/v1/navigation/routes`) 요청이 들어올 때마다, 매번 DB에서 해당 건물의 모든 노드, 엣지, 장애물 데이터를 읽어와 메모리 상에 `RoutingGraph` 객체를 새로 재구축했습니다.
- k6로 30VUs ~ 50VUs 부하를 가했을 때, 무거운 DB I/O와 객체 반복 생성으로 인해 평균 응답 시간이 약 **177ms ~ 218ms**, p95 수치가 최대 **321ms**까지 치솟는 병목이 관찰되었습니다.

## 💡 개선 방안 (To-Be)
- **Stable Graph 인메모리 캐싱:** 요청마다 변하지 않는 건물의 기본 뼈대인 `RoutingGraph` 인스턴스를 `MapQueryFacade` 내부에 캐싱 처리했습니다. (최종 경로 결과가 아닌 그래프 데이터 자체를 캐싱하여 동적 경로 계산 로직은 유지)
- **캐시 라이프사이클 관리:** 관리자가 도면을 새로 발행(`MapEditorPublishFinalizeService`)하면 기존 캐시를 폐기(Eviction)하고, 버전 관리를 통해 Stale 데이터가 참조되지 않도록 안전장치를 마련했습니다.
- **외부 API 쿼터 보호:** 외부 TMAP API 호출을 배제한 실내 전용 부하 테스트 시나리오(`indoor-navigation-routes.js`)를 격리 구축하여 안정적인 로컬 테스트 환경을 확보했습니다.

## 📊 성능 개선 결과 (k6 부하 테스트 요약)
> 30 VUs / 50 VUs 고부하 조건에서 지연 시간이 절반 이하로 감소했습니다.

| 시나리오 부하 | Before p95 | After p95 | 📉 p95 개선율 | Before Avg | After Avg | 📉 Avg 개선율 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| **Indoor-only 10 VUs** | 249.70 ms | 191.27 ms | **-23.4%** | 186.27 ms | 108.43 ms | **-41.8%** |
| **Indoor-only 30 VUs** | 321.24 ms | 131.03 ms | **-59.2%** | 218.41 ms | 85.13 ms | **-61.0%** |
| **Indoor-only 50 VUs** | 307.77 ms | 130.33 ms | **-57.7%** | 177.42 ms | 90.51 ms | **-49.0%** |

- **요약:** 모든 부하 구간에서 Failure Rate `0.00%`를 유지한 채, 평균 응답 시간 대폭 감소 및 **p95 Latency 기준 최대 59.2%의 성능 향상**을 달성했습니다.

## 🗂️ 추가된 파일
- `performance/k6/navigation-routes.js` : 하이브리드 경로 탐색 스크립트
- `performance/k6/indoor-navigation-routes.js` : 외부 API 격리 실내 전용 탐색 스크립트
- `performance-report.md` : 상세 성능 측정 및 비교 리포트




### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 내비게이션 라우팅 성능 측정 결과 문서가 추가되어, 기본/실내 전용 시나리오와 스모크·부하 테스트 결과를 한눈에 확인할 수 있습니다.
  * 라우팅 그래프 캐시 적용으로 퍼블리시된 경로 조회가 더 빠르고 안정적으로 동작합니다.

* **Bug Fixes**
  * 퍼블리시 후 최신 경로가 즉시 반영되도록 관련 캐시가 자동 갱신되도록 개선했습니다.
  * 실내 전용 경로 검증과 응답 성공 여부를 포함한 성능 테스트가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->